### PR TITLE
style(negentropy-ui): 表单内联化与表格系统性对齐设计规范

### DIFF
--- a/apps/negentropy-ui/app/(home)/dashboard/_components/TaskTable.tsx
+++ b/apps/negentropy-ui/app/(home)/dashboard/_components/TaskTable.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 
 import { TextTooltip } from "@/components/ui/TextTooltip";
+import { TruncatedCell } from "@/components/ui/TruncatedCell";
 
 import type { DashboardFilters, ScheduledTaskDTO } from "../_lib/types";
 
@@ -127,16 +128,8 @@ export function TaskTable({ tasks, filters, onSelect }: TaskTableProps) {
                       </TextTooltip>
                     </div>
                   </td>
-                  <td className="px-4 py-3 text-text-secondary">
-                    <TextTooltip content={t.handler_kind}>
-                      <span className="block truncate">{t.handler_kind}</span>
-                    </TextTooltip>
-                  </td>
-                  <td className="px-4 py-3 text-text-secondary">
-                    <TextTooltip content={triggerText(t)}>
-                      <span className="block truncate font-mono text-xs">{triggerText(t)}</span>
-                    </TextTooltip>
-                  </td>
+                  <TruncatedCell text={t.handler_kind} textClassName="text-text-secondary" />
+                  <TruncatedCell text={triggerText(t)} mono textClassName="text-text-secondary" />
                   <td className="px-4 py-3 text-text-secondary">
                     <span className="block truncate">{relativeFromNow(t.last_fire_at)}</span>
                   </td>

--- a/apps/negentropy-ui/app/interface/agents/_components/AgentFormDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/agents/_components/AgentFormDrawer.tsx
@@ -15,11 +15,15 @@ import {
   useRef,
   type ReactNode,
 } from "react";
-import { Button } from "@/components/ui/Button";
-import { ErrorBanner } from "@/components/ui/ErrorState";
 import { BaseDrawer } from "@/components/ui/BaseDrawer";
+import { Button } from "@/components/ui/Button";
 import { CollapsibleSection } from "@/components/ui/CollapsibleSection";
+import { ErrorBanner } from "@/components/ui/ErrorState";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
 import { LlmModelSelect } from "@/components/ui/LlmModelSelect";
+import { Select } from "@/components/ui/Select";
+import { Textarea } from "@/components/ui/Textarea";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import {
   fetchModelConfigs,
@@ -39,13 +43,6 @@ interface AgentFormDrawerProps {
   onSubmit: (data: Record<string, unknown>) => Promise<void>;
   agent: Agent | null;
 }
-
-/* ── Shared style constants ── */
-const INPUT =
-  "w-full rounded-md border border-border bg-input px-3 py-1.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring";
-const MONO =
-  "w-full rounded-md border border-border bg-input px-3 py-1.5 text-sm font-mono text-foreground outline-none focus:ring-1 focus:ring-ring";
-const LABEL = "mb-1.5 block text-xs font-medium text-text-muted";
 
 function SectionLabel({ children }: { children: ReactNode }) {
   return (
@@ -433,60 +430,51 @@ export function AgentFormDrawer({
           )}
 
           {/* Identity */}
-          <SectionLabel>Identity</SectionLabel>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div>
-              <label className={LABEL}>Name *</label>
-              <input
+          <section className="space-y-3">
+            <SectionLabel>Identity</SectionLabel>
+            <Field label="Name" required>
+              <Input
                 type="text"
                 value={formData.name}
                 onChange={(e) => setField("name", e.target.value)}
-                className={INPUT}
                 placeholder="my-agent"
                 required
               />
-            </div>
-            <div>
-              <label className={LABEL}>Display Name</label>
-              <input
+            </Field>
+            <Field label="Display Name">
+              <Input
                 type="text"
                 value={formData.display_name}
                 onChange={(e) => setField("display_name", e.target.value)}
-                className={INPUT}
                 placeholder="My Agent"
               />
-            </div>
-          </div>
-          <div>
-            <label className={LABEL}>Description</label>
-            <textarea
-              value={formData.description}
-              onChange={(e) => setField("description", e.target.value)}
-              className={INPUT}
-              rows={2}
-              placeholder="Brief description of this agent"
-            />
-          </div>
+            </Field>
+            <Field label="Description">
+              <Textarea
+                value={formData.description}
+                onChange={(e) => setField("description", e.target.value)}
+                rows={2}
+                placeholder="Brief description of this agent"
+              />
+            </Field>
+          </section>
 
           {/* Runtime */}
-          <SectionLabel>Runtime</SectionLabel>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div>
-              <label className={LABEL}>Agent Type *</label>
-              <select
+          <section className="space-y-3">
+            <SectionLabel>Runtime</SectionLabel>
+            <Field label="Agent Type" required>
+              <Select
                 value={formData.agent_type}
                 onChange={(e) => setField("agent_type", e.target.value)}
-                className={INPUT}
               >
                 <option value="llm_agent">LLM Agent</option>
                 <option value="sequential_agent">Sequential Agent</option>
                 <option value="parallel_agent">Parallel Agent</option>
                 <option value="loop_agent">Loop Agent</option>
                 <option value="custom_agent">Custom Agent</option>
-              </select>
-            </div>
-            <div>
-              <label className={LABEL}>Model</label>
+              </Select>
+            </Field>
+            <Field label="Model">
               <LlmModelSelect
                 models={llmModels}
                 value={formData.model}
@@ -496,110 +484,106 @@ export function AgentFormDrawer({
                 ariaLabel="Agent 使用的 LLM"
                 className="w-full"
               />
-            </div>
-          </div>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <div>
-              <label className={LABEL}>Visibility</label>
-              <select
+            </Field>
+            <Field label="Visibility">
+              <Select
                 value={formData.visibility}
                 onChange={(e) => setField("visibility", e.target.value)}
-                className={INPUT}
               >
                 <option value="private">Private</option>
                 <option value="shared">Shared</option>
                 <option value="public">Public</option>
-              </select>
-            </div>
-            <div className="flex items-end pb-0.5">
-              <label className="flex items-center gap-3 text-sm text-text-secondary">
-                <button
-                  type="button"
-                  role="switch"
-                  aria-checked={formData.is_enabled}
-                  onClick={() => setField("is_enabled", !formData.is_enabled)}
+              </Select>
+            </Field>
+            <Field variant="check" label="Enabled">
+              <button
+                type="button"
+                role="switch"
+                aria-checked={formData.is_enabled}
+                onClick={() => setField("is_enabled", !formData.is_enabled)}
+                className={cn(
+                  "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                  formData.is_enabled ? "bg-primary" : "bg-border",
+                )}
+              >
+                <span
                   className={cn(
-                    "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
-                    formData.is_enabled ? "bg-primary" : "bg-border",
+                    "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                    formData.is_enabled ? "translate-x-4" : "translate-x-0",
                   )}
-                >
-                  <span
-                    className={cn(
-                      "pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
-                      formData.is_enabled ? "translate-x-4" : "translate-x-0",
-                    )}
-                  />
-                </button>
-                Enabled
-              </label>
-            </div>
-          </div>
+                />
+              </button>
+            </Field>
+          </section>
 
           {/* System Prompt */}
-          <SectionLabel>System Prompt</SectionLabel>
-          <textarea
-            value={formData.system_prompt}
-            onChange={(e) => setField("system_prompt", e.target.value)}
-            className={MONO}
-            rows={10}
-            placeholder="You are a specialized agent for..."
-          />
+          <section className="space-y-3">
+            <SectionLabel>System Prompt</SectionLabel>
+            <Textarea
+              value={formData.system_prompt}
+              onChange={(e) => setField("system_prompt", e.target.value)}
+              className="font-mono"
+              rows={10}
+              placeholder="You are a specialized agent for..."
+            />
+          </section>
 
           {/* Tools */}
-          <SectionLabel>
-            Tools{" "}
-            {currentTools.length > 0 && (
-              <span className="text-primary">
-                ({currentTools.length} selected)
-              </span>
+          <section className="space-y-3">
+            <SectionLabel>
+              Tools{" "}
+              {currentTools.length > 0 && (
+                <span className="text-primary">
+                  ({currentTools.length} selected)
+                </span>
+              )}
+            </SectionLabel>
+            {availableTools.length > 0 && (
+              <Input
+                type="text"
+                value={toolSearch}
+                onChange={(e) => setToolSearch(e.target.value)}
+                placeholder="Search tools..."
+              />
             )}
-          </SectionLabel>
-          {availableTools.length > 0 && (
-            <input
-              type="text"
-              value={toolSearch}
-              onChange={(e) => setToolSearch(e.target.value)}
-              className={INPUT}
-              placeholder="Search tools..."
+            {filteredTools.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {filteredTools.map((t) => {
+                  const isSelected = currentTools.includes(t.name);
+                  return (
+                    <button
+                      key={t.name}
+                      type="button"
+                      onClick={() => {
+                        const next = isSelected
+                          ? currentTools.filter((n) => n !== t.name)
+                          : [...currentTools, t.name];
+                        setField("tools", next.join("\n"));
+                      }}
+                      className={
+                        "inline-flex cursor-pointer items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring " +
+                        (isSelected
+                          ? "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
+                          : "bg-muted text-text-secondary hover:bg-border/60 dark:hover:bg-border")
+                      }
+                    >
+                      <span className="text-micro opacity-60">
+                        {t.source === "builtin" ? "●" : "◆"}
+                      </span>
+                      {t.display_name || t.name}
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+            <Textarea
+              value={formData.tools}
+              onChange={(e) => setField("tools", e.target.value)}
+              className="font-mono"
+              rows={3}
+              placeholder="Select from above or type tool names (one per line)"
             />
-          )}
-          {filteredTools.length > 0 && (
-            <div className="mb-2.5 flex flex-wrap gap-1.5">
-              {filteredTools.map((t) => {
-                const isSelected = currentTools.includes(t.name);
-                return (
-                  <button
-                    key={t.name}
-                    type="button"
-                    onClick={() => {
-                      const next = isSelected
-                        ? currentTools.filter((n) => n !== t.name)
-                        : [...currentTools, t.name];
-                      setField("tools", next.join("\n"));
-                    }}
-                    className={
-                      "inline-flex cursor-pointer items-center gap-1 rounded-full px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring " +
-                      (isSelected
-                        ? "bg-sky-100 text-sky-700 dark:bg-sky-900/30 dark:text-sky-400"
-                        : "bg-muted text-text-secondary hover:bg-border/60 dark:hover:bg-border")
-                    }
-                  >
-                    <span className="text-micro opacity-60">
-                      {t.source === "builtin" ? "●" : "◆"}
-                    </span>
-                    {t.display_name || t.name}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-          <textarea
-            value={formData.tools}
-            onChange={(e) => setField("tools", e.target.value)}
-            className={MONO}
-            rows={3}
-            placeholder="Select from above or type tool names (one per line)"
-          />
+          </section>
 
           {/* Advanced (collapsible) */}
           <CollapsibleSection
@@ -617,43 +601,37 @@ export function AgentFormDrawer({
               </span>
             }
           >
-            <div className="space-y-4">
-              <div>
-                <label className={LABEL}>Skills</label>
-                <textarea
+            <div className="space-y-3">
+              <Field label="Skills">
+                <Textarea
                   value={formData.skills}
                   onChange={(e) => setField("skills", e.target.value)}
-                  className={MONO}
+                  className="font-mono"
                   rows={3}
                   placeholder="code-review&#10;document-analysis"
                 />
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div>
-                  <label className={LABEL}>Config (JSON)</label>
-                  <textarea
-                    value={formData.config}
-                    onChange={(e) => setField("config", e.target.value)}
-                    className={MONO}
-                    rows={6}
-                    placeholder='{"temperature": 0.7}'
-                  />
-                </div>
-                <div>
-                  <label className={LABEL}>ADK Config (JSON)</label>
-                  <textarea
-                    value={formData.adk_config}
-                    onChange={(e) => setField("adk_config", e.target.value)}
-                    className={MONO}
-                    rows={6}
-                    placeholder='{"agent_class":"LlmAgent","output_key":"perception_output"}'
-                  />
-                  <p className="mt-1 text-[11px] text-text-muted">
-                    Full-fidelity ADK config. Empty → auto-generate minimal
-                    config.
-                  </p>
-                </div>
-              </div>
+              </Field>
+              <Field label="Config (JSON)">
+                <Textarea
+                  value={formData.config}
+                  onChange={(e) => setField("config", e.target.value)}
+                  className="font-mono"
+                  rows={6}
+                  placeholder='{"temperature": 0.7}'
+                />
+              </Field>
+              <Field
+                label="ADK Config (JSON)"
+                description="Full-fidelity ADK config. Empty → auto-generate minimal config."
+              >
+                <Textarea
+                  value={formData.adk_config}
+                  onChange={(e) => setField("adk_config", e.target.value)}
+                  className="font-mono"
+                  rows={6}
+                  placeholder='{"agent_class":"LlmAgent","output_key":"perception_output"}'
+                />
+              </Field>
             </div>
           </CollapsibleSection>
         </form>

--- a/apps/negentropy-ui/app/interface/mcp/_components/McpServerCard.tsx
+++ b/apps/negentropy-ui/app/interface/mcp/_components/McpServerCard.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from "react-markdown";
 import { defaultRemarkPlugins, defaultRehypePlugins } from "@/utils/markdown-plugins";
 import { JsonViewer } from "@/components/ui/JsonViewer";
 import { SortableCardWrapper, SortableDragHandle } from "@/components/ui/SortableCardWrapper";
-import { TextTooltip } from "@/components/ui/TextTooltip";
+import { TruncatedCell } from "@/components/ui/TruncatedCell";
 import { useAuth } from "@/components/providers/AuthProvider";
 
 const MARKDOWN_CONTENT_CLASS = [
@@ -405,18 +405,8 @@ function SchemaSection({
                   key={row.path}
                   className="border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
                 >
-                  <td className="px-4 py-3">
-                    <TextTooltip content={row.path}>
-                      <span className="block truncate font-mono text-xs text-foreground">
-                        {row.path}
-                      </span>
-                    </TextTooltip>
-                  </td>
-                  <td className="px-4 py-3 text-text-secondary">
-                    <TextTooltip content={row.type}>
-                      <span className="block truncate">{row.type}</span>
-                    </TextTooltip>
-                  </td>
+                  <TruncatedCell text={row.path} mono textClassName="text-foreground" />
+                  <TruncatedCell text={row.type} textClassName="text-text-secondary" />
                   <td className="px-4 py-3">
                     {row.required ? (
                       <span className="text-rose-600 dark:text-rose-400">Yes</span>
@@ -424,24 +414,16 @@ function SchemaSection({
                       <span className="text-text-muted">No</span>
                     )}
                   </td>
-                  <td className="px-4 py-3 text-text-secondary">
-                    {row.description ? (
-                      <TextTooltip content={row.description}>
-                        <span className="block truncate">{row.description}</span>
-                      </TextTooltip>
-                    ) : (
-                      "-"
-                    )}
-                  </td>
-                  <td className="px-4 py-3 text-text-muted">
-                    {row.constraints ? (
-                      <TextTooltip content={row.constraints}>
-                        <span className="block truncate">{row.constraints}</span>
-                      </TextTooltip>
-                    ) : (
-                      "-"
-                    )}
-                  </td>
+                  {row.description ? (
+                    <TruncatedCell text={row.description} className="text-text-secondary" />
+                  ) : (
+                    <td className="px-4 py-3 text-text-secondary">-</td>
+                  )}
+                  {row.constraints ? (
+                    <TruncatedCell text={row.constraints} className="text-text-muted" />
+                  ) : (
+                    <td className="px-4 py-3 text-text-muted">-</td>
+                  )}
                 </tr>
               ))}
             </tbody>

--- a/apps/negentropy-ui/app/interface/mcp/_components/McpServerFormDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/mcp/_components/McpServerFormDrawer.tsx
@@ -16,6 +16,10 @@ import {
 } from "react";
 import { BaseDrawer } from "@/components/ui/BaseDrawer";
 import { Button } from "@/components/ui/Button";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Textarea } from "@/components/ui/Textarea";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 
 interface McpServer {
@@ -211,182 +215,136 @@ export function McpServerFormDrawer({
             </div>
           )}
 
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Basic Information
             </h3>
-            <div className="grid gap-4 lg:grid-cols-2">
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Name *
-                </label>
-                <input
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  placeholder="my-mcp-server"
-                  required
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Display Name
-                </label>
-                <input
-                  type="text"
-                  value={formData.display_name}
-                  onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  placeholder="My MCP Server"
-                />
-              </div>
-              <div className="lg:col-span-2">
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Description
-                </label>
-                <textarea
-                  value={formData.description}
-                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  rows={2}
-                  placeholder="Description of this MCP server"
-                />
-              </div>
-            </div>
+            <Field label="Name" required>
+              <Input
+                type="text"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                placeholder="my-mcp-server"
+                required
+              />
+            </Field>
+            <Field label="Display Name">
+              <Input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                placeholder="My MCP Server"
+              />
+            </Field>
+            <Field label="Description">
+              <Textarea
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                rows={2}
+                placeholder="Description of this MCP server"
+              />
+            </Field>
           </section>
 
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Runtime Setup
             </h3>
-            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Transport Type *
-                </label>
-                <select
-                  value={formData.transport_type}
-                  onChange={(e) => setFormData({ ...formData, transport_type: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                >
-                  <option value="stdio">STDIO</option>
-                  <option value="http">HTTP (Streamable)</option>
-                  <option value="sse">SSE</option>
-                </select>
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Visibility
-                </label>
-                <select
-                  value={formData.visibility}
-                  onChange={(e) => setFormData({ ...formData, visibility: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                >
-                  <option value="private">Private</option>
-                  <option value="shared">Shared</option>
-                  <option value="public">Public</option>
-                </select>
-              </div>
-              <div className="flex items-end">
-                <label className="flex w-full items-center gap-2 rounded-md border border-border px-3 py-2 text-sm text-text-secondary">
-                  <input
-                    type="checkbox"
-                    checked={formData.is_enabled}
-                    onChange={(e) => setFormData({ ...formData, is_enabled: e.target.checked })}
-                    className="rounded border-border"
-                  />
-                  Enabled
-                </label>
-              </div>
-              <div className="flex items-end">
-                <label className="flex w-full items-center gap-2 rounded-md border border-border px-3 py-2 text-sm text-text-secondary">
-                  <input
-                    type="checkbox"
-                    checked={formData.auto_start}
-                    onChange={(e) => setFormData({ ...formData, auto_start: e.target.checked })}
-                    className="rounded border-border"
-                  />
-                  Auto-start
-                </label>
-              </div>
-            </div>
+            <Field label="Transport Type" required>
+              <Select
+                value={formData.transport_type}
+                onChange={(e) => setFormData({ ...formData, transport_type: e.target.value })}
+              >
+                <option value="stdio">STDIO</option>
+                <option value="http">HTTP (Streamable)</option>
+                <option value="sse">SSE</option>
+              </Select>
+            </Field>
+            <Field label="Visibility">
+              <Select
+                value={formData.visibility}
+                onChange={(e) => setFormData({ ...formData, visibility: e.target.value })}
+              >
+                <option value="private">Private</option>
+                <option value="shared">Shared</option>
+                <option value="public">Public</option>
+              </Select>
+            </Field>
+            <Field variant="check" label="Enabled">
+              <input
+                type="checkbox"
+                checked={formData.is_enabled}
+                onChange={(e) => setFormData({ ...formData, is_enabled: e.target.checked })}
+                className="h-4 w-4"
+              />
+            </Field>
+            <Field variant="check" label="Auto-start">
+              <input
+                type="checkbox"
+                checked={formData.auto_start}
+                onChange={(e) => setFormData({ ...formData, auto_start: e.target.checked })}
+                className="h-4 w-4"
+              />
+            </Field>
           </section>
 
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Connection Details
             </h3>
 
             {formData.transport_type === "stdio" ? (
-              <div className="grid gap-4 lg:grid-cols-2">
-                <div className="lg:col-span-2">
-                  <label className="mb-1 block text-sm font-medium text-text-secondary">
-                    Command *
-                  </label>
-                  <input
+              <>
+                <Field label="Command" required>
+                  <Input
                     type="text"
                     value={formData.command}
                     onChange={(e) => setFormData({ ...formData, command: e.target.value })}
-                    className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
+                    className="font-mono"
                     placeholder="npx"
                   />
-                </div>
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-text-secondary">
-                    Arguments (one per line)
-                  </label>
-                  <textarea
+                </Field>
+                <Field label="Arguments (one per line)">
+                  <Textarea
                     value={formData.args}
                     onChange={(e) => setFormData({ ...formData, args: e.target.value })}
-                    className="min-h-[200px] w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
+                    className="min-h-[200px] font-mono"
                     rows={7}
                     placeholder="-y&#10;@modelcontextprotocol/server-filesystem&#10;/path/to/allowed/dir"
                   />
-                </div>
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-text-secondary">
-                    Environment Variables (JSON)
-                  </label>
-                  <textarea
+                </Field>
+                <Field label="Environment Variables (JSON)">
+                  <Textarea
                     value={formData.env}
                     onChange={(e) => setFormData({ ...formData, env: e.target.value })}
-                    className="min-h-[200px] w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
+                    className="min-h-[200px] font-mono"
                     rows={7}
                     placeholder='{"API_KEY": "xxx"}'
                   />
-                </div>
-              </div>
+                </Field>
+              </>
             ) : (
-              <div className="grid gap-4 lg:grid-cols-2">
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-text-secondary">
-                    URL *
-                  </label>
-                  <input
+              <>
+                <Field label="URL" required>
+                  <Input
                     type="url"
                     value={formData.url}
                     onChange={(e) => setFormData({ ...formData, url: e.target.value })}
-                    className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
                     placeholder={formData.transport_type === "http"
                       ? "http://localhost:8080/mcp"
                       : "http://localhost:8080/sse"}
                   />
-                </div>
-                <div>
-                  <label className="mb-1 block text-sm font-medium text-text-secondary">
-                    Headers (JSON)
-                  </label>
-                  <textarea
+                </Field>
+                <Field label="Headers (JSON)">
+                  <Textarea
                     value={formData.headers}
                     onChange={(e) => setFormData({ ...formData, headers: e.target.value })}
-                    className="min-h-[200px] w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
+                    className="min-h-[200px] font-mono"
                     rows={7}
                     placeholder='{"Authorization": "Bearer xxx"}'
                   />
-                </div>
-              </div>
+                </Field>
+              </>
             )}
           </section>
         </form>

--- a/apps/negentropy-ui/app/interface/repositories/_components/RepositoryFormDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/repositories/_components/RepositoryFormDrawer.tsx
@@ -17,6 +17,10 @@ import {
 import { toast } from "sonner";
 import { BaseDrawer } from "@/components/ui/BaseDrawer";
 import { Button } from "@/components/ui/Button";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Textarea } from "@/components/ui/Textarea";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { inspectBranches } from "@/features/repositories";
 import type {
@@ -215,133 +219,103 @@ export function RepositoryFormDrawer({
       >
         <form id={formId} onSubmit={handleSubmit} className="space-y-6 px-5 py-5">
           {/* 基本信息 */}
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Basic Information
             </h3>
-            <div className="grid gap-4 sm:grid-cols-2">
-              <div>
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  Name <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
-                  placeholder="e.g. negentropy"
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  Display Name
-                </label>
-                <input
-                  type="text"
-                  value={formData.display_name}
-                  onChange={(e) =>
-                    setFormData({ ...formData, display_name: e.target.value })
-                  }
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  placeholder="e.g. Negentropy"
-                />
-              </div>
-              <div className="sm:col-span-2">
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  GitHub URL <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="url"
-                  value={formData.github_url}
-                  onChange={(e) =>
-                    setFormData({ ...formData, github_url: e.target.value })
-                  }
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  placeholder="https://github.com/org/repo"
-                  required
-                />
-              </div>
-              <div className="sm:col-span-2">
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  Description
-                </label>
-                <textarea
-                  value={formData.description}
-                  onChange={(e) =>
-                    setFormData({ ...formData, description: e.target.value })
-                  }
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  rows={2}
-                  placeholder="Repository description"
-                />
-              </div>
-            </div>
+            <Field label="Name" required>
+              <Input
+                type="text"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="font-mono"
+                placeholder="e.g. negentropy"
+                required
+              />
+            </Field>
+            <Field label="Display Name">
+              <Input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) =>
+                  setFormData({ ...formData, display_name: e.target.value })
+                }
+                placeholder="e.g. Negentropy"
+              />
+            </Field>
+            <Field label="GitHub URL" required>
+              <Input
+                type="url"
+                value={formData.github_url}
+                onChange={(e) =>
+                  setFormData({ ...formData, github_url: e.target.value })
+                }
+                placeholder="https://github.com/org/repo"
+                required
+              />
+            </Field>
+            <Field label="Description">
+              <Textarea
+                value={formData.description}
+                onChange={(e) =>
+                  setFormData({ ...formData, description: e.target.value })
+                }
+                rows={2}
+                placeholder="Repository description"
+              />
+            </Field>
           </section>
 
           {/* 本地仓库 + 分支枚举 */}
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Local Repository
             </h3>
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  Local Path <span className="text-red-500">*</span>
-                </label>
-                <div className="flex items-start gap-2">
-                  <input
-                    type="text"
-                    value={formData.local_path}
-                    onChange={(e) =>
-                      setFormData({ ...formData, local_path: e.target.value })
-                    }
-                    className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
-                    placeholder="/path/to/repo"
-                    required
-                  />
-                  <Button
-                    type="button"
-                    variant="outline"
-                    onClick={handleInspect}
-                    disabled={inspecting || submitting}
-                    loading={inspecting}
-                    className="shrink-0"
-                  >
-                    Inspect Branches
-                  </Button>
-                </div>
-                {inspectError && (
-                  <p className="mt-1 text-xs text-red-600 dark:text-red-400">
-                    {inspectError}
-                  </p>
-                )}
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  Baseline Branch <span className="text-red-500">*</span>
-                </label>
-                <select
-                  value={formData.baseline_branch}
+            <Field label="Local Path" required error={inspectError ?? undefined}>
+              <div className="flex items-start gap-2">
+                <Input
+                  type="text"
+                  value={formData.local_path}
                   onChange={(e) =>
-                    setFormData({ ...formData, baseline_branch: e.target.value })
+                    setFormData({ ...formData, local_path: e.target.value })
                   }
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground disabled:opacity-50"
-                  disabled={branches.length === 0}
+                  className="font-mono"
+                  placeholder="/path/to/repo"
                   required
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleInspect}
+                  disabled={inspecting || submitting}
+                  loading={inspecting}
+                  className="shrink-0"
                 >
-                  {branches.length === 0 ? (
-                    <option value="">Inspect branches first…</option>
-                  ) : (
-                    branches.map((branch) => (
-                      <option key={branch} value={branch}>
-                        {branch}
-                      </option>
-                    ))
-                  )}
-                </select>
+                  Inspect Branches
+                </Button>
               </div>
-            </div>
+            </Field>
+            <Field label="Baseline Branch" required>
+              <Select
+                value={formData.baseline_branch}
+                onChange={(e) =>
+                  setFormData({ ...formData, baseline_branch: e.target.value })
+                }
+                className="font-mono"
+                disabled={branches.length === 0}
+                required
+              >
+                {branches.length === 0 ? (
+                  <option value="">Inspect branches first…</option>
+                ) : (
+                  branches.map((branch) => (
+                    <option key={branch} value={branch}>
+                      {branch}
+                    </option>
+                  ))
+                )}
+              </Select>
+            </Field>
           </section>
         </form>
       </BaseDrawer>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineEditDrawer.tsx
@@ -4,9 +4,13 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown, ExternalLink, RotateCcw, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
+import { BaseDrawer } from "@/components/ui/BaseDrawer";
 import { Button } from "@/components/ui/Button";
 import { ErrorBanner } from "@/components/ui/ErrorState";
-import { BaseDrawer } from "@/components/ui/BaseDrawer";
+import { Field, InlineField } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Textarea } from "@/components/ui/Textarea";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 import { cn } from "@/lib/utils";
 import { createRoutine, updateRoutine } from "@/features/routine";
@@ -623,21 +627,6 @@ export function RoutineEditDrawer({
       : undefined;
   const sourceTaskKeyStr = typeof sourceTaskKey === "string" ? sourceTaskKey : null;
 
-  /* ── 样式常量 ── */
-  const inputCls =
-    "w-full rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground placeholder:text-text-muted focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-60";
-  const labelCls = "mb-1 block text-xs font-medium text-text-secondary";
-  const labelInlineCls = "shrink-0 whitespace-nowrap text-xs font-medium text-text-secondary";
-  const reqMark = <span className="text-red-500"> *</span>;
-
-  // 字段级错误渲染助手（普通函数，非组件 —— 避免 render 期创建组件丢失状态）。
-  const renderFieldError = (name: string) =>
-    fieldErrors[name] ? (
-      <p role="alert" className="mt-0.5 text-xs text-red-500">
-        {fieldErrors[name]}
-      </p>
-    ) : null;
-
   return (
     <>
       <BaseDrawer
@@ -802,75 +791,81 @@ export function RoutineEditDrawer({
             {error && <ErrorBanner message={error} />}
 
             {/* ── Identity ── */}
-            <div>
-              <label className={labelCls}>Name{reqMark}</label>
-              <input
+            <Field label="Name" required error={fieldErrors.title}>
+              <Input
                 type="text"
                 value={form.title}
                 onChange={(e) => updateName(e.target.value)}
                 disabled={isFieldDisabled("title")}
                 placeholder="My routine"
-                className={cn(inputCls, fieldErrors.title && "border-red-400")}
+                className={fieldErrors.title ? "border-error focus:ring-error/60" : undefined}
               />
-              {renderFieldError("title")}
-              {/* Key: editable for create/builtin, muted text for edit */}
-              {(op === "create" || isBuiltinTemplate) ? (
-                <div className="mt-1.5">
-                  <label className={labelCls}>Key{reqMark}</label>
-                  <input
-                    type="text"
-                    value={form.key}
-                    onChange={(e) => update("key", e.target.value)}
-                    disabled={isFieldDisabled("key")}
-                    placeholder="unique_key"
-                    className={cn(inputCls, "font-mono text-xs", fieldErrors.key && "border-red-400")}
-                  />
-                  {renderFieldError("key")}
-                  {isBuiltinTemplate && !fieldErrors.key && (
-                    <p className="mt-0.5 text-xs text-text-secondary">Saved as a new template — pick a unique key.</p>
+            </Field>
+            {/* Key: editable for create/builtin, muted text for edit */}
+            {(op === "create" || isBuiltinTemplate) ? (
+              <Field
+                label="Key"
+                required
+                error={fieldErrors.key}
+                description={
+                  isBuiltinTemplate && !fieldErrors.key
+                    ? "Saved as a new template — pick a unique key."
+                    : undefined
+                }
+              >
+                <Input
+                  type="text"
+                  value={form.key}
+                  onChange={(e) => update("key", e.target.value)}
+                  disabled={isFieldDisabled("key")}
+                  placeholder="unique_key"
+                  className={cn(
+                    "font-mono text-xs",
+                    fieldErrors.key ? "border-error focus:ring-error/60" : undefined,
                   )}
-                </div>
-              ) : (
-                <p className="mt-1 text-xs font-mono text-text-secondary">key: {form.key}</p>
-              )}
-            </div>
+                />
+              </Field>
+            ) : (
+              <Field label="Key">
+                <p className="text-xs font-mono text-text-secondary">key: {form.key}</p>
+              </Field>
+            )}
 
             {/* ── Objective（视觉重心）── */}
-            <div>
-              <label className={labelCls}>Goal{!isFieldDisabled("goal") && reqMark}</label>
-              <textarea
+            <Field label="Goal" required={!isFieldDisabled("goal")} error={fieldErrors.goal}>
+              <Textarea
                 value={form.goal}
                 onChange={(e) => update("goal", e.target.value)}
                 disabled={isFieldDisabled("goal")}
                 rows={6}
                 placeholder="What should Claude Code accomplish?"
-                className={cn(inputCls, "resize-y", fieldErrors.goal && "border-red-400")}
               />
-              {renderFieldError("goal")}
-            </div>
-            <div>
-              <label className={labelCls}>Acceptance Criteria{!isFieldDisabled("acceptance_criteria") && reqMark}</label>
-              <textarea
+            </Field>
+            <Field
+              label="Acceptance Criteria"
+              required={!isFieldDisabled("acceptance_criteria")}
+              error={fieldErrors.acceptance_criteria}
+            >
+              <Textarea
                 value={form.acceptance_criteria}
                 onChange={(e) => update("acceptance_criteria", e.target.value)}
                 disabled={isFieldDisabled("acceptance_criteria")}
                 rows={4}
                 placeholder="How do you judge success?"
-                className={cn(inputCls, "resize-y", fieldErrors.acceptance_criteria && "border-red-400")}
               />
-              {renderFieldError("acceptance_criteria")}
-            </div>
+            </Field>
 
             {/* ── Execution Context（仅 routine entity）── */}
             {entity === "routine" && (
               <>
-                <div>
-                  <label className={labelCls}>Repository</label>
-                  <select
+                <Field
+                  label="Repository"
+                  description="选择已注册的 Repository 以自动派生 Project Path 与 Baseline Branch；或选 Manual 手动填写。"
+                >
+                  <Select
                     value={form.repository_id}
                     onChange={(e) => onPickRepository(e.target.value)}
                     disabled={isFieldDisabled("cwd")}
-                    className={inputCls}
                   >
                     <option value="">— Manual (enter path &amp; branch below) —</option>
                     {repos.map((r) => (
@@ -881,98 +876,97 @@ export function RoutineEditDrawer({
                     {repoLinked && !selectedRepo && (
                       <option value={form.repository_id}>(repository unavailable — switch to Manual)</option>
                     )}
-                  </select>
-                  <p className="mt-1 text-caption text-text-secondary">
-                    选择已注册的 Repository 以自动派生 Project Path 与 Baseline Branch；或选 Manual 手动填写。
-                  </p>
-                </div>
+                  </Select>
+                </Field>
 
                 {repoLinked ? (
-                  <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <label className={labelCls}>Project Path</label>
-                      <input
+                  <>
+                    <Field label="Project Path">
+                      <Input
                         type="text"
                         value={selectedRepo?.local_path ?? ""}
                         disabled
                         readOnly
                         placeholder="（仓库信息加载中或不可用）"
-                        className={cn(inputCls, "opacity-70")}
+                        className="opacity-70"
                       />
-                    </div>
-                    <div>
-                      <label className={labelCls}>Baseline Branch</label>
-                      <input
+                    </Field>
+                    <Field label="Baseline Branch">
+                      <Input
                         type="text"
                         value={selectedRepo?.baseline_branch ?? ""}
                         disabled
                         readOnly
                         placeholder="（仓库信息加载中或不可用）"
-                        className={cn(inputCls, "opacity-70")}
+                        className="opacity-70"
                       />
-                    </div>
-                  </div>
+                    </Field>
+                  </>
                 ) : (
-                  <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <label className={labelCls}>Project Path{requireWorktree && !isFieldDisabled("cwd") && reqMark}</label>
-                      <input
+                  <>
+                    <Field
+                      label="Project Path"
+                      required={requireWorktree && !isFieldDisabled("cwd")}
+                      error={fieldErrors.cwd}
+                    >
+                      <Input
                         type="text"
                         value={form.cwd}
                         onChange={(e) => update("cwd", e.target.value)}
                         disabled={isFieldDisabled("cwd")}
                         placeholder="/path/to/repo"
-                        className={cn(inputCls, fieldErrors.cwd && "border-red-400")}
+                        className={fieldErrors.cwd ? "border-error focus:ring-error/60" : undefined}
                       />
-                      {renderFieldError("cwd")}
-                    </div>
-                    <div>
-                      <label className={labelCls}>Baseline Branch{requireWorktree && !isFieldDisabled("baseline_branch") && reqMark}</label>
-                      <input
+                    </Field>
+                    <Field
+                      label="Baseline Branch"
+                      required={requireWorktree && !isFieldDisabled("baseline_branch")}
+                      error={fieldErrors.baseline_branch}
+                    >
+                      <Input
                         type="text"
                         value={form.baseline_branch}
                         onChange={(e) => update("baseline_branch", e.target.value)}
                         disabled={isFieldDisabled("baseline_branch")}
                         placeholder="e.g. origin/feature/1.x.x"
-                        className={cn(inputCls, fieldErrors.baseline_branch && "border-red-400")}
+                        className={fieldErrors.baseline_branch ? "border-error focus:ring-error/60" : undefined}
                       />
-                      {renderFieldError("baseline_branch")}
-                    </div>
-                  </div>
+                    </Field>
+                  </>
                 )}
-                <div>
-                  <label className={labelCls}>Additional Dirs</label>
-                  <input
+                <Field
+                  label="Additional Dirs"
+                  description={
+                    <>
+                      额外授予 Claude Code 只读访问的目录（逗号分隔），映射到{" "}
+                      <code className="text-xs">--add-dir</code>。仅 Project Worktree 可写，这些目录均为只读。
+                    </>
+                  }
+                >
+                  <Input
                     type="text"
                     value={form.read_dirs}
                     onChange={(e) => update("read_dirs", e.target.value)}
                     disabled={isFieldDisabled("read_dirs")}
                     placeholder="/path/to/other/repo, /path/to/docs"
-                    className={inputCls}
                   />
-                  <p className="mt-1 text-caption text-text-secondary">
-                    额外授予 Claude Code 只读访问的目录（逗号分隔），映射到 <code className="text-xs">--add-dir</code>。仅 Project
-                    Worktree 可写，这些目录均为只读。
-                  </p>
-                </div>
+                </Field>
               </>
             )}
 
             {/* ── Verification ── */}
-            <div>
-              <label className={labelCls}>Verification Command</label>
-              <input
+            <Field
+              label="Verification Command"
+              description="Test-driven gate — a non-zero exit code caps the score, mitigating LLM-judge bias."
+            >
+              <Input
                 type="text"
                 value={form.verification_command}
                 onChange={(e) => update("verification_command", e.target.value)}
                 disabled={isFieldDisabled("verification_command")}
                 placeholder="e.g. uv run pytest -q"
-                className={inputCls}
               />
-              <p className="mt-1 text-caption text-text-secondary">
-                Test-driven gate — a non-zero exit code caps the score, mitigating LLM-judge bias.
-              </p>
-            </div>
+            </Field>
 
             {/* ── Advanced Settings（统一折叠区）── */}
             <section>
@@ -995,66 +989,55 @@ export function RoutineEditDrawer({
                   <div>
                     <h4 className="mb-2 text-xs font-medium text-text-secondary">Budget &amp; Approval</h4>
                     <div className="grid grid-cols-3 gap-x-4 gap-y-2">
-                      <div className="flex items-center gap-2">
-                        <label className={labelInlineCls}>Max Iterations</label>
-                        <input
+                      <InlineField label="Max Iterations">
+                        <Input
                           type="number"
                           min={1}
                           value={form.max_iterations}
                           onChange={(e) => update("max_iterations", e.target.value)}
                           disabled={isFieldDisabled("max_iterations")}
-                          className={cn(inputCls, "min-w-0 flex-1")}
                         />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <label className={labelInlineCls}>Max Cost (USD)</label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Max Cost (USD)">
+                        <Input
                           type="number"
                           min={0}
                           step="0.5"
                           value={form.max_cost_usd}
                           onChange={(e) => update("max_cost_usd", e.target.value)}
                           disabled={isFieldDisabled("max_cost_usd")}
-                          className={cn(inputCls, "min-w-0 flex-1")}
                         />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <label className={labelInlineCls}>Score Threshold</label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Score Threshold">
+                        <Input
                           type="number"
                           min={0}
                           max={100}
                           value={form.success_score_threshold}
                           onChange={(e) => update("success_score_threshold", e.target.value)}
                           disabled={isFieldDisabled("success_score_threshold")}
-                          className={cn(inputCls, "min-w-0 flex-1")}
                         />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <label className={labelInlineCls}>No-Progress Limit</label>
-                        <input
+                      </InlineField>
+                      <InlineField label="No-Progress Limit">
+                        <Input
                           type="number"
                           min={1}
                           value={form.no_progress_patience}
                           onChange={(e) => update("no_progress_patience", e.target.value)}
                           disabled={isFieldDisabled("no_progress_patience")}
-                          className={cn(inputCls, "min-w-0 flex-1")}
                         />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <label className={labelInlineCls}>Max Turns / Iter.</label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Max Turns / Iter.">
+                        <Input
                           type="number"
                           min={1}
                           value={form.max_turns}
                           onChange={(e) => update("max_turns", e.target.value)}
                           disabled={isFieldDisabled("max_turns")}
-                          className={cn(inputCls, "min-w-0 flex-1")}
                         />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <label className={labelInlineCls}>Max Events / Iter.</label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Max Events / Iter.">
+                        <Input
                           type="number"
                           min={100}
                           max={100000}
@@ -1062,12 +1045,10 @@ export function RoutineEditDrawer({
                           onChange={(e) => update("max_events_per_iter", e.target.value)}
                           disabled={isFieldDisabled("max_events_per_iter")}
                           placeholder="5000"
-                          className={cn(inputCls, "min-w-0 flex-1")}
                         />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <label className={labelInlineCls}>Timeout</label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Timeout">
+                        <Input
                           type="number"
                           min={300}
                           max={86400}
@@ -1075,144 +1056,126 @@ export function RoutineEditDrawer({
                           onChange={(e) => update("timeout_seconds", e.target.value)}
                           disabled={isFieldDisabled("timeout_seconds")}
                           placeholder="10800"
-                          className={cn(inputCls, "min-w-0 flex-1")}
                         />
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <label className={labelInlineCls}>Deadline</label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Deadline">
+                        <Input
                           type="datetime-local"
                           value={form.deadline_at}
                           onChange={(e) => update("deadline_at", e.target.value)}
                           disabled={isFieldDisabled("deadline_at")}
-                          className={cn(inputCls, "min-w-0 flex-1")}
                         />
-                      </div>
+                      </InlineField>
                     </div>
-                    <div className="mt-3 flex items-start gap-2">
-                      <label className={cn(labelInlineCls, "pt-2")}>Approval Mode</label>
-                      <div className="min-w-0 flex-1">
-                        <select
-                          value={form.approval_mode}
-                          onChange={(e) => update("approval_mode", e.target.value as ApprovalMode)}
-                          disabled={isFieldDisabled("approval_mode")}
-                          className={inputCls}
-                        >
-                          {APPROVAL_OPTIONS.map((o) => (
-                            <option key={o.value} value={o.value}>
-                              {o.label}
-                            </option>
-                          ))}
-                        </select>
-                        <p className="mt-1 text-caption text-text-secondary">{APPROVAL_HELP[form.approval_mode]}</p>
-                      </div>
-                    </div>
+                    <Field
+                      className="mt-3"
+                      label="Approval Mode"
+                      description={APPROVAL_HELP[form.approval_mode]}
+                    >
+                      <Select
+                        value={form.approval_mode}
+                        onChange={(e) => update("approval_mode", e.target.value as ApprovalMode)}
+                        disabled={isFieldDisabled("approval_mode")}
+                      >
+                        {APPROVAL_OPTIONS.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))}
+                      </Select>
+                    </Field>
                   </div>
 
                   {/* Description */}
                   <div className="border-t border-border pt-3">
-                    <label className={labelCls}>Description</label>
-                    <textarea
-                      value={form.description}
-                      onChange={(e) => update("description", e.target.value)}
-                      disabled={isFieldDisabled("description")}
-                      rows={2}
-                      placeholder="Short summary of what this does"
-                      className={cn(inputCls, "resize-y")}
-                    />
+                    <Field label="Description">
+                      <Textarea
+                        value={form.description}
+                        onChange={(e) => update("description", e.target.value)}
+                        disabled={isFieldDisabled("description")}
+                        rows={2}
+                        placeholder="Short summary of what this does"
+                      />
+                    </Field>
                   </div>
 
                   {/* Template Metadata（仅 template entity）*/}
                   {entity === "template" && (
-                    <div className="border-t border-border pt-3">
-                      <h4 className="mb-2 text-xs font-medium text-text-secondary">Template Metadata</h4>
-                      <div className="grid grid-cols-2 gap-3">
-                        <div>
-                          <label className={labelCls}>Category</label>
-                          <select
-                            value={form.category}
-                            onChange={(e) => update("category", e.target.value)}
-                            disabled={isFieldDisabled("category")}
-                            className={inputCls}
-                          >
-                            {CATEGORY_OPTIONS.map((o) => (
-                              <option key={o.value} value={o.value}>
-                                {o.label}
-                              </option>
-                            ))}
-                          </select>
-                        </div>
-                        <div>
-                          <label className={labelCls}>Version</label>
-                          <input
-                            type="text"
-                            value={form.version}
-                            onChange={(e) => update("version", e.target.value)}
-                            disabled={isFieldDisabled("version")}
-                            placeholder="1.0.0"
-                            className={inputCls}
-                          />
-                        </div>
-                      </div>
-                      <div className="mt-2">
-                        <label className={labelCls}>Features</label>
-                        <input
+                    <div className="space-y-3 border-t border-border pt-3">
+                      <h4 className="text-xs font-medium text-text-secondary">Template Metadata</h4>
+                      <Field label="Category">
+                        <Select
+                          value={form.category}
+                          onChange={(e) => update("category", e.target.value)}
+                          disabled={isFieldDisabled("category")}
+                        >
+                          {CATEGORY_OPTIONS.map((o) => (
+                            <option key={o.value} value={o.value}>
+                              {o.label}
+                            </option>
+                          ))}
+                        </Select>
+                      </Field>
+                      <Field label="Version">
+                        <Input
+                          type="text"
+                          value={form.version}
+                          onChange={(e) => update("version", e.target.value)}
+                          disabled={isFieldDisabled("version")}
+                          placeholder="1.0.0"
+                        />
+                      </Field>
+                      <Field
+                        label="Features"
+                        description="Feature tags shown on the template card (comma-separated)."
+                      >
+                        <Input
                           type="text"
                           value={form.features_showcase}
                           onChange={(e) => update("features_showcase", e.target.value)}
                           disabled={isFieldDisabled("features_showcase")}
                           placeholder="feature 1, feature 2, feature 3"
-                          className={inputCls}
                         />
-                        <p className="mt-1 text-caption text-text-secondary">
-                          Feature tags shown on the template card (comma-separated).
-                        </p>
-                      </div>
+                      </Field>
                     </div>
                   )}
 
                   {/* Claude Code Config */}
-                  <div className="border-t border-border pt-3">
-                      <h4 className="mb-2 text-xs font-medium text-text-secondary">Claude Code Config</h4>
-                      <div className="grid grid-cols-2 gap-3">
-                        <div className="flex items-center gap-2">
-                          <label className={labelInlineCls}>Model</label>
-                          <input
-                            type="text"
-                            value={form.model}
-                            onChange={(e) => update("model", e.target.value)}
-                            disabled={isFieldDisabled("model")}
-                            placeholder="inherit global config"
-                            className={cn(inputCls, "min-w-0 flex-1")}
-                          />
-                        </div>
-                        <div className="flex items-center gap-2">
-                          <label className={labelInlineCls}>Permission Mode</label>
-                          <select
-                            value={form.permission_mode}
-                            onChange={(e) => update("permission_mode", e.target.value)}
-                            disabled={isFieldDisabled("permission_mode")}
-                            className={cn(inputCls, "min-w-0 flex-1")}
-                          >
-                            <option value="">default</option>
-                            <option value="auto">auto</option>
-                            <option value="ask">ask</option>
-                            <option value="plan">plan</option>
-                          </select>
-                        </div>
-                      </div>
-                      <div className="mt-2 flex items-center gap-2">
-                        <label className={labelInlineCls}>Allowed Tools</label>
-                        <input
+                  <div className="space-y-2 border-t border-border pt-3">
+                    <h4 className="text-xs font-medium text-text-secondary">Claude Code Config</h4>
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-2">
+                      <InlineField label="Model">
+                        <Input
                           type="text"
-                          value={form.allowed_tools}
-                          onChange={(e) => update("allowed_tools", e.target.value)}
-                          disabled={isFieldDisabled("allowed_tools")}
-                          placeholder="Bash, Read, Write, Edit, Glob, Grep"
-                          className={cn(inputCls, "min-w-0 flex-1")}
+                          value={form.model}
+                          onChange={(e) => update("model", e.target.value)}
+                          disabled={isFieldDisabled("model")}
+                          placeholder="inherit global config"
                         />
-                      </div>
+                      </InlineField>
+                      <InlineField label="Permission Mode">
+                        <Select
+                          value={form.permission_mode}
+                          onChange={(e) => update("permission_mode", e.target.value)}
+                          disabled={isFieldDisabled("permission_mode")}
+                        >
+                          <option value="">default</option>
+                          <option value="auto">auto</option>
+                          <option value="ask">ask</option>
+                          <option value="plan">plan</option>
+                        </Select>
+                      </InlineField>
                     </div>
+                    <InlineField label="Allowed Tools">
+                      <Input
+                        type="text"
+                        value={form.allowed_tools}
+                        onChange={(e) => update("allowed_tools", e.target.value)}
+                        disabled={isFieldDisabled("allowed_tools")}
+                        placeholder="Bash, Read, Write, Edit, Glob, Grep"
+                      />
+                    </InlineField>
+                  </div>
                 </div>
               )}
             </section>

--- a/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/RoutineTable.tsx
@@ -4,7 +4,7 @@ import { ExternalLink, GitMerge, GitPullRequest, Loader2, OctagonX, RotateCcw, T
 
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { TextTooltip } from "@/components/ui/TextTooltip";
+import { TruncatedCell } from "@/components/ui/TruncatedCell";
 import type { RoutineDTO } from "@/features/routine";
 
 import { canCancel, canCleanupWorktree, canRestart } from "./routine-controls";
@@ -86,95 +86,74 @@ export function RoutineTable({ routines, loading, onSelect, onOpenFull, onRestar
               onClick={() => onSelect(r)}
               className="cursor-pointer border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
             >
-              <td className="px-4 py-3">
-                <div className="flex min-w-0 items-center gap-2 font-medium text-foreground">
-                  <TextTooltip content={r.display_name || r.title}>
-                    <span className="min-w-0 flex-1 truncate">{r.display_name || r.title}</span>
-                  </TextTooltip>
-                  {r.key.startsWith("pdf-fidelity-patrol/") && (
+              <TruncatedCell
+                text={r.display_name || r.title}
+                textClassName="font-medium text-foreground"
+                trailing={
+                  r.key.startsWith("pdf-fidelity-patrol/") ? (
                     <span className="inline-flex items-center rounded-full bg-violet-500/10 px-1.5 py-0.5 text-micro font-semibold text-violet-700 dark:text-violet-300 shrink-0">
                       巡检
                     </span>
+                  ) : undefined
+                }
+              />
+              {/* 任务 ID（独立列）：约半宽截断展示，全文经悬浮单行恢复 + 一键复制。 */}
+              <TruncatedCell
+                text={r.key}
+                mono
+                textClassName="text-text-secondary"
+                trailing={<CopyButton value={r.key} ariaLabel="复制 ID" className="shrink-0" />}
+              />
+              {/* 状态芯片单行展示：不折行，溢出由 overflow-hidden 右缘裁切；悬浮 Tooltip（单行）显示完整组合标题。 */}
+              <TruncatedCell text={composeStatusTitle(r)} showOnOverflowOnly={false}>
+                <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
+                  <span
+                    className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(r.status)}`}
+                  >
+                    {r.status}
+                  </span>
+                  {r.pr_merged && (
+                    <span className={`${mergedBadgeClass} shrink-0`}>
+                      <GitMerge className="h-3 w-3" aria-hidden />
+                      Merged
+                    </span>
+                  )}
+                  {r.pr_state === "closed" && (
+                    <span className={`${closedBadgeClass} shrink-0`}>
+                      <X className="h-3 w-3" aria-hidden />
+                      Closed
+                    </span>
+                  )}
+                  {r.pr_state === "open" && (
+                    <span className={`${openBadgeClass} shrink-0`}>
+                      <GitPullRequest className="h-3 w-3" aria-hidden />
+                      Open
+                    </span>
+                  )}
+                  {/* 终止原因：succeeded 恒配 "success"，与状态芯片冗余故略去；其余（失败原因）内联同行截断。 */}
+                  {r.termination_reason && r.termination_reason !== "success" && (
+                    <span className="min-w-0 truncate text-xs text-text-secondary">
+                      {r.termination_reason}
+                    </span>
                   )}
                 </div>
-              </td>
-              <td className="px-4 py-3">
-                {/* 任务 ID（独立列）：约半宽截断展示，全文经悬浮单行恢复 + 一键复制。 */}
-                <div className="flex min-w-0 items-center gap-1">
-                  <TextTooltip content={r.key}>
-                    <span className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary">
-                      {r.key}
-                    </span>
-                  </TextTooltip>
-                  <CopyButton value={r.key} ariaLabel="复制 ID" className="shrink-0" />
-                </div>
-              </td>
-              <td className="px-4 py-3">
-                {/* 状态芯片单行展示：不折行，溢出由 overflow-hidden 右缘裁切；悬浮 Tooltip（单行）显示完整组合标题。 */}
-                <TextTooltip content={composeStatusTitle(r)}>
-                  <div className="flex min-w-0 items-center gap-1.5 overflow-hidden">
-                    <span
-                      className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-semibold ${routineStatusClass(r.status)}`}
-                    >
-                      {r.status}
-                    </span>
-                    {r.pr_merged && (
-                      <span className={`${mergedBadgeClass} shrink-0`}>
-                        <GitMerge className="h-3 w-3" aria-hidden />
-                        Merged
-                      </span>
-                    )}
-                    {r.pr_state === "closed" && (
-                      <span className={`${closedBadgeClass} shrink-0`}>
-                        <X className="h-3 w-3" aria-hidden />
-                        Closed
-                      </span>
-                    )}
-                    {r.pr_state === "open" && (
-                      <span className={`${openBadgeClass} shrink-0`}>
-                        <GitPullRequest className="h-3 w-3" aria-hidden />
-                        Open
-                      </span>
-                    )}
-                    {/* 终止原因：succeeded 恒配 "success"，与状态芯片冗余故略去；其余（失败原因）内联同行截断。 */}
-                    {r.termination_reason && r.termination_reason !== "success" && (
-                      <span className="min-w-0 truncate text-xs text-text-secondary">
-                        {r.termination_reason}
-                      </span>
-                    )}
-                  </div>
-                </TextTooltip>
-              </td>
-              <td className="px-4 py-3 tabular-nums text-text-secondary">
-                <TextTooltip content={`${r.iteration_count}${r.max_iterations ? ` / ${r.max_iterations}` : ""}`}>
-                  <span className="block truncate">
-                    {r.iteration_count}
-                    {r.max_iterations ? ` / ${r.max_iterations}` : ""}
-                  </span>
-                </TextTooltip>
-              </td>
-              <td className={`px-4 py-3 font-semibold tabular-nums ${scoreColorClass(r.best_score)}`}>
-                <TextTooltip content={String(r.best_score ?? "—")}>
-                  <span className="block truncate">{r.best_score ?? "—"}</span>
-                </TextTooltip>
-              </td>
-              <td className="px-4 py-3 tabular-nums text-text-secondary">
-                <TextTooltip
-                  content={`$${r.total_cost_usd.toFixed(3)}${r.max_cost_usd ? ` / $${r.max_cost_usd}` : ""}`}
-                >
-                  <span className="block truncate">
-                    ${r.total_cost_usd.toFixed(3)}
-                    {r.max_cost_usd ? <span className="text-text-secondary"> / ${r.max_cost_usd}</span> : null}
-                  </span>
-                </TextTooltip>
-              </td>
-              <td className="px-4 py-3 text-xs text-text-secondary">
-                <TextTooltip content={r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}>
-                  <span className="block truncate">
-                    {r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
-                  </span>
-                </TextTooltip>
-              </td>
+              </TruncatedCell>
+              <TruncatedCell
+                text={`${r.iteration_count}${r.max_iterations ? ` / ${r.max_iterations}` : ""}`}
+                className="tabular-nums text-text-secondary"
+              />
+              <TruncatedCell
+                text={r.best_score ?? "—"}
+                className={`font-semibold tabular-nums ${scoreColorClass(r.best_score)}`}
+              />
+              <TruncatedCell
+                className="tabular-nums text-text-secondary"
+                text={`$${r.total_cost_usd.toFixed(3)}${r.max_cost_usd ? ` / $${r.max_cost_usd}` : ""}`}
+              />
+              <TruncatedCell
+                text={r.updated_at ? new Date(r.updated_at).toLocaleString() : "—"}
+                className="text-xs text-text-secondary"
+              />
               <td className="px-4 py-3 text-right">
                 <div className="flex items-center justify-end gap-2 overflow-hidden">
                   {onRestart && canRestart(r.status) && (

--- a/apps/negentropy-ui/app/interface/scheduler/_components/ManifestField.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/ManifestField.tsx
@@ -1,5 +1,8 @@
 "use client";
 
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
 import type { PayloadFieldSchema } from "@/features/scheduler";
 
 interface ManifestFieldProps {
@@ -14,15 +17,11 @@ interface ManifestFieldProps {
  * 按 PayloadFieldSchema.type 映射到对应的表单控件。
  */
 export function ManifestField({ field, value, onChange, disabled }: ManifestFieldProps) {
-  const inputCls =
-    "w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
-  const labelCls = "mb-1 block text-xs font-medium text-text-secondary";
-
   const handleChange = (v: unknown) => onChange(field.name, v);
 
   if (field.type === "boolean") {
     return (
-      <label className="flex items-center gap-2 py-1">
+      <Field variant="check" label={field.label} required={field.required}>
         <input
           type="checkbox"
           checked={!!value}
@@ -30,26 +29,17 @@ export function ManifestField({ field, value, onChange, disabled }: ManifestFiel
           disabled={disabled}
           className="h-4 w-4 rounded border-border text-foreground focus:ring-ring"
         />
-        <span className={labelCls}>
-          {field.label}
-          {field.required && <span className="ml-0.5 text-red-500">*</span>}
-        </span>
-      </label>
+      </Field>
     );
   }
 
   if (field.type === "enum" && field.enum_options) {
     return (
-      <div>
-        <label className={labelCls}>
-          {field.label}
-          {field.required && <span className="ml-0.5 text-red-500">*</span>}
-        </label>
-        <select
+      <Field label={field.label} required={field.required} description={field.help_text}>
+        <Select
           value={String(value ?? "")}
           onChange={(e) => handleChange(e.target.value)}
           disabled={disabled}
-          className={inputCls}
         >
           <option value="">—</option>
           {field.enum_options.map((opt) => (
@@ -57,69 +47,55 @@ export function ManifestField({ field, value, onChange, disabled }: ManifestFiel
               {opt}
             </option>
           ))}
-        </select>
-        {field.help_text && (
-          <p className="mt-0.5 text-micro text-text-muted">{field.help_text}</p>
-        )}
-      </div>
+        </Select>
+      </Field>
     );
   }
 
   if (field.type === "integer") {
     return (
-      <div>
-        <label className={labelCls}>
-          {field.label}
-          {field.required && <span className="ml-0.5 text-red-500">*</span>}
-        </label>
-        <input
+      <Field label={field.label} required={field.required}>
+        <Input
           type="number"
           step={1}
           value={value != null ? String(value) : ""}
-          onChange={(e) => handleChange(e.target.value === "" ? null : parseInt(e.target.value, 10))}
+          onChange={(e) =>
+            handleChange(e.target.value === "" ? null : parseInt(e.target.value, 10))
+          }
           disabled={disabled}
           placeholder={field.help_text}
-          className={inputCls}
         />
-      </div>
+      </Field>
     );
   }
 
   if (field.type === "number") {
     return (
-      <div>
-        <label className={labelCls}>
-          {field.label}
-          {field.required && <span className="ml-0.5 text-red-500">*</span>}
-        </label>
-        <input
+      <Field label={field.label} required={field.required}>
+        <Input
           type="number"
           step="any"
           value={value != null ? String(value) : ""}
-          onChange={(e) => handleChange(e.target.value === "" ? null : parseFloat(e.target.value))}
+          onChange={(e) =>
+            handleChange(e.target.value === "" ? null : parseFloat(e.target.value))
+          }
           disabled={disabled}
           placeholder={field.help_text}
-          className={inputCls}
         />
-      </div>
+      </Field>
     );
   }
 
   // default: string
   return (
-    <div>
-      <label className={labelCls}>
-        {field.label}
-        {field.required && <span className="ml-0.5 text-red-500">*</span>}
-      </label>
-      <input
+    <Field label={field.label} required={field.required}>
+      <Input
         type="text"
         value={String(value ?? "")}
         onChange={(e) => handleChange(e.target.value)}
         disabled={disabled}
         placeholder={field.help_text}
-        className={inputCls}
       />
-    </div>
+    </Field>
   );
 }

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerExecutionPanel.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerExecutionPanel.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 
 import { Skeleton } from "@/components/ui/Skeleton";
 import { TextTooltip } from "@/components/ui/TextTooltip";
+import { TruncatedCell } from "@/components/ui/TruncatedCell";
 import type { ExecutionStatus, TaskExecutionDTO } from "@/features/scheduler";
 import { patrolReasonLabel, patrolReasonStyle } from "@/features/scheduler/patrol-reason";
 
@@ -115,11 +116,10 @@ export function SchedulerExecutionPanel({
                 key={e.id}
                 className="border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
               >
-                <td className="px-4 py-3 text-muted-foreground">
-                  <TextTooltip content={formatTime(e.started_at)}>
-                    <span className="block truncate">{formatTime(e.started_at)}</span>
-                  </TextTooltip>
-                </td>
+                <TruncatedCell
+                  text={formatTime(e.started_at)}
+                  textClassName="text-muted-foreground"
+                />
                 <td className="px-4 py-3">
                   <span
                     className={`inline-flex items-center rounded-full px-2 py-0.5 text-micro font-semibold ${STATUS_STYLES[e.status]}`}
@@ -127,25 +127,21 @@ export function SchedulerExecutionPanel({
                     {e.status}
                   </span>
                 </td>
-                <td className="px-4 py-3 text-foreground font-medium">
-                  <TextTooltip content={e.task_key ?? "—"}>
-                    <span className="block truncate">{e.task_key ?? "—"}</span>
-                  </TextTooltip>
-                </td>
+                <TruncatedCell
+                  text={e.task_key ?? "—"}
+                  textClassName="text-foreground font-medium"
+                />
                 <td className="px-4 py-3 text-muted-foreground">
                   <span className="block truncate">{formatDuration(e.duration_ms)}</span>
                 </td>
-                <td className="px-4 py-3 text-muted-foreground">
-                  <TextTooltip content={e.fire_reason}>
-                    <span className="block truncate">{e.fire_reason}</span>
-                  </TextTooltip>
-                </td>
-                <td className="px-4 py-3 text-muted-foreground">
-                  {e.error ? (
-                    <TextTooltip content={e.error}>
-                      <span className="block truncate text-red-600 dark:text-red-400">{e.error}</span>
-                    </TextTooltip>
-                  ) : (
+                <TruncatedCell
+                  text={e.fire_reason}
+                  textClassName="text-muted-foreground"
+                />
+                {e.error ? (
+                  <TruncatedCell text={e.error} textClassName="text-red-600 dark:text-red-400" />
+                ) : (
+                  <td className="px-4 py-3 text-muted-foreground">
                     <div className="flex min-w-0 flex-col gap-0.5">
                       <div className="flex min-w-0 items-center gap-1.5">
                         {patrolReasonLabel(e.metrics?.reason) && (
@@ -163,8 +159,8 @@ export function SchedulerExecutionPanel({
                       </div>
                       <SpawnedRoutineLink metrics={e.metrics} />
                     </div>
-                  )}
-                </td>
+                  </td>
+                )}
               </tr>
             ))
           )}

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskFormDialog.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskFormDialog.tsx
@@ -3,7 +3,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { Button } from "@/components/ui/Button";
 import { ErrorBanner } from "@/components/ui/ErrorState";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
+import { Select } from "@/components/ui/Select";
+import { Textarea } from "@/components/ui/Textarea";
 import type {
   ScheduledTaskDTO,
   HandlerDescriptor,
@@ -280,9 +284,6 @@ export function SchedulerTaskFormDialog({
 
   if (!open) return null;
 
-  const inputCls =
-    "w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground focus:border-border focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50";
-  const labelCls = "mb-1 block text-xs font-medium text-text-secondary";
   const sectionTitleCls = "text-micro uppercase tracking-overline text-text-muted mb-2";
 
   return (
@@ -313,36 +314,27 @@ export function SchedulerTaskFormDialog({
             <h3 className={sectionTitleCls}>Basic</h3>
             <div className="space-y-3">
               {isEdit ? (
-                <div>
-                  <label className={labelCls}>Key</label>
-                  <input type="text" value={formData.key} disabled className={inputCls} />
-                  <p className="mt-0.5 text-micro text-text-muted">Key cannot be changed after creation</p>
-                </div>
+                <Field label="Key" description="Key cannot be changed after creation">
+                  <Input type="text" value={formData.key} disabled />
+                </Field>
               ) : (
-                <div>
-                  <label className={labelCls}>
-                    Key <span className="text-red-500">*</span>
-                  </label>
-                  <input
+                <Field label="Key" required error={fieldErrors.key}>
+                  <Input
                     type="text"
                     value={formData.key}
                     onChange={(e) => updateField("key", e.target.value)}
                     placeholder="unique_task_key"
-                    className={`${inputCls} ${fieldErrors.key ? "border-red-400" : ""}`}
+                    className={fieldErrors.key ? "border-error focus:ring-error/60" : undefined}
                   />
-                  {fieldErrors.key && <p className="mt-0.5 text-micro text-red-500">{fieldErrors.key}</p>}
-                </div>
+                </Field>
               )}
 
-              <div>
-                <label className={labelCls}>
-                  Handler <span className="text-red-500">*</span>
-                </label>
-                <select
+              <Field label="Handler" required error={fieldErrors.handler_kind}>
+                <Select
                   value={formData.handler_kind}
                   onChange={(e) => updateField("handler_kind", e.target.value)}
                   disabled={isEdit || loadingHandlers}
-                  className={`${inputCls} ${fieldErrors.handler_kind ? "border-red-400" : ""}`}
+                  className={fieldErrors.handler_kind ? "border-error focus:ring-error/60" : undefined}
                 >
                   <option value="">— Select handler —</option>
                   {handlers.map((h) => (
@@ -350,43 +342,35 @@ export function SchedulerTaskFormDialog({
                       {h.label}
                     </option>
                   ))}
-                </select>
-                {fieldErrors.handler_kind && (
-                  <p className="mt-0.5 text-micro text-red-500">{fieldErrors.handler_kind}</p>
-                )}
-              </div>
+                </Select>
+              </Field>
 
-              <div>
-                <label className={labelCls}>Display Name</label>
-                <input
+              <Field label="Display Name">
+                <Input
                   type="text"
                   value={formData.display_name}
                   onChange={(e) => updateField("display_name", e.target.value)}
                   placeholder="Human-readable name"
-                  className={inputCls}
                 />
-              </div>
+              </Field>
 
-              <div>
-                <label className={labelCls}>Description</label>
-                <textarea
+              <Field label="Description">
+                <Textarea
                   value={formData.description}
                   onChange={(e) => updateField("description", e.target.value)}
                   placeholder="What this task does"
                   rows={2}
-                  className={inputCls}
                 />
-              </div>
+              </Field>
 
-              <label className="flex items-center gap-2">
+              <Field variant="check" label="Enabled">
                 <input
                   type="checkbox"
                   checked={formData.enabled}
                   onChange={(e) => updateField("enabled", e.target.checked)}
                   className="h-4 w-4 rounded border-border"
                 />
-                <span className={labelCls}>Enabled</span>
-              </label>
+              </Field>
             </div>
           </section>
 
@@ -394,58 +378,46 @@ export function SchedulerTaskFormDialog({
           <section>
             <h3 className={sectionTitleCls}>Schedule</h3>
             <div className="space-y-3">
-              <div>
-                <label className={labelCls}>Trigger Type</label>
-                <select
+              <Field label="Trigger Type">
+                <Select
                   value={formData.trigger_type}
                   onChange={(e) => updateField("trigger_type", e.target.value)}
-                  className={inputCls}
                 >
                   {(currentDescriptor?.trigger_types || ["interval", "cron", "oneshot"]).map((t) => (
                     <option key={t} value={t}>
                       {t}
                     </option>
                   ))}
-                </select>
-              </div>
+                </Select>
+              </Field>
               {formData.trigger_type === "interval" && (
-                <div>
-                  <label className={labelCls}>
-                    Interval (seconds) <span className="text-red-500">*</span>
-                  </label>
-                  <input
+                <Field label="Interval (seconds)" required error={fieldErrors.interval_seconds}>
+                  <Input
                     type="number"
                     step="1"
                     min="1"
                     value={formData.interval_seconds}
                     onChange={(e) => updateField("interval_seconds", e.target.value)}
                     placeholder="60"
-                    className={`${inputCls} ${fieldErrors.interval_seconds ? "border-red-400" : ""}`}
+                    className={fieldErrors.interval_seconds ? "border-error focus:ring-error/60" : undefined}
                   />
-                  {fieldErrors.interval_seconds && (
-                    <p className="mt-0.5 text-micro text-red-500">{fieldErrors.interval_seconds}</p>
-                  )}
-                </div>
+                </Field>
               )}
               {formData.trigger_type === "cron" && (
-                <div>
-                  <label className={labelCls}>
-                    Cron Expression <span className="text-red-500">*</span>
-                  </label>
-                  <input
+                <Field
+                  label="Cron Expression"
+                  required
+                  error={fieldErrors.cron_expr}
+                  description="5-field POSIX cron: min hour day month weekday"
+                >
+                  <Input
                     type="text"
                     value={formData.cron_expr}
                     onChange={(e) => updateField("cron_expr", e.target.value)}
                     placeholder="0 * * * *"
-                    className={`${inputCls} font-mono ${fieldErrors.cron_expr ? "border-red-400" : ""}`}
+                    className={`font-mono ${fieldErrors.cron_expr ? "border-error focus:ring-error/60" : ""}`}
                   />
-                  {fieldErrors.cron_expr && (
-                    <p className="mt-0.5 text-micro text-red-500">{fieldErrors.cron_expr}</p>
-                  )}
-                  <p className="mt-0.5 text-micro text-text-muted">
-                    5-field POSIX cron: min hour day month weekday
-                  </p>
-                </div>
+                </Field>
               )}
             </div>
           </section>
@@ -453,61 +425,52 @@ export function SchedulerTaskFormDialog({
           {/* Metadata */}
           <section>
             <h3 className={sectionTitleCls}>Metadata</h3>
-            <div className="grid grid-cols-2 gap-3">
-              <div>
-                <label className={labelCls}>Role</label>
-                <input
+            <div className="space-y-3">
+              <Field label="Role">
+                <Input
                   type="text"
                   value={formData.role}
                   onChange={(e) => updateField("role", e.target.value)}
                   placeholder="e.g. sentinel"
-                  className={inputCls}
                 />
-              </div>
-              <div>
-                <label className={labelCls}>Scenario</label>
-                <input
+              </Field>
+              <Field label="Scenario">
+                <Input
                   type="text"
                   value={formData.scenario}
                   onChange={(e) => updateField("scenario", e.target.value)}
                   placeholder="e.g. maintenance"
-                  className={inputCls}
                 />
-              </div>
-              <div>
-                <label className={labelCls}>Category</label>
-                <input
+              </Field>
+              <Field label="Category">
+                <Input
                   type="text"
                   value={formData.category}
                   onChange={(e) => updateField("category", e.target.value)}
                   placeholder="e.g. maintenance"
-                  className={inputCls}
                 />
-              </div>
-              <div>
-                <label className={labelCls}>Max Concurrency</label>
-                <input
+              </Field>
+              <Field label="Max Concurrency" error={fieldErrors.max_concurrency}>
+                <Input
                   type="number"
                   step="1"
                   min="1"
                   value={formData.max_concurrency}
                   onChange={(e) => updateField("max_concurrency", e.target.value)}
-                  className={`${inputCls} ${fieldErrors.max_concurrency ? "border-red-400" : ""}`}
+                  className={fieldErrors.max_concurrency ? "border-error focus:ring-error/60" : undefined}
                 />
-              </div>
+              </Field>
               {currentDescriptor?.supports_token_budget && (
-                <div>
-                  <label className={labelCls}>Token Budget</label>
-                  <input
+                <Field label="Token Budget">
+                  <Input
                     type="number"
                     step="1"
                     min="0"
                     value={formData.token_budget}
                     onChange={(e) => updateField("token_budget", e.target.value)}
                     placeholder="e.g. 100000"
-                    className={inputCls}
                   />
-                </div>
+                </Field>
               )}
             </div>
           </section>
@@ -569,12 +532,12 @@ export function SchedulerTaskFormDialog({
                 </div>
               ) : (
                 <div>
-                  <textarea
+                  <Textarea
                     value={payloadJsonText}
                     onChange={(e) => setPayloadJsonText(e.target.value)}
                     rows={6}
-                    className={`${inputCls} font-mono text-xs ${
-                      fieldErrors.payloadJson ? "border-red-400" : ""
+                    className={`font-mono text-xs ${
+                      fieldErrors.payloadJson ? "border-error focus:ring-error/60" : ""
                     }`}
                   />
                   {fieldErrors.payloadJson && (
@@ -589,11 +552,11 @@ export function SchedulerTaskFormDialog({
           {(!currentDescriptor || currentDescriptor.payload_fields.length === 0) && !loadingHandlers && formData.handler_kind && (
             <section>
               <h3 className={sectionTitleCls}>Payload (JSON)</h3>
-              <textarea
+              <Textarea
                 value={payloadJsonText}
                 onChange={(e) => setPayloadJsonText(e.target.value)}
                 rows={4}
-                className={`${inputCls} font-mono text-xs`}
+                className="font-mono text-xs"
                 placeholder="{}"
               />
             </section>

--- a/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskTable.tsx
+++ b/apps/negentropy-ui/app/interface/scheduler/_components/SchedulerTaskTable.tsx
@@ -2,7 +2,7 @@
 
 import { CopyButton } from "@/components/ui/CopyButton";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { TextTooltip } from "@/components/ui/TextTooltip";
+import { TruncatedCell } from "@/components/ui/TruncatedCell";
 import type { ScheduledTaskDTO } from "@/features/scheduler";
 
 interface SchedulerTaskTableProps {
@@ -130,39 +130,24 @@ export function SchedulerTaskTable({
                 onClick={() => onSelect(t)}
                 className="cursor-pointer border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
               >
-                <td className="px-4 py-3">
-                  <TextTooltip content={t.display_name || t.key}>
-                    <span className="block truncate font-medium text-foreground">{t.display_name || t.key}</span>
-                  </TextTooltip>
-                </td>
+                <TruncatedCell
+                  text={t.display_name || t.key}
+                  textClassName="font-medium text-foreground"
+                />
                 {/* 任务 ID（独立列）：约半宽截断展示，全文经悬浮单行恢复 + 一键复制（对齐 RoutineTable ID 列）。 */}
-                <td className="px-4 py-3">
-                  <div className="flex min-w-0 items-center gap-1">
-                    <TextTooltip content={t.key}>
-                      <span className="min-w-0 flex-1 truncate font-mono text-xs text-text-secondary">{t.key}</span>
-                    </TextTooltip>
-                    <CopyButton value={t.key} ariaLabel="复制 ID" className="shrink-0" />
-                  </div>
-                </td>
-                <td className="px-4 py-3 text-muted-foreground">
-                  {t.description ? (
-                    <TextTooltip content={t.description}>
-                      <span className="block truncate">{t.description}</span>
-                    </TextTooltip>
-                  ) : (
-                    "—"
-                  )}
-                </td>
-                <td className="px-4 py-3 text-muted-foreground">
-                  <TextTooltip content={t.handler_kind}>
-                    <span className="block truncate">{t.handler_kind}</span>
-                  </TextTooltip>
-                </td>
-                <td className="px-4 py-3 text-muted-foreground">
-                  <TextTooltip content={triggerText(t)}>
-                    <span className="block truncate font-mono text-xs">{triggerText(t)}</span>
-                  </TextTooltip>
-                </td>
+                <TruncatedCell
+                  text={t.key}
+                  mono
+                  textClassName="text-text-secondary"
+                  trailing={<CopyButton value={t.key} ariaLabel="复制 ID" className="shrink-0" />}
+                />
+                {t.description ? (
+                  <TruncatedCell text={t.description} textClassName="text-muted-foreground" />
+                ) : (
+                  <td className="px-4 py-3 text-muted-foreground">—</td>
+                )}
+                <TruncatedCell text={t.handler_kind} textClassName="text-muted-foreground" />
+                <TruncatedCell text={triggerText(t)} mono textClassName="text-muted-foreground" />
                 <td className="px-4 py-3 text-muted-foreground">
                   <span className="block truncate">{relativeFromNow(t.last_fire_at)}</span>
                 </td>

--- a/apps/negentropy-ui/app/interface/skills/_components/SkillFormDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/skills/_components/SkillFormDrawer.tsx
@@ -14,10 +14,15 @@ import {
   useMemo,
   useRef,
 } from "react";
+import { BaseDrawer } from "@/components/ui/BaseDrawer";
 import { Button } from "@/components/ui/Button";
 import { ErrorBanner } from "@/components/ui/ErrorState";
-import { BaseDrawer } from "@/components/ui/BaseDrawer";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Textarea } from "@/components/ui/Textarea";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
+import { cn } from "@/lib/utils";
 
 interface Skill {
   id: string;
@@ -301,154 +306,114 @@ export function SkillFormDrawer({
             </div>
           )}
 
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Basic Information
             </h3>
-            <div className="grid gap-4 lg:grid-cols-2">
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Name *
-                </label>
-                <input
-                  type="text"
-                  value={formData.name}
-                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  placeholder="my-skill"
-                  required
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Display Name
-                </label>
-                <input
-                  type="text"
-                  value={formData.display_name}
-                  onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  placeholder="My Skill"
-                />
-              </div>
-              <div className="lg:col-span-2">
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Description
-                </label>
-                <textarea
-                  value={formData.description}
-                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  rows={2}
-                  placeholder="Description of this skill"
-                />
-              </div>
-            </div>
+            <Field label="Name" required>
+              <Input
+                type="text"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                placeholder="my-skill"
+                required
+              />
+            </Field>
+            <Field label="Display Name">
+              <Input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                placeholder="My Skill"
+              />
+            </Field>
+            <Field label="Description">
+              <Textarea
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                rows={2}
+                placeholder="Description of this skill"
+              />
+            </Field>
           </section>
 
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Runtime Setup
             </h3>
-            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-5">
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Category
-                </label>
-                <input
-                  type="text"
-                  value={formData.category}
-                  onChange={(e) => setFormData({ ...formData, category: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  placeholder="general"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Version
-                </label>
-                <input
-                  type="text"
-                  value={formData.version}
-                  onChange={(e) => setFormData({ ...formData, version: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  placeholder="1.0.0"
-                />
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Visibility
-                </label>
-                <select
-                  value={formData.visibility}
-                  onChange={(e) => setFormData({ ...formData, visibility: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                >
-                  <option value="private">Private</option>
-                  <option value="shared">Shared</option>
-                  <option value="public">Public</option>
-                </select>
-              </div>
-              <div className="flex items-end">
-                <label className="flex w-full items-center gap-2 rounded-md border border-border px-3 py-2 text-sm text-text-secondary">
-                  <input
-                    type="checkbox"
-                    checked={formData.is_enabled}
-                    onChange={(e) => setFormData({ ...formData, is_enabled: e.target.checked })}
-                    className="rounded border-border"
-                  />
-                  Enabled
-                </label>
-              </div>
-              <div className="flex items-end">
-                <label
-                  className="flex w-full items-center gap-2 rounded-md border border-border px-3 py-2 text-sm text-text-secondary"
-                  title="全局技能：自动注入全系统所有 Agent（一核五翼及未来新增）的 Progressive Disclosure"
-                >
-                  <input
-                    type="checkbox"
-                    data-testid="skills-form-is-global"
-                    checked={formData.is_global}
-                    onChange={(e) => setFormData({ ...formData, is_global: e.target.checked })}
-                    className="rounded border-border"
-                  />
+            <Field label="Category">
+              <Input
+                type="text"
+                value={formData.category}
+                onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+                placeholder="general"
+              />
+            </Field>
+            <Field label="Version">
+              <Input
+                type="text"
+                value={formData.version}
+                onChange={(e) => setFormData({ ...formData, version: e.target.value })}
+                placeholder="1.0.0"
+              />
+            </Field>
+            <Field label="Visibility">
+              <Select
+                value={formData.visibility}
+                onChange={(e) => setFormData({ ...formData, visibility: e.target.value })}
+              >
+                <option value="private">Private</option>
+                <option value="shared">Shared</option>
+                <option value="public">Public</option>
+              </Select>
+            </Field>
+            <Field variant="check" label="Enabled">
+              <input
+                type="checkbox"
+                checked={formData.is_enabled}
+                onChange={(e) => setFormData({ ...formData, is_enabled: e.target.checked })}
+                className="h-4 w-4"
+              />
+            </Field>
+            <Field
+              variant="check"
+              label={
+                <span title="全局技能：自动注入全系统所有 Agent（一核五翼及未来新增）的 Progressive Disclosure">
                   Global
-                </label>
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Priority
-                </label>
-                <input
-                  type="number"
-                  value={formData.priority}
-                  onChange={(e) => setFormData({ ...formData, priority: parseInt(e.target.value) || 0 })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                />
-              </div>
-            </div>
+                </span>
+              }
+            >
+              <input
+                type="checkbox"
+                data-testid="skills-form-is-global"
+                checked={formData.is_global}
+                onChange={(e) => setFormData({ ...formData, is_global: e.target.checked })}
+                className="h-4 w-4"
+              />
+            </Field>
+            <Field label="Priority">
+              <Input
+                type="number"
+                value={formData.priority}
+                onChange={(e) => setFormData({ ...formData, priority: parseInt(e.target.value) || 0 })}
+              />
+            </Field>
           </section>
 
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Prompt & Requirements
             </h3>
-            <div>
-              <label className="mb-1 block text-sm font-medium text-text-secondary">
-                Prompt Template
-              </label>
-              <textarea
+            <Field label="Prompt Template">
+              <Textarea
                 value={formData.prompt_template}
                 onChange={(e) => setFormData({ ...formData, prompt_template: e.target.value })}
-                className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
+                className="font-mono"
                 rows={5}
                 placeholder="Enter the skill's prompt template..."
               />
-            </div>
-            <div>
-              <label className="mb-1 block text-sm font-medium text-text-secondary">
-                Required Tools
-              </label>
+            </Field>
+            <Field label="Required Tools">
               {availableTools.length > 0 && (
                 <div className="mb-2 flex flex-wrap gap-1.5">
                   {availableTools.map((t) => {
@@ -479,57 +444,59 @@ export function SkillFormDrawer({
                   })}
                 </div>
               )}
-              <textarea
+              <Textarea
                 value={formData.required_tools}
                 onChange={(e) => setFormData({ ...formData, required_tools: e.target.value })}
-                className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
+                className="font-mono"
                 rows={3}
                 placeholder="Select from above or type tool names (one per line)"
               />
-            </div>
+            </Field>
           </section>
 
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Tool Enforcement
             </h3>
-            <fieldset className="rounded-md border border-border p-3 text-sm">
-              <legend className="px-1 text-xs text-text-muted">
-                Required tools enforcement
-              </legend>
-              <div className="flex flex-wrap items-center gap-4">
-                <label className="inline-flex items-center gap-2">
-                  <input
-                    type="radio"
-                    name="enforcement_mode"
-                    value="warning"
-                    data-testid="skills-form-enforcement-warning"
-                    checked={formData.enforcement_mode === "warning"}
-                    onChange={() =>
-                      setFormData({ ...formData, enforcement_mode: "warning" })
-                    }
-                  />
-                  <span className="text-foreground">
-                    warning <span className="text-xs text-text-muted">(log missing tools, keep running)</span>
-                  </span>
-                </label>
-                <label className="inline-flex items-center gap-2">
-                  <input
-                    type="radio"
-                    name="enforcement_mode"
-                    value="strict"
-                    data-testid="skills-form-enforcement-strict"
-                    checked={formData.enforcement_mode === "strict"}
-                    onChange={() =>
-                      setFormData({ ...formData, enforcement_mode: "strict" })
-                    }
-                  />
-                  <span className="text-foreground">
-                    strict <span className="text-xs text-rose-600 dark:text-rose-400">(block Agent if any required tool is missing)</span>
-                  </span>
-                </label>
-              </div>
-            </fieldset>
+            <Field label="Enforcement Mode">
+              <fieldset className="text-sm">
+                <legend className="px-1 text-xs text-text-muted">
+                  Required tools enforcement
+                </legend>
+                <div className="flex flex-wrap items-center gap-4">
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="enforcement_mode"
+                      value="warning"
+                      data-testid="skills-form-enforcement-warning"
+                      checked={formData.enforcement_mode === "warning"}
+                      onChange={() =>
+                        setFormData({ ...formData, enforcement_mode: "warning" })
+                      }
+                    />
+                    <span className="text-foreground">
+                      warning <span className="text-xs text-text-muted">(log missing tools, keep running)</span>
+                    </span>
+                  </label>
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="enforcement_mode"
+                      value="strict"
+                      data-testid="skills-form-enforcement-strict"
+                      checked={formData.enforcement_mode === "strict"}
+                      onChange={() =>
+                        setFormData({ ...formData, enforcement_mode: "strict" })
+                      }
+                    />
+                    <span className="text-foreground">
+                      strict <span className="text-xs text-rose-600 dark:text-rose-400">(block Agent if any required tool is missing)</span>
+                    </span>
+                  </label>
+                </div>
+              </fieldset>
+            </Field>
           </section>
 
           <section className="space-y-4">
@@ -632,78 +599,66 @@ export function SkillFormDrawer({
             )}
           </section>
 
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               JSON Configuration
             </h3>
-            <div className="grid gap-4 xl:grid-cols-2">
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Config Schema (JSON)
-                </label>
-                <textarea
-                  value={formData.config_schema}
-                  onChange={(e) => {
-                    setFormData({ ...formData, config_schema: e.target.value });
-                    if (fieldErrors.config_schema) {
-                      setFieldErrors((prev) => ({ ...prev, config_schema: undefined }));
-                    }
-                  }}
-                  aria-invalid={fieldErrors.config_schema ? "true" : undefined}
-                  data-testid="skills-form-config-schema"
-                  className={
-                    "min-h-[220px] w-full rounded-md border px-3 py-2 text-sm font-mono bg-input text-foreground " +
-                    (fieldErrors.config_schema
-                      ? "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-500"
-                      : "border-border")
+            <Field label="Config Schema (JSON)">
+              <Textarea
+                value={formData.config_schema}
+                onChange={(e) => {
+                  setFormData({ ...formData, config_schema: e.target.value });
+                  if (fieldErrors.config_schema) {
+                    setFieldErrors((prev) => ({ ...prev, config_schema: undefined }));
                   }
-                  rows={8}
-                  placeholder='{"type": "object"}'
-                />
-                {fieldErrors.config_schema && (
-                  <p
-                    role="status"
-                    data-testid="skills-form-config-schema-error"
-                    className="mt-1 text-xs text-red-600 dark:text-red-400"
-                  >
-                    Invalid JSON: {fieldErrors.config_schema}
-                  </p>
+                }}
+                aria-invalid={fieldErrors.config_schema ? "true" : undefined}
+                data-testid="skills-form-config-schema"
+                className={cn(
+                  "min-h-[220px] font-mono",
+                  fieldErrors.config_schema && "border-error focus:ring-error/60",
                 )}
-              </div>
-              <div>
-                <label className="mb-1 block text-sm font-medium text-text-secondary">
-                  Default Config (JSON)
-                </label>
-                <textarea
-                  value={formData.default_config}
-                  onChange={(e) => {
-                    setFormData({ ...formData, default_config: e.target.value });
-                    if (fieldErrors.default_config) {
-                      setFieldErrors((prev) => ({ ...prev, default_config: undefined }));
-                    }
-                  }}
-                  aria-invalid={fieldErrors.default_config ? "true" : undefined}
-                  data-testid="skills-form-default-config"
-                  className={
-                    "min-h-[220px] w-full rounded-md border px-3 py-2 text-sm font-mono bg-input text-foreground " +
-                    (fieldErrors.default_config
-                      ? "border-red-500 focus:border-red-500 focus:ring-red-500 dark:border-red-500"
-                      : "border-border")
+                rows={8}
+                placeholder='{"type": "object"}'
+              />
+              {fieldErrors.config_schema && (
+                <p
+                  role="status"
+                  data-testid="skills-form-config-schema-error"
+                  className="text-xs text-red-600 dark:text-red-400"
+                >
+                  Invalid JSON: {fieldErrors.config_schema}
+                </p>
+              )}
+            </Field>
+            <Field label="Default Config (JSON)">
+              <Textarea
+                value={formData.default_config}
+                onChange={(e) => {
+                  setFormData({ ...formData, default_config: e.target.value });
+                  if (fieldErrors.default_config) {
+                    setFieldErrors((prev) => ({ ...prev, default_config: undefined }));
                   }
-                  rows={8}
-                  placeholder="{}"
-                />
-                {fieldErrors.default_config && (
-                  <p
-                    role="status"
-                    data-testid="skills-form-default-config-error"
-                    className="mt-1 text-xs text-red-600 dark:text-red-400"
-                  >
-                    Invalid JSON: {fieldErrors.default_config}
-                  </p>
+                }}
+                aria-invalid={fieldErrors.default_config ? "true" : undefined}
+                data-testid="skills-form-default-config"
+                className={cn(
+                  "min-h-[220px] font-mono",
+                  fieldErrors.default_config && "border-error focus:ring-error/60",
                 )}
-              </div>
-            </div>
+                rows={8}
+                placeholder="{}"
+              />
+              {fieldErrors.default_config && (
+                <p
+                  role="status"
+                  data-testid="skills-form-default-config-error"
+                  className="text-xs text-red-600 dark:text-red-400"
+                >
+                  Invalid JSON: {fieldErrors.default_config}
+                </p>
+              )}
+            </Field>
           </section>
         </form>
       </BaseDrawer>

--- a/apps/negentropy-ui/app/interface/skills/_components/SkillScheduleDialog.tsx
+++ b/apps/negentropy-ui/app/interface/skills/_components/SkillScheduleDialog.tsx
@@ -7,6 +7,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Textarea } from "@/components/ui/Textarea";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 import { toast } from "sonner";
 
@@ -177,39 +180,34 @@ export function SkillScheduleDialog({
           <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-muted">
             New schedule
           </h3>
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            <label className="text-xs text-text-secondary">
-              cron_expr
-              <input
+          <div className="space-y-3">
+            <Field label="cron_expr">
+              <Input
                 data-testid="schedule-form-cron"
                 type="text"
                 value={cronExpr}
                 onChange={(e) => setCronExpr(e.target.value)}
                 placeholder="0 9 * * 1"
-                className="mt-1 w-full rounded-md border border-border bg-input px-2 py-1 text-sm font-mono text-foreground"
+                className="font-mono"
               />
-            </label>
-            <label className="text-xs text-text-secondary">
-              enabled
-              <div className="mt-1 inline-flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  checked={enabled}
-                  onChange={(e) => setEnabled(e.target.checked)}
-                />
-                <span>{enabled ? "true" : "false"}</span>
-              </div>
-            </label>
-            <label className="text-xs text-text-secondary sm:col-span-2">
-              vars (JSON)
-              <textarea
+            </Field>
+            <Field variant="check" label="enabled">
+              <input
+                type="checkbox"
+                checked={enabled}
+                onChange={(e) => setEnabled(e.target.checked)}
+                className="h-4 w-4"
+              />
+            </Field>
+            <Field label="vars (JSON)">
+              <Textarea
                 data-testid="schedule-form-vars"
                 rows={4}
                 value={varsText}
                 onChange={(e) => setVarsText(e.target.value)}
-                className="mt-1 w-full rounded-md border border-border bg-input px-2 py-1 text-xs font-mono text-foreground"
+                className="font-mono text-xs"
               />
-            </label>
+            </Field>
           </div>
           <div className="mt-2 flex justify-end">
             <button

--- a/apps/negentropy-ui/app/interface/tools/_components/ToolFormDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/tools/_components/ToolFormDrawer.tsx
@@ -17,6 +17,10 @@ import {
 import { toast } from "sonner";
 import { BaseDrawer } from "@/components/ui/BaseDrawer";
 import { Button } from "@/components/ui/Button";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Textarea } from "@/components/ui/Textarea";
 import { useConfirmDialog } from "@/components/ui/useConfirmDialog";
 
 interface BuiltinTool {
@@ -212,15 +216,13 @@ export function ToolFormDrawer({
     const max = schema.maximum;
 
     return (
-      <div key={key}>
-        <label className="block text-sm font-medium text-text-secondary mb-1">
-          {schema.title || key}
-          {schema.required && <span className="text-red-500 ml-1">*</span>}
-        </label>
-        {schema.description && (
-          <p className="text-xs text-text-muted mb-1">{schema.description}</p>
-        )}
-        <input
+      <Field
+        key={key}
+        label={schema.title || key}
+        required={schema.required}
+        description={schema.description}
+      >
+        <Input
           type={inputType}
           value={value === undefined || value === null ? String(schema.default ?? "") : String(value)}
           step={step}
@@ -233,9 +235,8 @@ export function ToolFormDrawer({
             }
             onChange(key, val);
           }}
-          className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
         />
-      </div>
+      </Field>
     );
   };
 
@@ -281,98 +282,77 @@ export function ToolFormDrawer({
       >
         <form id={formId} onSubmit={handleSubmit} className="space-y-6 px-5 py-5">
           {/* 基本信息 */}
-          <section className="space-y-4">
+          <section className="space-y-3">
             <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
               Basic Information
             </h3>
-            <div className="grid gap-4 sm:grid-cols-2">
-              {!tool && (
-                <div className="sm:col-span-2">
-                  <label className="block text-sm font-medium text-text-secondary mb-1">
-                    Name <span className="text-red-500">*</span>
-                  </label>
-                  <input
-                    type="text"
-                    value={formData.name}
-                    onChange={(e) => setFormData({ ...formData, name: e.target.value })}
-                    className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm font-mono text-foreground"
-                    placeholder="e.g. google_search"
-                    required
-                  />
-                </div>
-              )}
-              <div>
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  Display Name
-                </label>
-                <input
+            {!tool && (
+              <Field label="Name" required>
+                <Input
                   type="text"
-                  value={formData.display_name}
-                  onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  placeholder="e.g. Google Search"
+                  value={formData.name}
+                  onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                  className="font-mono"
+                  placeholder="e.g. google_search"
+                  required
                 />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  Tool Type
-                </label>
-                <select
-                  value={formData.tool_type}
-                  onChange={(e) => setFormData({ ...formData, tool_type: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  disabled={!!tool}
-                >
-                  <option value="search">Search</option>
-                  <option value="retrieval">Retrieval</option>
-                  <option value="custom">Custom</option>
-                  <option value="claude_code">Agent</option>
-                </select>
-              </div>
-              <div className="sm:col-span-2">
-                <label className="block text-sm font-medium text-text-secondary mb-1">
-                  Description
-                </label>
-                <textarea
-                  value={formData.description}
-                  onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                  className="w-full rounded-md border border-border bg-input px-3 py-2 text-sm text-foreground"
-                  rows={2}
-                  placeholder="Tool description"
-                />
-              </div>
-            </div>
+              </Field>
+            )}
+            <Field label="Display Name">
+              <Input
+                type="text"
+                value={formData.display_name}
+                onChange={(e) => setFormData({ ...formData, display_name: e.target.value })}
+                placeholder="e.g. Google Search"
+              />
+            </Field>
+            <Field label="Tool Type">
+              <Select
+                value={formData.tool_type}
+                onChange={(e) => setFormData({ ...formData, tool_type: e.target.value })}
+                disabled={!!tool}
+              >
+                <option value="search">Search</option>
+                <option value="retrieval">Retrieval</option>
+                <option value="custom">Custom</option>
+                <option value="claude_code">Agent</option>
+              </Select>
+            </Field>
+            <Field label="Description">
+              <Textarea
+                value={formData.description}
+                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                rows={2}
+                placeholder="Tool description"
+              />
+            </Field>
           </section>
 
           {/* 凭证字段 */}
           {Object.keys(credentialFieldDefs).length > 0 && (
-            <section className="space-y-4">
+            <section className="space-y-3">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
                 Credentials
               </h3>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {Object.entries(credentialFieldDefs).map(([key, schema]) =>
-                  renderDynamicField(key, schema, credentialFields[key], (k, v) =>
-                    setCredentialFields((prev) => ({ ...prev, [k]: v })),
-                  ),
-                )}
-              </div>
+              {Object.entries(credentialFieldDefs).map(([key, schema]) =>
+                renderDynamicField(key, schema, credentialFields[key], (k, v) =>
+                  setCredentialFields((prev) => ({ ...prev, [k]: v })),
+                ),
+              )}
             </section>
           )}
 
           {/* 配置字段 */}
           {Object.keys(configFieldDefs).length > 0 && (
-            <section className="space-y-4">
+            <section className="space-y-3">
               <h3 className="text-xs font-semibold uppercase tracking-wide text-text-muted">
                 Configuration
               </h3>
-              <div className="grid gap-4 sm:grid-cols-2">
-                {Object.entries(configFieldDefs).map(([key, schema]) =>
-                  renderDynamicField(key, schema, configFields[key], (k, v) =>
-                    setConfigFields((prev) => ({ ...prev, [k]: v })),
-                  ),
-                )}
-              </div>
+              {Object.entries(configFieldDefs).map(([key, schema]) =>
+                renderDynamicField(key, schema, configFields[key], (k, v) =>
+                  setConfigFields((prev) => ({ ...prev, [k]: v })),
+                ),
+              )}
             </section>
           )}
 

--- a/apps/negentropy-ui/app/knowledge/apis/_components/ApiDocPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/ApiDocPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { ApiEndpoint, getMethodColor } from "@/features/knowledge/utils/api-specs";
-import { TextTooltip } from "@/components/ui/TextTooltip";
+import { TruncatedCell } from "@/components/ui/TruncatedCell";
 import { CodeExample } from "./CodeExample";
 
 interface ApiDocPanelProps {
@@ -65,32 +65,21 @@ export function ApiDocPanel({ endpoint }: ApiDocPanelProps) {
                     key={param.name}
                     className="border-b border-border/60 transition-colors last:border-0 hover:bg-muted/40"
                   >
-                    <td className="px-4 py-3">
-                      <TextTooltip content={param.name}>
-                        <span className="block truncate font-mono text-xs text-foreground">
-                          {param.name}
-                        </span>
-                      </TextTooltip>
-                    </td>
-                    <td className="px-4 py-3 text-text-secondary">
-                      <TextTooltip content={param.in}>
-                        <span className="block truncate">{param.in}</span>
-                      </TextTooltip>
-                    </td>
-                    <td className="px-4 py-3 text-text-secondary">
-                      <TextTooltip
-                        content={`${param.type}${param.enum ? ` (${param.enum.join(", ")})` : ""}`}
-                      >
-                        <span className="block truncate">
+                    <TruncatedCell text={param.name} mono textClassName="text-foreground" />
+                    <TruncatedCell text={param.in} textClassName="text-text-secondary" />
+                    <TruncatedCell
+                      className="text-text-secondary"
+                      text={
+                        <>
                           {param.type}
                           {param.enum && (
                             <span className="text-text-muted">
                               {" "}({param.enum.join(", ")})
                             </span>
                           )}
-                        </span>
-                      </TextTooltip>
-                    </td>
+                        </>
+                      }
+                    />
                     <td className="px-4 py-3">
                       {param.required ? (
                         <span className="text-rose-500">是</span>
@@ -98,20 +87,19 @@ export function ApiDocPanel({ endpoint }: ApiDocPanelProps) {
                         <span className="text-text-muted">否</span>
                       )}
                     </td>
-                    <td className="px-4 py-3 text-text-secondary">
-                      <TextTooltip
-                        content={`${param.description}${param.default !== undefined ? ` (默认: ${String(param.default)})` : ""}`}
-                      >
-                        <span className="block truncate">
+                    <TruncatedCell
+                      className="text-text-secondary"
+                      text={
+                        <>
                           {param.description}
                           {param.default !== undefined && (
                             <span className="text-text-muted">
                               {" "}(默认: {String(param.default)})
                             </span>
                           )}
-                        </span>
-                      </TextTooltip>
-                    </td>
+                        </>
+                      }
+                    />
                   </tr>
                 ))}
               </tbody>

--- a/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/CheckboxInput.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/CheckboxInput.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Field } from "@/components/ui/Field";
 import { FormFieldConfig } from "@/features/knowledge/utils/api-specs";
 
 interface CheckboxInputProps {
@@ -10,26 +11,19 @@ interface CheckboxInputProps {
 
 export function CheckboxInput({ field, value, onChange }: CheckboxInputProps) {
   return (
-    <div className="flex items-center">
+    <Field
+      variant="check"
+      label={field.label}
+      required={field.required}
+      description={field.description}
+    >
       <input
         type="checkbox"
         id={field.name}
         checked={value}
         onChange={(e) => onChange(e.target.checked)}
-        className="h-3.5 w-3.5 rounded border-input text-blue-600 focus:ring-blue-500 dark:bg-input"
+        className="h-4 w-4"
       />
-      <label
-        htmlFor={field.name}
-        className="ml-2 text-xs text-text-secondary"
-      >
-        {field.label}
-        {field.required && <span className="text-rose-500 ml-1">*</span>}
-      </label>
-      {field.description && (
-        <span className="ml-2 text-micro text-text-muted">
-          {field.description}
-        </span>
-      )}
-    </div>
+    </Field>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/CorpusSelect.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/CorpusSelect.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { Field } from "@/components/ui/Field";
+import { Select } from "@/components/ui/Select";
+import { Loader2 } from "lucide-react";
 import { FormFieldConfig } from "@/features/knowledge/utils/api-specs";
 import { useCorporaList } from "../hooks/useCorporaList";
-import { Loader2 } from "lucide-react";
 
 interface CorpusSelectProps {
   field: FormFieldConfig;
@@ -14,44 +16,34 @@ export function CorpusSelect({ field, value, onChange }: CorpusSelectProps) {
   const { corpora, loading, error } = useCorporaList();
 
   return (
-    <div>
-      <label className="block text-xs font-medium text-text-secondary">
-        {field.label}{" "}
-        {field.required && <span className="text-rose-500">*</span>}
-      </label>
-      <div className="relative mt-1">
-        <select
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          disabled={loading}
-          className="w-full rounded-lg border border-input bg-background px-3 py-2 text-xs text-foreground focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          <option value="">
-            {loading ? "加载中..." : "选择语料库..."}
+    <Field
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      error={error ?? undefined}
+    >
+      <Select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={loading}
+        trailing={
+          loading ? (
+            <Loader2 className="pointer-events-none absolute right-9 top-1/2 h-4 w-4 -translate-y-1/2 animate-spin text-text-muted" />
+          ) : null
+        }
+      >
+        <option value="">{loading ? "加载中..." : "选择语料库..."}</option>
+        {corpora.map((corpus) => (
+          <option key={corpus.id} value={corpus.id}>
+            {corpus.name} ({corpus.id.slice(0, 8)}...)
           </option>
-          {corpora.map((corpus) => (
-            <option key={corpus.id} value={corpus.id}>
-              {corpus.name} ({corpus.id.slice(0, 8)}...)
-            </option>
-          ))}
-        </select>
-        {loading && (
-          <Loader2 className="absolute right-8 top-1/2 h-3 w-3 -translate-y-1/2 animate-spin text-text-muted" />
-        )}
-      </div>
-      {error && (
-        <p className="mt-1 text-micro text-rose-500">{error}</p>
-      )}
+        ))}
+      </Select>
       {!loading && corpora.length === 0 && !error && (
-        <p className="mt-1 text-micro text-amber-500">
+        <p className="text-caption text-amber-500">
           暂无语料库，请先创建一个
         </p>
       )}
-      {field.description && (
-        <p className="mt-1 text-micro text-text-muted">
-          {field.description}
-        </p>
-      )}
-    </div>
+    </Field>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/JsonInput.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/JsonInput.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState } from "react";
+import { Field } from "@/components/ui/Field";
+import { Textarea } from "@/components/ui/Textarea";
+import { cn } from "@/lib/utils";
 import { FormFieldConfig } from "@/features/knowledge/utils/api-specs";
 
 interface JsonInputProps {
@@ -40,30 +43,22 @@ export function JsonInput({ field, value, onChange }: JsonInputProps) {
   };
 
   return (
-    <div>
-      <label className="block text-xs font-medium text-text-secondary">
-        {field.label}{" "}
-        {field.required && <span className="text-rose-500">*</span>}
-      </label>
-      <textarea
+    <Field
+      label={field.label}
+      required={field.required}
+      description={field.description}
+      error={error ?? undefined}
+    >
+      <Textarea
         value={text}
         onChange={handleChange}
         placeholder={field.placeholder || '{"key": "value"}'}
         rows={3}
-        className={`mt-1 w-full rounded-lg border bg-background px-3 py-2 text-xs font-mono text-foreground focus:outline-none focus:ring-1 ${
-          error
-            ? "border-rose-300 focus:border-rose-500 focus:ring-rose-500 dark:border-rose-700"
-            : "border-input focus:border-blue-500 focus:ring-blue-500"
-        }`}
+        className={cn(
+          "font-mono",
+          error ? "border-error focus:ring-error/60" : undefined,
+        )}
       />
-      {error && (
-        <p className="mt-1 text-micro text-rose-500">{error}</p>
-      )}
-      {field.description && !error && (
-        <p className="mt-1 text-micro text-text-muted">
-          {field.description}
-        </p>
-      )}
-    </div>
+    </Field>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/NumberInput.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/NumberInput.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
 import { FormFieldConfig } from "@/features/knowledge/utils/api-specs";
 
 interface NumberInputProps {
@@ -22,12 +24,12 @@ export function NumberInput({ field, value, onChange }: NumberInputProps) {
   };
 
   return (
-    <div>
-      <label className="block text-xs font-medium text-text-secondary">
-        {field.label}{" "}
-        {field.required && <span className="text-rose-500">*</span>}
-      </label>
-      <input
+    <Field
+      label={field.label}
+      required={field.required}
+      description={field.description}
+    >
+      <Input
         type="number"
         value={value ?? ""}
         onChange={handleChange}
@@ -35,13 +37,8 @@ export function NumberInput({ field, value, onChange }: NumberInputProps) {
         max={field.max}
         step={field.max && field.max < 10 ? 0.01 : 1}
         placeholder={field.placeholder}
-        className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-xs text-foreground tabular-nums focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+        className="tabular-nums"
       />
-      {field.description && (
-        <p className="mt-1 text-micro text-text-muted">
-          {field.description}
-        </p>
-      )}
-    </div>
+    </Field>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/SelectInput.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/SelectInput.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Field } from "@/components/ui/Field";
+import { Select } from "@/components/ui/Select";
 import { FormFieldConfig } from "@/features/knowledge/utils/api-specs";
 
 interface SelectInputProps {
@@ -10,27 +12,18 @@ interface SelectInputProps {
 
 export function SelectInput({ field, value, onChange }: SelectInputProps) {
   return (
-    <div>
-      <label className="block text-xs font-medium text-text-secondary">
-        {field.label}{" "}
-        {field.required && <span className="text-rose-500">*</span>}
-      </label>
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-xs text-foreground focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-      >
+    <Field
+      label={field.label}
+      required={field.required}
+      description={field.description}
+    >
+      <Select value={value} onChange={(e) => onChange(e.target.value)}>
         {field.options?.map((option) => (
           <option key={option.value} value={option.value}>
             {option.label}
           </option>
         ))}
-      </select>
-      {field.description && (
-        <p className="mt-1 text-micro text-text-muted">
-          {field.description}
-        </p>
-      )}
-    </div>
+      </Select>
+    </Field>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/TextInput.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/TextInput.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
 import { FormFieldConfig } from "@/features/knowledge/utils/api-specs";
 
 interface TextInputProps {
@@ -10,23 +12,17 @@ interface TextInputProps {
 
 export function TextInput({ field, value, onChange }: TextInputProps) {
   return (
-    <div>
-      <label className="block text-xs font-medium text-text-secondary">
-        {field.label}{" "}
-        {field.required && <span className="text-rose-500">*</span>}
-      </label>
-      <input
+    <Field
+      label={field.label}
+      required={field.required}
+      description={field.description}
+    >
+      <Input
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={field.placeholder}
-        className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-xs text-foreground focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
       />
-      {field.description && (
-        <p className="mt-1 text-micro text-text-muted">
-          {field.description}
-        </p>
-      )}
-    </div>
+    </Field>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/TextareaInput.tsx
+++ b/apps/negentropy-ui/app/knowledge/apis/_components/form-fields/TextareaInput.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Field } from "@/components/ui/Field";
+import { Textarea } from "@/components/ui/Textarea";
 import { FormFieldConfig } from "@/features/knowledge/utils/api-specs";
 
 interface TextareaInputProps {
@@ -10,23 +12,17 @@ interface TextareaInputProps {
 
 export function TextareaInput({ field, value, onChange }: TextareaInputProps) {
   return (
-    <div>
-      <label className="block text-xs font-medium text-text-secondary">
-        {field.label}{" "}
-        {field.required && <span className="text-rose-500">*</span>}
-      </label>
-      <textarea
+    <Field
+      label={field.label}
+      required={field.required}
+      description={field.description}
+    >
+      <Textarea
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={field.placeholder}
         rows={3}
-        className="mt-1 w-full rounded-lg border border-input bg-background px-3 py-2 text-xs text-foreground focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
       />
-      {field.description && (
-        <p className="mt-1 text-micro text-text-muted">
-          {field.description}
-        </p>
-      )}
-    </div>
+    </Field>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/base/_components/AddSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/AddSourceDialog.tsx
@@ -3,6 +3,8 @@
 import { useRef, useState } from "react";
 import { toast } from "@/lib/activity-toast";
 import { AsyncPipelineResult, ChunkingConfig } from "@/features/knowledge";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 // 支持的文件扩展名
@@ -249,21 +251,13 @@ export function AddSourceDialog({
 
         {/* Content */}
         {mode === "url" ? (
-          <div>
-            <label
-              htmlFor="add-source-url-input"
-              className="mb-1 block text-xs font-medium text-text-secondary"
-            >
-              URL <span className="text-red-500">*</span>
-            </label>
-            <input
-              id="add-source-url-input"
-              className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none focus:border-foreground focus:ring-1 focus:ring-foreground"
+          <Field label="URL" required>
+            <Input
               placeholder="https://example.com/article"
               value={url}
               onChange={(e) => setUrl(e.target.value)}
             />
-          </div>
+          </Field>
         ) : (
           <div>
             {/* File Upload Area */}
@@ -332,19 +326,13 @@ export function AddSourceDialog({
             {/* Source URI for file */}
             {selectedFile && (
               <div className="mt-3">
-                <label
-                  htmlFor="add-source-uri-input"
-                  className="mb-1 block text-xs font-medium text-text-secondary"
-                >
-                  Source URI
-                </label>
-                <input
-                  id="add-source-uri-input"
-                  className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none focus:border-foreground focus:ring-1 focus:ring-foreground"
-                  placeholder="e.g., document.pdf"
-                  value={sourceUri}
-                  onChange={(e) => setSourceUri(e.target.value)}
-                />
+                <Field label="Source URI">
+                  <Input
+                    placeholder="e.g., document.pdf"
+                    value={sourceUri}
+                    onChange={(e) => setSourceUri(e.target.value)}
+                  />
+                </Field>
               </div>
             )}
           </div>

--- a/apps/negentropy-ui/app/knowledge/base/_components/ContentExplorer.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/ContentExplorer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { TextTooltip } from "@/components/ui/TextTooltip";
+import { TruncatedCell } from "@/components/ui/TruncatedCell";
 import { KnowledgeItem } from "@/features/knowledge";
 
 interface ContentExplorerProps {
@@ -55,19 +55,12 @@ export function ContentExplorer({ items, loading, error, offset = 0 }: ContentEx
                   <td className="px-4 py-3 tabular-nums text-text-secondary">
                     {offset + index + 1}
                   </td>
-                  <td className="px-4 py-3">
-                    {/* 单行截断 + 悬浮全文（对齐 Routine/Scheduler 表格规范）。 */}
-                    <TextTooltip content={item.content}>
-                      <span className="block truncate text-foreground">{item.content}</span>
-                    </TextTooltip>
-                  </td>
-                  <td className="px-4 py-3">
-                    <TextTooltip content={new Date(item.created_at).toLocaleString()}>
-                      <span className="block truncate text-text-secondary">
-                        {new Date(item.created_at).toLocaleString()}
-                      </span>
-                    </TextTooltip>
-                  </td>
+                  {/* 单行截断 + 悬浮全文（对齐 Routine/Scheduler 表格规范）。 */}
+                  <TruncatedCell text={item.content} textClassName="text-foreground" />
+                  <TruncatedCell
+                    text={new Date(item.created_at).toLocaleString()}
+                    textClassName="text-text-secondary"
+                  />
                 </tr>
               ))}
             </tbody>

--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusFormDialog.tsx
@@ -9,6 +9,10 @@ import {
   normalizeChunkingConfig,
   SeparatorsTextarea,
 } from "@/features/knowledge";
+import { Field, InlineField } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Textarea } from "@/components/ui/Textarea";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface CorpusFormDialogProps {
@@ -100,31 +104,23 @@ export function CorpusFormDialog({
         </div>
 
         <div className="space-y-4">
-          <div>
-            <label className="mb-1 block text-xs font-medium text-text-secondary">
-              名称 <span className="text-red-500">*</span>
-            </label>
-            <input
-              className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none focus:border-foreground focus:ring-1 focus:ring-foreground"
+          <Field label="名称" required>
+            <Input
               placeholder="例如：产品文档"
               value={name}
               onChange={(e) => setName(e.target.value)}
               autoFocus
             />
-          </div>
+          </Field>
 
-          <div>
-            <label className="mb-1 block text-xs font-medium text-text-secondary">
-              描述
-            </label>
-            <textarea
-              className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none focus:border-foreground focus:ring-1 focus:ring-foreground"
+          <Field label="描述">
+            <Textarea
               rows={3}
               placeholder="简要描述该数据源的内容用途..."
               value={description}
               onChange={(e) => setDescription(e.target.value)}
             />
-          </div>
+          </Field>
 
           <div className="pt-2">
             <button
@@ -152,12 +148,8 @@ export function CorpusFormDialog({
             {showAdvanced && (
               <div className="mt-3 space-y-3 rounded-lg bg-muted p-3">
                 {/* Strategy Selection */}
-                <div>
-                  <label className="mb-1 block text-micro font-medium text-text-muted">
-                    Strategy
-                  </label>
-                  <select
-                    className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
+                <Field label="Strategy">
+                  <Select
                     value={config.strategy}
                     onChange={(e) =>
                       setConfig(
@@ -175,18 +167,14 @@ export function CorpusFormDialog({
                     <option value="hierarchical">
                       Hierarchical (Parent + Child)
                     </option>
-                  </select>
-                </div>
+                  </Select>
+                </Field>
 
                 {config.strategy === "fixed" && (
                   <div className="grid grid-cols-2 gap-3">
-                    <div>
-                      <label className="mb-1 block text-micro font-medium text-text-muted">
-                        Chunk Size (Target)
-                      </label>
-                      <input
+                    <InlineField label="Chunk Size (Target)">
+                      <Input
                         type="number"
-                        className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                         value={String(config.chunk_size)}
                         onChange={(e) =>
                           setConfig({
@@ -195,14 +183,10 @@ export function CorpusFormDialog({
                           })
                         }
                       />
-                    </div>
-                    <div>
-                      <label className="mb-1 block text-micro font-medium text-text-muted">
-                        Overlap (Chars)
-                      </label>
-                      <input
+                    </InlineField>
+                    <InlineField label="Overlap (Chars)">
+                      <Input
                         type="number"
-                        className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                         value={String(config.overlap)}
                         onChange={(e) =>
                           setConfig({
@@ -211,20 +195,16 @@ export function CorpusFormDialog({
                           })
                         }
                       />
-                    </div>
+                    </InlineField>
                   </div>
                 )}
 
                 {config.strategy === "recursive" && (
                   <div className="space-y-3 border-t border-border pt-3">
                     <div className="grid grid-cols-2 gap-3">
-                      <div>
-                        <label className="mb-1 block text-micro font-medium text-text-muted">
-                          Chunk Size (Target)
-                        </label>
-                        <input
+                      <InlineField label="Chunk Size (Target)">
+                        <Input
                           type="number"
-                          className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                           value={String(config.chunk_size)}
                           onChange={(e) =>
                             setConfig({
@@ -233,14 +213,10 @@ export function CorpusFormDialog({
                             })
                           }
                         />
-                      </div>
-                      <div>
-                        <label className="mb-1 block text-micro font-medium text-text-muted">
-                          Overlap (Chars)
-                        </label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Overlap (Chars)">
+                        <Input
                           type="number"
-                          className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                           value={String(config.overlap)}
                           onChange={(e) =>
                             setConfig({
@@ -249,13 +225,10 @@ export function CorpusFormDialog({
                             })
                           }
                         />
-                      </div>
+                      </InlineField>
                     </div>
 
-                    <div>
-                      <label className="mb-1 block text-micro font-medium text-text-muted">
-                        Separators (one per line)
-                      </label>
+                    <Field label="Separators (one per line)">
                       <SeparatorsTextarea
                         className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                         rows={4}
@@ -265,60 +238,46 @@ export function CorpusFormDialog({
                           setConfig({ ...config, separators })
                         }
                       />
-                    </div>
+                    </Field>
                   </div>
                 )}
 
                 {config.strategy === "semantic" && (
-                  <div className="grid grid-cols-2 gap-3 border-t border-border pt-3">
-                    <div className="col-span-2">
-                      <label className="mb-1 block text-micro font-medium text-blue-600 dark:text-blue-400">
-                        Semantic Chunking Options
-                      </label>
+                  <div className="space-y-3 border-t border-border pt-3">
+                    <div className="text-micro font-medium text-blue-600 dark:text-blue-400">
+                      Semantic Chunking Options
                     </div>
-                    <div>
-                      <label className="mb-1 block text-micro font-medium text-text-muted">
-                        Similarity Threshold (0-1)
-                      </label>
-                      <input
-                        type="number"
-                        step="0.05"
-                        max="1.0"
-                        min="0.0"
-                        className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
-                        value={String(config.semantic_threshold)}
-                        onChange={(e) =>
-                          setConfig({
-                            ...config,
-                            semantic_threshold: Number(e.target.value) || 0.85,
-                          })
-                        }
-                      />
-                    </div>
-                    <div>
-                      <label className="mb-1 block text-micro font-medium text-text-muted">
-                        Buffer Size
-                      </label>
-                      <input
-                        type="number"
-                        className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
-                        value={String(config.semantic_buffer_size)}
-                        onChange={(e) =>
-                          setConfig({
-                            ...config,
-                            semantic_buffer_size: Number(e.target.value) || 1,
-                          })
-                        }
-                      />
-                    </div>
-                    <div className="grid grid-cols-2 gap-2">
-                      <div>
-                        <label className="mb-1 block text-micro font-medium text-text-muted">
-                          Max Size
-                        </label>
-                        <input
+                    <div className="grid grid-cols-2 gap-3">
+                      <InlineField label="Similarity Threshold (0-1)">
+                        <Input
                           type="number"
-                          className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
+                          step="0.05"
+                          max="1.0"
+                          min="0.0"
+                          value={String(config.semantic_threshold)}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              semantic_threshold: Number(e.target.value) || 0.85,
+                            })
+                          }
+                        />
+                      </InlineField>
+                      <InlineField label="Buffer Size">
+                        <Input
+                          type="number"
+                          value={String(config.semantic_buffer_size)}
+                          onChange={(e) =>
+                            setConfig({
+                              ...config,
+                              semantic_buffer_size: Number(e.target.value) || 1,
+                            })
+                          }
+                        />
+                      </InlineField>
+                      <InlineField label="Max Size">
+                        <Input
+                          type="number"
                           value={String(config.max_chunk_size)}
                           onChange={(e) =>
                             setConfig({
@@ -327,14 +286,10 @@ export function CorpusFormDialog({
                             })
                           }
                         />
-                      </div>
-                      <div>
-                        <label className="mb-1 block text-micro font-medium text-text-muted">
-                          Min Size
-                        </label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Min Size">
+                        <Input
                           type="number"
-                          className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                           value={String(config.min_chunk_size)}
                           onChange={(e) =>
                             setConfig({
@@ -343,7 +298,7 @@ export function CorpusFormDialog({
                             })
                           }
                         />
-                      </div>
+                      </InlineField>
                     </div>
                   </div>
                 )}
@@ -351,13 +306,9 @@ export function CorpusFormDialog({
                 {config.strategy === "hierarchical" && (
                   <div className="space-y-3 border-t border-border pt-3">
                     <div className="grid grid-cols-3 gap-3">
-                      <div>
-                        <label className="mb-1 block text-micro font-medium text-text-muted">
-                          Parent Size
-                        </label>
-                        <input
+                      <InlineField label="Parent Size">
+                        <Input
                           type="number"
-                          className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                           value={String(config.hierarchical_parent_chunk_size)}
                           onChange={(e) =>
                             setConfig({
@@ -367,14 +318,10 @@ export function CorpusFormDialog({
                             })
                           }
                         />
-                      </div>
-                      <div>
-                        <label className="mb-1 block text-micro font-medium text-text-muted">
-                          Child Size
-                        </label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Child Size">
+                        <Input
                           type="number"
-                          className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                           value={String(config.hierarchical_child_chunk_size)}
                           onChange={(e) =>
                             setConfig({
@@ -384,14 +331,10 @@ export function CorpusFormDialog({
                             })
                           }
                         />
-                      </div>
-                      <div>
-                        <label className="mb-1 block text-micro font-medium text-text-muted">
-                          Child Overlap
-                        </label>
-                        <input
+                      </InlineField>
+                      <InlineField label="Child Overlap">
+                        <Input
                           type="number"
-                          className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                           value={String(config.hierarchical_child_overlap)}
                           onChange={(e) =>
                             setConfig({
@@ -401,12 +344,9 @@ export function CorpusFormDialog({
                             })
                           }
                         />
-                      </div>
+                      </InlineField>
                     </div>
-                    <div>
-                      <label className="mb-1 block text-micro font-medium text-text-muted">
-                        Separators (one per line)
-                      </label>
+                    <Field label="Separators (one per line)">
                       <SeparatorsTextarea
                         className="w-full rounded border border-input bg-background px-2 py-1 text-xs"
                         rows={4}
@@ -416,18 +356,16 @@ export function CorpusFormDialog({
                           setConfig({ ...config, separators })
                         }
                       />
-                    </div>
+                    </Field>
                   </div>
                 )}
 
                 {(config.strategy === "fixed" ||
                   config.strategy === "recursive" ||
                   config.strategy === "hierarchical") && (
-                  <div className="flex items-center pt-1">
+                  <Field variant="check" label="Preserve Newlines">
                     <input
                       type="checkbox"
-                      id="preserve-newlines"
-                      className="h-3 w-3 rounded border-input"
                       checked={config.preserve_newlines}
                       onChange={(e) =>
                         setConfig({
@@ -435,14 +373,9 @@ export function CorpusFormDialog({
                           preserve_newlines: e.target.checked,
                         })
                       }
+                      className="h-4 w-4"
                     />
-                    <label
-                      htmlFor="preserve-newlines"
-                      className="ml-2 text-xs text-text-secondary"
-                    >
-                      Preserve Newlines
-                    </label>
-                  </div>
+                  </Field>
                 )}
 
                 <div className="text-micro text-text-muted">

--- a/apps/negentropy-ui/app/knowledge/base/_components/CorpusSettingsPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/CorpusSettingsPanel.tsx
@@ -16,6 +16,8 @@ import {
   type ModelConfigItem,
   type CorpusModelsConfig,
 } from "@/features/knowledge";
+import { Field, InlineField } from "@/components/ui/Field";
+import { Select } from "@/components/ui/Select";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
 import { ChunkingStrategyPanel } from "./ChunkingStrategyPanel";
@@ -143,15 +145,11 @@ function CorpusSettingsPanel({
           Embedding Model 影响 Embedding Indexing / Vector Search；LLM Model 影响 URL 与 PDF 文档抽取调用 MCP 时的 Plan LLM。
         </p>
 
-        <div className="mt-3 grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
-              Embedding Model
-            </label>
-            <select
+        <div className="mt-3 space-y-3">
+          <Field label="Embedding Model">
+            <Select
               value={embeddingConfigId}
               onChange={(e) => setEmbeddingConfigId(e.target.value)}
-              className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
             >
               <option value="">(使用全局默认)</option>
               {embeddingModels.map((m) => (
@@ -159,26 +157,22 @@ function CorpusSettingsPanel({
                   {m.display_name?.trim() || `${m.vendor}/${m.model_name}`}
                 </option>
               ))}
-            </select>
+            </Select>
             {embeddingConfigId && (() => {
               const sel = embeddingModels.find((m) => m.id === embeddingConfigId);
               const dims = typeof sel?.config?.dimensions === "number" ? sel.config.dimensions : null;
               return dims != null ? (
-                <span className="mt-1 inline-block rounded bg-blue-100 px-1.5 py-0.5 text-micro font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                <span className="inline-block rounded bg-blue-100 px-1.5 py-0.5 text-micro font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
                   {dims} dims
                 </span>
               ) : null;
             })()}
-          </div>
+          </Field>
 
-          <div>
-            <label className="block text-xs font-medium text-text-secondary mb-1">
-              LLM Model
-            </label>
-            <select
+          <Field label="LLM Model">
+            <Select
               value={llmConfigId}
               onChange={(e) => setLlmConfigId(e.target.value)}
-              className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm"
             >
               <option value="">(使用全局默认)</option>
               {llmModels.map((m) => (
@@ -186,8 +180,8 @@ function CorpusSettingsPanel({
                   {m.display_name?.trim() || `${m.vendor}/${m.model_name}`}
                 </option>
               ))}
-            </select>
-          </div>
+            </Select>
+          </Field>
         </div>
       </div>
 
@@ -320,17 +314,15 @@ function CorpusSettingsPanel({
 
                   return (
                     <div key={`${routeKey}-${index}`} className="grid gap-3 rounded-lg border border-border bg-card p-3 md:grid-cols-[120px_1fr_1fr_auto]">
-                      <div className="text-xs font-semibold text-text-secondary">
+                      <div className="flex items-center text-xs font-semibold text-text-secondary">
                         {index === 0 ? "主用" : "备用"}
                       </div>
-                      <label className="text-xs">
-                        <div className="mb-1 text-muted-foreground">MCP Server</div>
-                        <select
+                      <InlineField label="MCP Server">
+                        <Select
                           value={selectedServerId}
                           onChange={(e) =>
                             setTarget({ server_id: e.target.value, tool_name: "" })
                           }
-                          className="w-full rounded border border-border bg-background px-2 py-2"
                         >
                           <option value="">未配置</option>
                           {serverOptions.map((server) => (
@@ -338,15 +330,13 @@ function CorpusSettingsPanel({
                               {server.display_name || server.name}
                             </option>
                           ))}
-                        </select>
-                      </label>
-                      <label className="text-xs">
-                        <div className="mb-1 text-muted-foreground">Tool</div>
-                        <select
+                        </Select>
+                      </InlineField>
+                      <InlineField label="Tool">
+                        <Select
                           value={target?.tool_name || ""}
                           onChange={(e) => setTarget({ tool_name: e.target.value })}
                           disabled={!selectedServerId}
-                          className="w-full rounded border border-border bg-background px-2 py-2 disabled:opacity-50"
                         >
                           <option value="">未配置</option>
                           {visibleToolOptions.map((tool) => (
@@ -354,9 +344,9 @@ function CorpusSettingsPanel({
                               {tool.display_name || tool.name}
                             </option>
                           ))}
-                        </select>
-                      </label>
-                      <div className="flex items-end">
+                        </Select>
+                      </InlineField>
+                      <div className="flex items-center">
                         <button
                           type="button"
                           onClick={clearTarget}

--- a/apps/negentropy-ui/app/knowledge/base/_components/ReplaceSourceDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/_components/ReplaceSourceDialog.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { toast } from "@/lib/activity-toast";
 import { AsyncPipelineResult } from "@/features/knowledge";
+import { Field } from "@/components/ui/Field";
+import { Textarea } from "@/components/ui/Textarea";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 
 interface ReplaceSourceDialogProps {
@@ -114,18 +116,14 @@ export function ReplaceSourceDialog({
         </div>
 
         {/* Content Input */}
-        <div>
-          <label className="mb-1 block text-xs font-medium text-text-secondary">
-            New Content <span className="text-red-500">*</span>
-          </label>
-          <textarea
-            className="w-full rounded-lg border border-input bg-background px-3 py-2 text-sm outline-none focus:border-foreground focus:ring-1 focus:ring-foreground"
+        <Field label="New Content" required>
+          <Textarea
             rows={8}
             placeholder="Paste new content to replace the existing one..."
             value={text}
             onChange={(e) => setText(e.target.value)}
           />
-        </div>
+        </Field>
 
         {/* Error Message */}
         {error && (

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -10,6 +10,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
@@ -47,7 +48,9 @@ import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { Button } from "@/components/ui/Button";
 import { AnimatedList } from "@/components/ui/AnimatedList";
 import { outlineButtonClassName } from "@/components/ui/button-styles";
+import { DropdownMenu, type DropdownMenuItem } from "@/components/ui/DropdownMenu";
 import { TextTooltip } from "@/components/ui/TextTooltip";
+import { TruncatedCell } from "@/components/ui/TruncatedCell";
 import { navPillClassName, navRailContainerClassName } from "@/components/ui/nav-styles";
 import {
   tableBodyClassName,
@@ -75,6 +78,108 @@ const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 
 type ViewMode = "overview" | "corpus";
 type CorpusTab = "documents" | "settings" | "document-chunks";
+
+/** 语料文档行内操作字面量联合（对齐 runDocumentAction 第一参）。 */
+type DocAction =
+  | "sync"
+  | "rebuild"
+  | "replace"
+  | "archive"
+  | "unarchive"
+  | "download"
+  | "view"
+  | "delete";
+
+/**
+ * Corpus Documents 行内 Actions —— 主操作（View / Download）单行内联 + 「More」溢出菜单
+ * 承载 Replace / Rebuild / Sync[url] / Archive|Unarchive / Delete，修复旧 `flex flex-wrap`
+ * 七按钮换行违规。**模块级**定义（非 page 内联），避免每次渲染重挂丢失 DropdownMenu 菜单态。
+ *
+ * `runDocumentAction` 作为 `onAction` 透传；action 字面量与条件（Sync 仅 url、Archive/Unarchive
+ * 互斥、Delete danger）逐字对齐原内联按钮，原 `title` 语义迁入菜单项 `ariaLabel`。
+ */
+function CorpusDocRowActions({
+  doc,
+  sourceType,
+  onAction,
+}: {
+  doc: KnowledgeDocument;
+  sourceType: string;
+  onAction: (action: DocAction, doc: KnowledgeDocument) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement>(null);
+  const moreItems: DropdownMenuItem[] = [
+    {
+      label: "Replace",
+      ariaLabel: "用新文本替换该文档并重建索引（保留文档元信息）",
+      onSelect: () => onAction("replace", doc),
+    },
+    {
+      label: "Rebuild",
+      ariaLabel: "重新分块并重建向量索引（不更换原始内容）",
+      onSelect: () => onAction("rebuild", doc),
+    },
+    ...(sourceType === "url"
+      ? [
+          {
+            label: "Sync",
+            ariaLabel: "重新抓取该 URL 源并刷新内容（仅 URL 类型）",
+            onSelect: () => onAction("sync", doc),
+          },
+        ]
+      : []),
+    {
+      label: doc.archived ? "Unarchive" : "Archive",
+      ariaLabel: doc.archived
+        ? "取消归档，恢复参与检索"
+        : "归档该文档，将其从默认检索中排除（可解档恢复）",
+      onSelect: () => onAction(doc.archived ? "unarchive" : "archive", doc),
+    },
+    {
+      label: "Delete",
+      ariaLabel: "删除该文档及其全部 Chunks",
+      danger: true,
+      onSelect: () => onAction("delete", doc),
+    },
+  ];
+  return (
+    <div className="flex items-center justify-end gap-1">
+      <button
+        type="button"
+        onClick={() => onAction("view", doc)}
+        title="打开文档详情页查看解析后的 Markdown 正文"
+        className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
+      >
+        View
+      </button>
+      <button
+        type="button"
+        onClick={() => onAction("download", doc)}
+        title="下载原始文件到本地"
+        className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
+      >
+        Download
+      </button>
+      <button
+        ref={anchorRef}
+        type="button"
+        aria-label="更多操作"
+        onClick={() => setOpen((o) => !o)}
+        className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
+      >
+        More
+      </button>
+      <DropdownMenu
+        open={open}
+        onClose={() => setOpen(false)}
+        anchorRef={anchorRef}
+        items={moreItems}
+        align="end"
+      />
+    </div>
+  );
+}
 
 export default function KnowledgeBasePage() {
   const pathname = usePathname();
@@ -920,135 +1025,90 @@ export default function KnowledgeBasePage() {
                   </div>
 
                   <div className={tableContainerClassName}>
-                    {/* 表头 */}
-                    <div className={cn("grid grid-cols-12 gap-2", tableHeaderClassName)}>
-                      <div className="col-span-3 text-center">Name</div>
-                      <div className="col-span-1 text-center">Source</div>
-                      <div className="col-span-1 text-center">Size</div>
-                      <div className="col-span-2 text-center">Status</div>
-                      <div className="col-span-2 text-center">Updated At</div>
-                      <div className="col-span-3 text-center">Actions</div>
-                    </div>
-
-                    {documentsLoading ? (
-                      <p className="px-4 py-6 text-center text-xs text-muted-foreground">Loading...</p>
-                    ) : documents.length === 0 ? (
-                      <p className="px-4 py-6 text-center text-xs text-muted-foreground">No documents.</p>
-                    ) : (
-                      <div className={tableBodyClassName}>
-                        {documents.map((doc) => {
-                          const sourceType = String(doc.metadata?.source_type || "file");
-                          return (
-                            <div
-                              key={doc.id}
-                              className={cn("grid grid-cols-12 items-center gap-2", tableRowClassName)}
-                            >
-                              {/* Name —— 点击进入 document-chunks 标签页 */}
-                              <button
-                                className="col-span-3 min-w-0 text-left"
-                                onClick={() => syncQueryState({ view: "corpus", corpusId: selectedCorpusId, tab: "document-chunks", documentId: doc.id })}
-                              >
-                                <TextTooltip content={effectiveDocumentName(doc)}>
-                                  <p className="truncate text-sm font-medium">
-                                    {effectiveDocumentName(doc)}
-                                  </p>
-                                </TextTooltip>
-                              </button>
-                              {/* Source */}
-                              <div className="col-span-1 min-w-0 text-center">
-                                <TextTooltip content={sourceType}>
-                                  <div className="block truncate text-xs text-muted-foreground">
-                                    {sourceType}
-                                  </div>
-                                </TextTooltip>
-                              </div>
-                              {/* Size */}
-                              <div className="col-span-1 text-center text-xs text-muted-foreground">
-                                {doc.file_size} bytes
-                              </div>
-                              {/* Status */}
-                              <div className="col-span-2 flex justify-center">
-                                <PipelineStatusBadge
-                                  status={
-                                    buildingDocIds.has(doc.id)
-                                      ? "processing"
-                                      : doc.markdown_extract_status || doc.status
-                                  }
-                                />
-                              </div>
-                              {/* Updated At —— 列表按最终修改时间倒序 */}
-                              <div className="col-span-2 text-center text-xs text-muted-foreground">
-                                {formatRelativeTime(doc.updated_at ?? undefined)}
-                              </div>
-                              {/* Actions */}
-                              <div className="col-span-3 flex flex-wrap items-center justify-end gap-1">
-                                <button
-                                  onClick={() => runDocumentAction("view", doc)}
-                                  title="打开文档详情页查看解析后的 Markdown 正文"
-                                  className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
-                                >
-                                  View
-                                </button>
-                                <button
-                                  onClick={() => runDocumentAction("download", doc)}
-                                  title="下载原始文件到本地"
-                                  className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
-                                >
-                                  Download
-                                </button>
-                                <button
-                                  onClick={() => runDocumentAction("replace", doc)}
-                                  title="用新文本替换该文档并重建索引（保留文档元信息）"
-                                  className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
-                                >
-                                  Replace
-                                </button>
-                                <button
-                                  onClick={() => runDocumentAction("rebuild", doc)}
-                                  title="重新分块并重建向量索引（不更换原始内容）"
-                                  className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
-                                >
-                                  Rebuild
-                                </button>
-                                {sourceType === "url" && (
+                    {/* 固定列宽：百分比合计 100%（6 列），随容器等比缩放；与 <th> 解耦，
+                        超长内容由单元格 truncate 截断。colgroup 内禁止行内 JSX 注释（hydration）。 */}
+                    <table className="w-full table-fixed text-sm">
+                      <colgroup>
+                        <col className="w-[30%]" />
+                        <col className="w-[12%]" />
+                        <col className="w-[10%]" />
+                        <col className="w-[16%]" />
+                        <col className="w-[14%]" />
+                        <col className="w-[18%]" />
+                      </colgroup>
+                      <thead>
+                        <tr className={cn("text-left", tableHeaderClassName)}>
+                          <th className="px-4 py-2.5 font-medium">Name</th>
+                          <th className="px-4 py-2.5 font-medium">Source</th>
+                          <th className="px-4 py-2.5 font-medium">Size</th>
+                          <th className="px-4 py-2.5 font-medium">Status</th>
+                          <th className="px-4 py-2.5 font-medium">Updated At</th>
+                          <th className="px-4 py-2.5 text-right font-medium">Actions</th>
+                        </tr>
+                      </thead>
+                      <tbody className={tableBodyClassName}>
+                        {documentsLoading ? (
+                          <tr>
+                            <td colSpan={6} className="px-4 py-6 text-center text-xs text-muted-foreground">
+                              Loading...
+                            </td>
+                          </tr>
+                        ) : documents.length === 0 ? (
+                          <tr>
+                            <td colSpan={6} className="px-4 py-6 text-center text-xs text-muted-foreground">
+                              No documents.
+                            </td>
+                          </tr>
+                        ) : (
+                          documents.map((doc) => {
+                            const sourceType = String(doc.metadata?.source_type || "file");
+                            return (
+                              <tr key={doc.id} className={tableRowClassName}>
+                                {/* Name —— 点击进入 document-chunks 标签页（button 内嵌截断 span，
+                                    TruncatedCell 无 onClick 透传，故此列手写 td 保留导航语义） */}
+                                <td className="px-4 py-3">
                                   <button
-                                    onClick={() => runDocumentAction("sync", doc)}
-                                    title="重新抓取该 URL 源并刷新内容（仅 URL 类型）"
-                                    className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
+                                    type="button"
+                                    className="block min-w-0 text-left"
+                                    onClick={() => syncQueryState({ view: "corpus", corpusId: selectedCorpusId, tab: "document-chunks", documentId: doc.id })}
                                   >
-                                    Sync
+                                    <TextTooltip content={effectiveDocumentName(doc)}>
+                                      <span className="block truncate text-sm font-medium">
+                                        {effectiveDocumentName(doc)}
+                                      </span>
+                                    </TextTooltip>
                                   </button>
-                                )}
-                                {!doc.archived ? (
-                                  <button
-                                    onClick={() => runDocumentAction("archive", doc)}
-                                    title="归档该文档，将其从默认检索中排除（可解档恢复）"
-                                    className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
-                                  >
-                                    Archive
-                                  </button>
-                                ) : (
-                                  <button
-                                    onClick={() => runDocumentAction("unarchive", doc)}
-                                    title="取消归档，恢复参与检索"
-                                    className={outlineButtonClassName("neutral", "rounded px-2 py-1 text-caption")}
-                                  >
-                                    Unarchive
-                                  </button>
-                                )}
-                                <button
-                                  onClick={() => runDocumentAction("delete", doc)}
-                                  title="删除该文档及其全部 Chunks"
-                                  className={outlineButtonClassName("danger", "rounded px-2 py-1 text-caption")}
-                                >
-                                  Delete
-                                </button>
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
+                                </td>
+                                {/* Source */}
+                                <TruncatedCell text={sourceType} textClassName="text-xs text-text-secondary" />
+                                {/* Size */}
+                                <TruncatedCell text={`${doc.file_size} bytes`} textClassName="text-xs text-text-secondary" />
+                                {/* Status */}
+                                <td className="px-4 py-3">
+                                  <PipelineStatusBadge
+                                    status={
+                                      buildingDocIds.has(doc.id)
+                                        ? "processing"
+                                        : doc.markdown_extract_status || doc.status
+                                    }
+                                  />
+                                </td>
+                                {/* Updated At —— 列表按最终修改时间倒序 */}
+                                <TruncatedCell text={formatRelativeTime(doc.updated_at ?? undefined)} textClassName="text-xs text-text-secondary" />
+                                {/* Actions —— 单行：View/Download 内联 + More 溢出菜单 */}
+                                <td className="px-4 py-3">
+                                  <CorpusDocRowActions
+                                    doc={doc}
+                                    sourceType={sourceType}
+                                    onAction={runDocumentAction}
+                                  />
+                                </td>
+                              </tr>
+                            );
+                          })
+                        )}
+                      </tbody>
+                    </table>
 
                     {/* 分页：每页 10 条 */}
                     {documentsTotal > 0 && (

--- a/apps/negentropy-ui/app/knowledge/documents/_components/ImportDocumentDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/_components/ImportDocumentDialog.tsx
@@ -3,6 +3,8 @@
 import { useRef, useState } from "react";
 import { toast } from "@/lib/activity-toast";
 import { AsyncPipelineResult } from "@/features/knowledge";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
 import { OverlayDismissLayer } from "@/components/ui/OverlayDismissLayer";
 import { FileText, FileType, Link2, UploadCloud, X } from "lucide-react";
 
@@ -348,15 +350,8 @@ export function ImportDocumentDialog({
         </div>
       ) : (
         /* URL Input */
-        <div>
-          <label
-            htmlFor="import-document-url"
-            className="mb-1.5 block text-xs font-medium text-text-secondary"
-          >
-            网页 URL
-          </label>
-          <input
-            id="import-document-url"
+        <Field label="网页 URL">
+          <Input
             type="url"
             value={url}
             onChange={(e) => {
@@ -364,9 +359,8 @@ export function ImportDocumentDialog({
               setError(null);
             }}
             placeholder="https://example.com/article"
-            className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-text-muted focus:border-foreground/40 focus:outline-none"
           />
-        </div>
+        </Field>
       )}
 
       {/* Tab Description */}

--- a/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/CorpusSelector.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { InlineField } from "@/components/ui/Field";
+import { Select } from "@/components/ui/Select";
 import { CorpusRecord, fetchCorpora } from "@/features/knowledge";
 
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
@@ -52,17 +54,13 @@ export function CorpusSelector({
   }, [onChange, onCorporaLoaded, defaultCorpusName]);
 
   return (
-    <div className="flex items-center gap-2">
-      <label className="text-xs font-medium text-text-secondary whitespace-nowrap">
-        语料库
-      </label>
-      <select
+    <InlineField label="语料库">
+      <Select
         key={loading ? "loading" : "loaded"}
         value={value ?? ""}
         onChange={(e) => onChange(e.target.value)}
         autoComplete="off"
         disabled={loading}
-        className="rounded-lg border border-input bg-background px-3 py-1.5 text-sm text-foreground focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 disabled:opacity-50"
       >
         <option value="" disabled>{loading ? "加载中..." : "选择语料库..."}</option>
         {corpora.map((c) => (
@@ -70,7 +68,7 @@ export function CorpusSelector({
             {c.name}
           </option>
         ))}
-      </select>
-    </div>
+      </Select>
+    </InlineField>
   );
 }

--- a/apps/negentropy-ui/app/knowledge/graph/_components/EntityListPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/EntityListPanel.tsx
@@ -8,6 +8,7 @@ import {
 
 import { Pagination } from "@/components/ui/Pagination";
 import { TextTooltip } from "@/components/ui/TextTooltip";
+import { TruncatedCell } from "@/components/ui/TruncatedCell";
 import { useInfiniteList, type OffsetFetcher } from "@/hooks/useInfiniteList";
 import { useInfiniteScrollSentinel, useScrollPageSync } from "@/hooks/useInfiniteScrollSentinel";
 
@@ -202,13 +203,10 @@ export function EntityListPanel({
                         : ""
                     }`}
                   >
-                    <td className="px-4 py-3">
-                      <TextTooltip content={entity.name}>
-                        <span className="block truncate font-medium text-foreground">
-                          {entity.name}
-                        </span>
-                      </TextTooltip>
-                    </td>
+                    <TruncatedCell
+                      text={entity.name}
+                      textClassName="font-medium text-foreground"
+                    />
                     <td className="px-4 py-3">
                       {/* 类型：色点 + label，单行截断，全文悬浮。 */}
                       <div className="flex min-w-0 items-center gap-1">

--- a/apps/negentropy-ui/app/knowledge/graph/_components/ModelConfigPanel.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/ModelConfigPanel.tsx
@@ -9,6 +9,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { TaskModelSelect } from "@/components/interface/TaskModelSelect";
+import { Field } from "@/components/ui/Field";
+import { Select } from "@/components/ui/Select";
 import {
   type CorpusModelsConfig,
   type ModelConfigItem,
@@ -215,14 +217,10 @@ export function ModelConfigPanel({
       </p>
 
       <div className="mt-3 space-y-3">
-        <div>
-          <label className="block text-xs font-medium text-text-secondary mb-1">
-            LLM Model
-          </label>
-          <select
+        <Field label="LLM Model">
+          <Select
             value={llmConfigId}
             onChange={(e) => setLlmConfigId(e.target.value)}
-            className="w-full rounded-lg border border-input bg-background px-3 py-1.5 text-xs"
           >
             <option value="">(使用全局默认)</option>
             {llmModels.map((m) => (
@@ -230,17 +228,13 @@ export function ModelConfigPanel({
                 {m.display_name?.trim() || `${m.vendor}/${m.model_name}`}
               </option>
             ))}
-          </select>
-        </div>
+          </Select>
+        </Field>
 
-        <div>
-          <label className="block text-xs font-medium text-text-secondary mb-1">
-            Embedding Model
-          </label>
-          <select
+        <Field label="Embedding Model">
+          <Select
             value={embeddingConfigId}
             onChange={(e) => setEmbeddingConfigId(e.target.value)}
-            className="w-full rounded-lg border border-input bg-background px-3 py-1.5 text-xs"
           >
             <option value="">(使用全局默认)</option>
             {embeddingModels.map((m) => (
@@ -248,13 +242,13 @@ export function ModelConfigPanel({
                 {m.display_name?.trim() || `${m.vendor}/${m.model_name}`}
               </option>
             ))}
-          </select>
+          </Select>
           {dims != null && (
             <span className="mt-1 inline-block rounded bg-blue-100 px-1.5 py-0.5 text-micro font-medium text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
               {dims} dims
             </span>
           )}
-        </div>
+        </Field>
       </div>
 
       <button

--- a/apps/negentropy-ui/app/knowledge/graph/_components/PathExplorer.tsx
+++ b/apps/negentropy-ui/app/knowledge/graph/_components/PathExplorer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { Field } from "@/components/ui/Field";
+import { Select } from "@/components/ui/Select";
 import {
   type GraphEntityItem,
   fetchGraphEntities,
@@ -59,14 +61,10 @@ export function PathExplorer({ corpusId, onPathFound }: PathExplorerProps) {
   return (
     <div className="space-y-3">
       <div className="space-y-2">
-        <div>
-          <label className="block text-micro font-medium text-text-muted mb-0.5">
-            起始实体
-          </label>
-          <select
+        <Field label="起始实体">
+          <Select
             value={sourceId}
             onChange={(e) => setSourceId(e.target.value)}
-            className="w-full rounded-lg border border-input bg-background px-2 py-1.5 text-xs text-foreground"
           >
             <option value="">选择起始实体...</option>
             {entities.map((e) => (
@@ -74,16 +72,12 @@ export function PathExplorer({ corpusId, onPathFound }: PathExplorerProps) {
                 {e.name} ({e.entity_type})
               </option>
             ))}
-          </select>
-        </div>
-        <div>
-          <label className="block text-micro font-medium text-text-muted mb-0.5">
-            目标实体
-          </label>
-          <select
+          </Select>
+        </Field>
+        <Field label="目标实体">
+          <Select
             value={targetId}
             onChange={(e) => setTargetId(e.target.value)}
-            className="w-full rounded-lg border border-input bg-background px-2 py-1.5 text-xs text-foreground"
           >
             <option value="">选择目标实体...</option>
             {entities.map((e) => (
@@ -91,8 +85,8 @@ export function PathExplorer({ corpusId, onPathFound }: PathExplorerProps) {
                 {e.name} ({e.entity_type})
               </option>
             ))}
-          </select>
-        </div>
+          </Select>
+        </Field>
       </div>
 
       <button

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/CreateWikiPublicationDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/CreateWikiPublicationDialog.tsx
@@ -15,6 +15,10 @@ import {
 import { slugify } from "@/features/knowledge/utils/wiki-slug";
 import { toast } from "@/lib/activity-toast";
 import { BaseModal } from "@/components/ui/BaseModal";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Select } from "@/components/ui/Select";
+import { Textarea } from "@/components/ui/Textarea";
 
 interface CreateWikiPublicationDialogProps {
   open: boolean;
@@ -99,52 +103,45 @@ export function CreateWikiPublicationDialog({
       }
     >
       <div className="space-y-3">
-        <div>
-          <label className="block text-xs font-medium text-muted-foreground mb-1">名称 *</label>
-          <input
+        <Field label="名称" required>
+          <Input
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="例如：工程 Wiki"
-            className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
-        </div>
-        <div>
-          <label className="block text-xs font-medium text-muted-foreground mb-1">Slug *</label>
-          <input
+        </Field>
+        <Field
+          label="Slug"
+          required
+          description={<>作为站点 URL 前缀，例如 /{slug || "engineering"}/...</>}
+        >
+          <Input
             value={slug}
             onChange={(e) => {
               setSlugEdited(true);
               setSlug(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, "-"));
             }}
             placeholder="engineering"
-            className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
-          <p className="mt-1 text-caption text-muted-foreground">
-            作为站点 URL 前缀，例如 /{slug || "engineering"}/...
-          </p>
-        </div>
-        <div>
-          <label className="block text-xs font-medium text-muted-foreground mb-1">描述</label>
-          <textarea
+        </Field>
+        <Field label="描述">
+          <Textarea
             value={description}
             onChange={(e) => setDescription(e.target.value)}
             placeholder="简要说明本发布的目标受众与内容范围"
             rows={2}
-            className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
           />
-        </div>
-        <div>
-          <label className="block text-xs font-medium text-muted-foreground mb-1">主题</label>
-          <select
+        </Field>
+        <Field label="主题">
+          <Select
             value={theme}
             onChange={(e) => setTheme(e.target.value as WikiTheme)}
-            className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none"
           >
             <option value="default">默认</option>
             <option value="book">图书（Book）</option>
             <option value="docs">文档（Docs）</option>
-          </select>
-        </div>
+          </Select>
+        </Field>
       </div>
     </BaseModal>
   );

--- a/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/CreateNodeDialog.tsx
+++ b/apps/negentropy-ui/app/knowledge/wiki/_components/catalog/CreateNodeDialog.tsx
@@ -11,6 +11,8 @@ import {
   createCatalogNode,
   CatalogNode,
 } from "@/features/knowledge";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
 import { toast } from "@/lib/activity-toast";
 
 function slugify(text: string): string {
@@ -101,22 +103,19 @@ export function CreateNodeDialog({
           目录节点用于组织子目录与文档。文档需通过节点详情页「挂载文档」入口添加，无需在此选择类型。
         </p>
         <div className="space-y-3">
-          <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1">
-              名称 *
-            </label>
-            <input
+          <Field label="名称" required>
+            <Input
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder="节点名称"
-              className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
             />
-          </div>
-          <div>
-            <label className="block text-xs font-medium text-muted-foreground mb-1">
-              Slug *
-            </label>
-            <input
+          </Field>
+          <Field
+            label="Slug"
+            required
+            description="仅支持小写字母、数字与短横线；将作为 URL 片段与 Wiki 层级标识。"
+          >
+            <Input
               value={slug}
               onChange={(e) => {
                 setSlugEdited(true);
@@ -125,12 +124,8 @@ export function CreateNodeDialog({
                 );
               }}
               placeholder="node-slug"
-              className="w-full rounded-md border border-border bg-background px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary/20"
             />
-            <p className="mt-1 text-caption text-muted-foreground">
-              仅支持小写字母、数字与短横线；将作为 URL 片段与 Wiki 层级标识。
-            </p>
-          </div>
+          </Field>
         </div>
         <div className="flex justify-end gap-2 mt-5">
           <button

--- a/apps/negentropy-ui/app/memory/core-blocks/_components/CoreBlockEditorDrawer.tsx
+++ b/apps/negentropy-ui/app/memory/core-blocks/_components/CoreBlockEditorDrawer.tsx
@@ -9,6 +9,9 @@
 import { useEffect, useState } from "react";
 import { BaseDrawer } from "@/components/ui/BaseDrawer";
 import { Button } from "@/components/ui/Button";
+import { Field } from "@/components/ui/Field";
+import { Input } from "@/components/ui/Input";
+import { Textarea } from "@/components/ui/Textarea";
 import type { CoreBlockItem } from "@/features/memory";
 
 /**
@@ -119,11 +122,8 @@ export function CoreBlockEditorDrawer({
         )}
 
         {/* Scope */}
-        <div>
-          <label className="text-micro uppercase tracking-overline text-muted-foreground">
-            Scope
-          </label>
-          <div className="mt-1.5 flex gap-1.5">
+        <Field label="Scope">
+          <div className="flex gap-1.5">
             {SCOPES.map((s) => (
               <button
                 key={s}
@@ -140,53 +140,42 @@ export function CoreBlockEditorDrawer({
               </button>
             ))}
           </div>
-        </div>
+        </Field>
 
         {/* Thread ID (scope=thread only) */}
         {threadRequired && (
-          <div>
-            <label className="text-micro uppercase tracking-overline text-muted-foreground">
-              Thread ID
-            </label>
-            <input
-              className="mt-1.5 w-full rounded-lg border border-border bg-background px-3 py-2 text-xs disabled:opacity-60"
+          <Field label="Thread ID">
+            <Input
               placeholder="UUID"
               value={threadId}
               disabled={isEdit}
               onChange={(e) => setThreadId(e.target.value)}
             />
-          </div>
+          </Field>
         )}
 
         {/* Label */}
-        <div>
-          <label className="text-micro uppercase tracking-overline text-muted-foreground">
-            Label
-          </label>
-          <input
-            className="mt-1.5 w-full rounded-lg border border-border bg-background px-3 py-2 text-xs disabled:opacity-60"
+        <Field label="Label">
+          <Input
             placeholder="persona / human / …"
             value={label}
             disabled={isEdit}
             onChange={(e) => setLabel(e.target.value)}
           />
-        </div>
+        </Field>
 
         {/* Content */}
-        <div>
-          <label className="text-micro uppercase tracking-overline text-muted-foreground">
-            Content
-          </label>
-          <textarea
-            className="mt-1.5 h-48 w-full resize-y rounded-lg border border-border bg-background px-3 py-2 text-xs leading-relaxed"
+        <Field label="Content">
+          <Textarea
+            className="h-48 text-xs leading-relaxed"
             placeholder="常驻摘要内容（超长将由后端按 token 预算截断）"
             value={content}
             onChange={(e) => setContent(e.target.value)}
           />
-          <p className="mt-1 text-micro text-muted-foreground tabular-nums">
+          <p className="text-micro text-muted-foreground tabular-nums">
             {content.length} chars
           </p>
-        </div>
+        </Field>
       </div>
     </BaseDrawer>
   );

--- a/apps/negentropy-ui/components/ui/Field.tsx
+++ b/apps/negentropy-ui/components/ui/Field.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { createContext, useId, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { TextTooltip } from "./TextTooltip";
+import { Tooltip } from "./Tooltip";
+import { HelpCircle } from "lucide-react";
+
+/**
+ * Field — 水平表单字段原语（label 与控件同行，label 固定占 1/12 宽）。
+ *
+ * 落实 AGENTS.md「UI 表单设计规范」：字段 label 与输入控件**同行**（非上下堆叠），
+ * label 一律仅占 1/12 宽度。超长 label 经 [[TextTooltip]] 溢出感知截断（省略号 + 悬停全文），
+ * 与表格「截断 + Tooltip」哲学一致。
+ *
+ * 布局（12 栅格）：`col-span-1` label 格 + `col-span-11` 控件格。
+ * - label 格 `min-w-0`（grid item 默认 min-width:auto 会阻止 truncate）；
+ * - label 元素本身亦 `min-w-0 truncate`，作为 TextTooltip 的 asChild 触发器，
+ *   溢出门控读其 scrollWidth/clientWidth，仅在真正省略号时弹浮层。
+ *
+ * 变体：
+ * - `standard`（默认）：label 在 1/12 格，控件在 11/12 格；
+ * - `check`：勾选框 / 开关类（控件即 label），1/12 格留空作缩进对齐，11/12 格内以 `<label>`
+ *   包裹「控件 + 文本」实现隐式关联（点击文本切换勾选）。
+ *
+ * 经 {@link FieldContext} 自动生成字段 id，供 {@link Input}/{@link Select}/{@link Textarea}
+ * 作 fallback `id`，实现零样板 label↔控件关联（a11y）。
+ */
+
+/** 字段 id 上下文：<Field> 生成并下发，控件原语消费作 fallback id。 */
+export const FieldContext = createContext<string | undefined>(undefined);
+
+export interface FieldProps {
+  /** 字段 label（支持富文本）。超长时省略号截断，悬停 TextTooltip 显示全文。 */
+  label: ReactNode;
+  /** 显式指定关联控件 id；缺省则用 <Field> 自动生成的 id。 */
+  htmlFor?: string;
+  /** 是否必填（渲染红色 `*`）。 */
+  required?: boolean;
+  /** 字段说明：在 label 旁渲染 `?` 图标（Tooltip 悬停展示）。 */
+  hint?: ReactNode;
+  /** 字段错误：在控件下方渲染 `<p role="alert" className="text-error">`。 */
+  error?: string;
+  /** 帮助文本：在控件下方渲染（11/12 格内）。 */
+  description?: ReactNode;
+  /** 控件（Input / Select / Textarea / 复合 div）。 */
+  children: ReactNode;
+  /** 根容器额外类名。 */
+  className?: string;
+  /** 布局变体：standard（默认）/ check（勾选框/开关）。 */
+  variant?: "standard" | "check";
+}
+
+export function Field({
+  label,
+  htmlFor,
+  required,
+  hint,
+  error,
+  description,
+  children,
+  className,
+  variant = "standard",
+}: FieldProps) {
+  const autoId = useId();
+  const fieldId = htmlFor ?? autoId;
+
+  // check 变体：控件即 label（勾选框/开关），1/12 格留空对齐全局左缩进。
+  if (variant === "check") {
+    return (
+      <FieldContext.Provider value={fieldId}>
+        <div className={cn("grid grid-cols-12 gap-x-3 items-start", className)}>
+          <div className="col-span-1" aria-hidden />
+          <div className="col-span-11 min-w-0 space-y-1">
+            {/* 隐式关联：勾选控件作为 <label> 后代，点击文本即可切换。 */}
+            <label htmlFor={htmlFor} className="flex items-center gap-2 text-sm text-foreground">
+              {children}
+              <span className="text-text-secondary">{label}</span>
+              {required && <span className="text-error"> *</span>}
+            </label>
+            {description && <p className="text-caption text-text-muted">{description}</p>}
+            {error && (
+              <p role="alert" className="text-xs text-error">
+                {error}
+              </p>
+            )}
+          </div>
+        </div>
+      </FieldContext.Provider>
+    );
+  }
+
+  return (
+    <FieldContext.Provider value={fieldId}>
+      <div className={cn("grid grid-cols-12 gap-x-3 items-start", className)}>
+        {/* label 格：1/12，min-w-0 允许内部 truncate；pt-2 与控件首行基线对齐。 */}
+        <div className="col-span-1 flex min-w-0 items-center gap-1 pt-2">
+          <TextTooltip content={label}>
+            <label
+              htmlFor={fieldId}
+              className="min-w-0 truncate text-xs font-medium text-text-secondary"
+            >
+              {label}
+              {required && <span className="text-error"> *</span>}
+            </label>
+          </TextTooltip>
+          {hint && (
+            <Tooltip content={hint} triggerProps={{ "aria-label": "字段说明" }}>
+              <HelpCircle className="h-3 w-3 shrink-0 text-text-muted" />
+            </Tooltip>
+          )}
+        </div>
+        {/* 控件格：11/12。description / error 紧随控件，置于同列。 */}
+        <div className="col-span-11 min-w-0 space-y-1">
+          {children}
+          {description && <p className="text-caption text-text-muted">{description}</p>}
+          {error && (
+            <p role="alert" className="text-xs text-error">
+              {error}
+            </p>
+          )}
+        </div>
+      </div>
+    </FieldContext.Provider>
+  );
+}
+
+/**
+ * InlineField — 紧凑同质字段组的内联原语（用于密集数字输入网格，如 Budget & Approval）。
+ *
+ * 与 {@link Field} 的分工：Field 是「全宽单字段一行」（label 1/12 + 控件 11/12）；
+ * InlineField 用于在调用方提供的 `grid-cols-N` 网格单元内，label 与控件**按单元宽度**内联，
+ * label `max-w-[50%]` 封顶（避免吃掉数值输入），仍 `min-w-0 truncate` + TextTooltip。
+ * 替代历史 `labelInlineCls = "shrink-0 whitespace-nowrap"`（原先不截断），补齐截断语义。
+ */
+export interface InlineFieldProps {
+  label: ReactNode;
+  htmlFor?: string;
+  required?: boolean;
+  hint?: ReactNode;
+  error?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function InlineField({
+  label,
+  htmlFor,
+  required,
+  hint,
+  error,
+  children,
+  className,
+}: InlineFieldProps) {
+  const autoId = useId();
+  const fieldId = htmlFor ?? autoId;
+  return (
+    <FieldContext.Provider value={fieldId}>
+      <div className={cn("flex min-w-0 items-center gap-2", className)}>
+        <TextTooltip content={label}>
+          <label
+            htmlFor={fieldId}
+            className="max-w-[50%] min-w-0 shrink-0 truncate text-xs font-medium text-text-secondary"
+          >
+            {label}
+            {required && <span className="text-error"> *</span>}
+          </label>
+        </TextTooltip>
+        {hint && (
+          <Tooltip content={hint} triggerProps={{ "aria-label": "字段说明" }}>
+            <HelpCircle className="h-3 w-3 shrink-0 text-text-muted" />
+          </Tooltip>
+        )}
+        <div className="min-w-0 flex-1">
+          {children}
+          {error && (
+            <p role="alert" className="mt-0.5 text-xs text-error">
+              {error}
+            </p>
+          )}
+        </div>
+      </div>
+    </FieldContext.Provider>
+  );
+}

--- a/apps/negentropy-ui/components/ui/Input.tsx
+++ b/apps/negentropy-ui/components/ui/Input.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { forwardRef, useContext, type ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+import { FieldContext } from "./Field";
+
+/**
+ * Input — 文本输入控件原语（单一事实源）。
+ *
+ * 统一全仓历史 4 套 input 样式约定到 token 化基线 {@link baseInputCls}：
+ * - 圆角 / 边框 / 底色 / 聚焦环均用 @theme 语义 token（随明暗翻转）；
+ * - `focus:ring-2 ring-ring/60` 较历史 `ring-1` 或硬编码蓝更符合 AA 可见性；
+ * - `min-w-0` 内置，保证在 flex 复合行内可收缩；
+ * - `w-full` 为默认，复合行由调用方 `className="w-auto flex-1"` 覆盖（cn/tailwind-merge 生效）。
+ *
+ * 经 {@link FieldContext} 自动拾取 <Field> 下发的 id 作 fallback，实现零样板 label↔控件关联。
+ */
+
+/** 输入控件类名 SSOT —— 表单输入族（Input/Select/Textarea）共用。 */
+export const baseInputCls =
+  "w-full min-w-0 rounded-control border border-border bg-input px-3 py-2 text-sm text-foreground transition-colors placeholder:text-text-muted focus:outline-none focus:ring-2 focus:ring-ring/60 disabled:cursor-not-allowed disabled:opacity-60";
+
+export interface InputProps extends ComponentPropsWithoutRef<"input"> {
+  className?: string;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  { className, type = "text", id, ...props },
+  ref,
+) {
+  const fieldId = useContext(FieldContext);
+  return (
+    <input
+      ref={ref}
+      type={type}
+      id={id ?? fieldId}
+      className={cn(baseInputCls, className)}
+      {...props}
+    />
+  );
+});

--- a/apps/negentropy-ui/components/ui/Select.tsx
+++ b/apps/negentropy-ui/components/ui/Select.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { forwardRef, useContext, type ComponentPropsWithoutRef, type ReactNode } from "react";
+import { ChevronDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { FieldContext } from "./Field";
+import { baseInputCls } from "./Input";
+
+/**
+ * Select — 下拉选择控件原语。原生 `<select>` + 自定义 chevron。
+ *
+ * - `appearance-none pr-9` 隐藏原生箭头，由绝对定位 `ChevronDown`（lucide）替代，统一视觉；
+ * - `trailing` 槽位：渲染于 chevron 左侧的附加节点（如 CorpusSelect 的 loading spinner，
+ *   调用方以 `pointer-events-none absolute right-9 …` 定位）；
+ * - 因外层包 `relative w-full`，复合行内调用方需再包 `<div className="min-w-0 flex-1">`；
+ * - 经 {@link FieldContext} 自动拾取 <Field> 下发的 id 作 fallback。
+ */
+export interface SelectProps extends ComponentPropsWithoutRef<"select"> {
+  className?: string;
+  /** chevron 左侧的附加节点（如 loading spinner）。 */
+  trailing?: ReactNode;
+}
+
+export const Select = forwardRef<HTMLSelectElement, SelectProps>(function Select(
+  { className, trailing, id, children, ...props },
+  ref,
+) {
+  const fieldId = useContext(FieldContext);
+  return (
+    <div className="relative w-full">
+      <select
+        ref={ref}
+        id={id ?? fieldId}
+        className={cn(baseInputCls, "appearance-none pr-9", className)}
+        {...props}
+      >
+        {children}
+      </select>
+      {trailing}
+      <ChevronDown
+        className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 text-text-muted"
+        aria-hidden
+      />
+    </div>
+  );
+});

--- a/apps/negentropy-ui/components/ui/Textarea.tsx
+++ b/apps/negentropy-ui/components/ui/Textarea.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { forwardRef, useContext, type ComponentPropsWithoutRef } from "react";
+import { cn } from "@/lib/utils";
+import { FieldContext } from "./Field";
+import { baseInputCls } from "./Input";
+
+/**
+ * Textarea — 多行文本控件原语。复用 {@link baseInputCls}，默认 `rows=3`、可纵向缩放。
+ * 经 {@link FieldContext} 自动拾取 <Field> 下发的 id 作 fallback。
+ */
+export interface TextareaProps extends ComponentPropsWithoutRef<"textarea"> {
+  className?: string;
+}
+
+export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(function Textarea(
+  { className, id, rows = 3, ...props },
+  ref,
+) {
+  const fieldId = useContext(FieldContext);
+  return (
+    <textarea
+      ref={ref}
+      id={id ?? fieldId}
+      rows={rows}
+      className={cn(baseInputCls, "resize-y", className)}
+      {...props}
+    />
+  );
+});

--- a/apps/negentropy-ui/components/ui/TruncatedCell.tsx
+++ b/apps/negentropy-ui/components/ui/TruncatedCell.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { type ReactElement, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+import { TextTooltip } from "./TextTooltip";
+
+/**
+ * TruncatedCell — 表格单元格「截断 + 溢出 Tooltip」原语（去重全仓 ~20 处习惯写法）。
+ *
+ * 落实 AGENTS.md「UI 表格设计规范」第 3 条：单元格内容单行、超出省略号截断、悬停 Tooltip 全文。
+ * 三种形态由 props 组合覆盖：
+ * 1. **纯文本截断**（默认）：`<TruncatedCell text={value} />` → `<td><TextTooltip><span class="truncate"/></TextTooltip></td>`；
+ * 2. **文本 + 尾图标**（如 ID + CopyButton）：`<TruncatedCell text={key} mono trailing={<CopyButton/>} />`；
+ * 3. **复合单元格**（如状态芯片组合）：`<TruncatedCell text={composeStatusTitle(r)} showOnOverflowOnly={false}>{<div>…chips…</div>}</TruncatedCell>`
+ *    —— 此时 children 为自定义单元格内容，text 仅作 Tooltip 文案，`showOnOverflowOnly` 置 false（复合内容恒弹）。
+ *
+ * 设计参考：[[RoutineTable]]（黄金标准，手写 `<td><TextTooltip><span class="min-w-0 flex-1 truncate">`）。
+ */
+export interface TruncatedCellProps {
+  /** 文本内容（同时作为 Tooltip 文案）。纯文本形态下渲染为截断 span 的内容。 */
+  text?: ReactNode;
+  /** 复合单元格内容（如状态芯片组合）。提供时 text 仅作 Tooltip 文案，不渲染截断 span。 */
+  children?: ReactElement;
+  /** 尾部图标节点（如 CopyButton），与文本同行渲染。 */
+  trailing?: ReactNode;
+  /** `<td>` 类名（默认 `px-4 py-3`，对齐参考表）。 */
+  className?: string;
+  /** 截断 span 的文本类名（字号/颜色/字重等）。 */
+  textClassName?: string;
+  /** 等宽字体（ID/key/cron 等场景）。 */
+  mono?: boolean;
+  /** 是否仅溢出时弹 Tooltip（默认 true；复合形态置 false）。透传给 TextTooltip。 */
+  showOnOverflowOnly?: boolean;
+  /** colspan 透传。 */
+  colSpan?: number;
+}
+
+export function TruncatedCell({
+  text,
+  children,
+  trailing,
+  className,
+  textClassName,
+  mono,
+  showOnOverflowOnly = true,
+  colSpan,
+}: TruncatedCellProps) {
+  // 形态 3：复合单元格（children 提供自定义内容）
+  if (children !== undefined) {
+    return (
+      <td className={cn("px-4 py-3", className)} colSpan={colSpan}>
+        <TextTooltip content={text ?? children} showOnOverflowOnly={showOnOverflowOnly}>
+          {children}
+        </TextTooltip>
+      </td>
+    );
+  }
+
+  const truncateSpan = (
+    <span className={cn("block min-w-0 truncate", mono && "font-mono text-xs", textClassName)}>
+      {text}
+    </span>
+  );
+
+  // 形态 2：文本 + 尾图标
+  if (trailing) {
+    return (
+      <td className={cn("px-4 py-3", className)} colSpan={colSpan}>
+        <div className="flex min-w-0 items-center gap-1">
+          <TextTooltip content={text} showOnOverflowOnly={showOnOverflowOnly}>
+            {truncateSpan}
+          </TextTooltip>
+          {trailing}
+        </div>
+      </td>
+    );
+  }
+
+  // 形态 1：纯文本截断
+  return (
+    <td className={cn("px-4 py-3", className)} colSpan={colSpan}>
+      <TextTooltip content={text} showOnOverflowOnly={showOnOverflowOnly}>
+        {truncateSpan}
+      </TextTooltip>
+    </td>
+  );
+}

--- a/apps/negentropy-ui/components/ui/table-styles.ts
+++ b/apps/negentropy-ui/components/ui/table-styles.ts
@@ -15,12 +15,48 @@
 export const tableContainerClassName =
   "overflow-hidden rounded-xl border border-border bg-card";
 
-/** 表头行视觉（不含布局；调用方再组合 grid/flex）。 */
+/** 表头行视觉（不含布局；调用方再组合 grid/flex）。
+ *  `whitespace-nowrap` 落实「列名禁止折行」（UI 表格设计规范第 3 条）——配合 table-fixed + colgroup
+ *  固定列宽，多词表头（如 "Best Score"/"巡检状态"）在窄视口下亦强制单行。 */
 export const tableHeaderClassName =
-  "border-b border-border px-4 py-2.5 text-xs font-medium uppercase tracking-overline text-text-secondary";
+  "whitespace-nowrap border-b border-border px-4 py-2.5 text-xs font-medium uppercase tracking-overline text-text-secondary";
 
 /** 表体：柔和的横向行分隔线（与参考表 border-border/60 一致）。 */
 export const tableBodyClassName = "divide-y divide-border/60";
 
 /** 数据行视觉（不含布局/grid）：统一内边距与 hover 反馈。 */
 export const tableRowClassName = "px-4 py-3 transition-colors hover:bg-muted/40";
+
+/**
+ * 语义列宽注册表 —— 「相同属性列采用相同固定列宽」（UI 表格设计规范第 2 条）的单一事实源。
+ *
+ * **适用范围（保守）**：仅用于新表与 [[TABLE_COL_WIDTHS]] 首次落地的违规表转换
+ * （`app/knowledge/base/page.tsx` 语料表）。**不**回溯重写既有 9 个合规表的 `<colgroup>` ——
+ * 各表列数不同（Routine 8 / Scheduler 10 / Documents 11），其百分比已各自合 100，
+ * 强制对齐会引发可见的列宽回退（纯 churn，需逐表视觉 sign-off，宜另开 follow-up）。
+ *
+ * 消费方式：`<colgroup><col className={TABLE_COL_WIDTHS.name} /> …</colgroup>`
+ * （注意：`<colgroup>` 内禁止行内 JSX 注释，否则其内部的星斜杠序列会触发 hydration 报错 —— 见 SchedulerTaskTable 先例）。
+ */
+export const TABLE_COL_WIDTHS = {
+  /** 行选择勾选框列（固定窄宽）。 */
+  select: "w-10",
+  /** 主标识列（名称/标题）。 */
+  name: "w-[18%]",
+  /** ID / key 列（含复制按钮）。 */
+  id: "w-[13%]",
+  /** 状态列（状态芯片）。 */
+  status: "w-[13%]",
+  /** 描述 / 摘要列。 */
+  description: "w-[18%]",
+  /** 类型列（handler/trigger/source 等短枚举）。 */
+  kind: "w-[10%]",
+  /** 时间列（created/updated/last/next）。 */
+  time: "w-[8%]",
+  /** 数值指标列（progress/score/cost/size）。 */
+  metric: "w-[7%]",
+  /** 操作列（单行按钮，必要时溢出菜单）。 */
+  actions: "w-[17%]",
+} as const;
+
+export type TableColKey = keyof typeof TABLE_COL_WIDTHS;

--- a/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
+++ b/apps/negentropy-ui/tests/unit/knowledge/KnowledgeBasePage.test.tsx
@@ -405,7 +405,8 @@ describe("KnowledgeBasePage", () => {
       await flushPromises();
     });
 
-    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "更多操作" }));
+    await user.click(screen.getByRole("menuitem", { name: "删除该文档及其全部 Chunks" }));
 
     const dialog = screen.getByRole("dialog", { name: "Delete Document" });
     expect(dialog).toHaveTextContent("example.md");
@@ -435,7 +436,8 @@ describe("KnowledgeBasePage", () => {
       await flushPromises();
     });
 
-    await user.click(screen.getByRole("button", { name: "Delete" }));
+    await user.click(screen.getByRole("button", { name: "更多操作" }));
+    await user.click(screen.getByRole("menuitem", { name: "删除该文档及其全部 Chunks" }));
     const dialog = screen.getByRole("dialog", { name: "Delete Document" });
     await user.click(within(dialog).getByRole("button", { name: "Delete" }));
 


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：`negentropy-ui` 表单普遍为**垂直堆叠**（label 在控件上方），且存在 **4 套不一致**的 input/label 样式约定；表格方面表头会换行、`truncate+Tooltip` 写法重复约 20 处、`base/page` 语料表仍为 `div-grid` 违规。均违反 `AGENTS.md`「UI 表单/表格设计规范」（label 与控件同行且占 1/12 宽度；列宽固定、不折行、省略号+Tooltip）。
- 关联上下文：`AGENTS.md` UI 表单/表格设计规范；前序 #1070（表格 UI 全局对齐）。

# 核心变更
- **新增共享原语（SSOT）**：`Field`/`InlineField`（label 1/12 同行 + 溢出截断 `TextTooltip`，`variant="check"` 处理勾选/开关，`FieldContext` 自动 label↔控件关联）、`Input`/`Select`/`Textarea`（`baseInputCls` 统一历史 4 套约定）、`TruncatedCell`（去重截断写法，三形态：纯文本/尾图标/复合）、`TABLE_COL_WIDTHS` 列宽注册表、表头 `whitespace-nowrap`。
- **表单内联化**：约 25 个表单由垂直堆叠改为水平内联（`col-span-1` label + `col-span-11` 控件），覆盖 Tier-1 配置抽屉（Routine/Scheduler/Repository/Mcp/Skill/Tool/Agent）、动态 API 字段（7 组件）、知识库对话框（Corpus/AddSource/Replace/Import/CreateWiki 等）、长尾面板（ManifestField/graph/wiki/memory）。原无字段级 label 的区块级控件（Payload JSON/System Prompt 等）仅换基类样式，最小干预。
- **表格系统性修复**：表头 `whitespace-nowrap`；违规表 `base/page` 语料 Documents 表转 `<table table-fixed>` + `<colgroup>`，Actions 改单行 + More 溢出 `DropdownMenu`（抽取模块级 `CorpusDocRowActions`）；9 个合规表抽取 `TruncatedCell`。
- **测试同步**：`KnowledgeBasePage` 文档删除经 More 菜单触发（反映新溢出 UX），语料库删除保持直接按钮。

# 风险与回滚
- **主要风险**：表单由多列网格改为单列全宽行，部分抽屉（Routine/Scheduler）变长；1/12 label 在 480px 最窄抽屉下约 35px，长 label 靠省略号 + 悬停 Tooltip 还原全文（已按设计规范决策采用严格 1/12）。
- **回滚方式**：`revert` 本 PR 两个 commit（原语 + 迁移）。

# 验证证据
- **单元测试**：`vitest` **989/989 全绿**（含 `RoutineTable`、`KnowledgeBasePage`、interface layout 等）。
- **静态检查**：`typecheck` + `lint`（`--max-warnings=0`）全绿。
- **E2E/视觉**：待人工借已认证 Chrome 在 dev server 验证（窄/宽抽屉、深色模式、Actions 溢出菜单）。

# 影响范围
- **前端**：`apps/negentropy-ui` 表单与表格组件（约 38 文件 + 5 新原语）。
- **后端**：无。
- **GitHub Actions / 文档**：无。

# Next Best Action
- 视觉验收：`cd apps/negentropy-ui && pnpm exec next dev --webpack -p 3293`，重点核对 `RoutineEditDrawer`/`SchedulerTaskFormDialog`/`RepositoryFormDrawer` 的 label 截断 + Tooltip、`base/page` 语料表 Actions 溢出菜单、深色模式对比度；若 480px 下 label 可读性不佳，可回调 label 列至 `col-span-2`（偏离 1/12 但更可读）。
