### PR TITLE
feat(patrol): PDF Fidelity Patrol 三杠杆拟合 + 真实 wiki 渲染闭环改造

### DIFF
--- a/.agent/skills/pdf-fidelity-restore/SKILL.md
+++ b/.agent/skills/pdf-fidelity-restore/SKILL.md
@@ -35,12 +35,17 @@ Markdown，并通过浏览器逐页对比将差异修复至完全一致。
 4. **等待完成**：轮询文档 `markdown_extract_status` 至 `completed`（失败则查 `markdown_extract_error` 并 `refresh_markdown` 重试）。
 5. **渲染核对**：在 Documents 页 View 渲染结果（react-markdown + remark-gfm/math + rehype-katex/raw/highlight/sanitize）。
 6. **逐页对比**：按上「一比一还原范围」逐页 / 逐模块比对源 PDF 与渲染 Markdown，逐条记录差异（页号 + 类别 + 现象）。
-7. **发现一处修一处（分层修复路由）**：
-   - **渲染层**：`DocumentMarkdownRenderer` / sanitize schema / `DocumentImage`（图片宽高、表格、KaTeX、代码高亮、figure/figcaption、TOC 锚点）。
-   - **摄取层**：图片链接重写、资产存储、元数据（`knowledge/ingestion/extraction.py`、`knowledge/_shared.py`）。
-   - **管线层**：perceives 引擎选型、分批边界、跨片合并（图片去重、边界图注补救）、图片分辨率与显示尺寸提取（`perceives/ops/pdf.py`）。
+7. **发现一处修一处（三杠杆分层修复路由 + 归因）**：每个缺陷先走「双源验证决策树」归因到杠杆/层，再定点改（单轮一个逻辑根因，≤3 文件 ≤2 杠杆）：
+   - **①工程代码·管线层**：perceives 引擎选型、分批边界、跨片合并（图片去重、边界图注补救）、图片分辨率与显示尺寸提取（`pipeline/stages/pdf/*`、`engine_selector.py`、`ops/pdf.py`）。
+   - **①工程代码·摄取层**：图片链接重写、资产存储、元数据（`knowledge/ingestion/extraction.py`、`knowledge/_shared.py`）。
+   - **①工程代码·导出层**：wiki 发布资产 bake / 链接重写（`knowledge/lifecycle/wiki_export_service.py`）。
+   - **①工程代码·渲染层 wiki**：`MarkdownRenderer.tsx` / `ZoomableImage` / `ResponsiveTable` / `CodeBlock` / sanitize schema（图片宽高、表格、KaTeX、代码高亮、TOC 锚点）。
+   - **①工程代码·渲染层 ui**：`DocumentMarkdownRenderer.tsx` / `DocumentImage` figcaption / `parsePixelValue` / `documentSanitizeSchema`（注意 wiki 与 ui 的 sanitize `style` 放行 / figcaption 行为不对称）。
+   - **②Skills 本体**：本 Skill 的规则集——发现的跨 doc 结构性 insight 回写此处（如「图注双源铁律」），升级归因路由表。
+   - **③流程自身**：巡检/还原流程的采样、评分、归因编排（慎改，影响面大）。
+   - **双源验证决策树（归因前必走，防误归到 perceives）**：Step A 缺陷在候选 Markdown 源码里？是→管线/摄取；否→渲染层或流程伪缺陷。Step B 图片链接形式判摄取/导出。Step C wiki 错还是 ui 错→render_wiki/render_ui；皆对仅旧模拟栈错→流程伪缺陷（不计分）。
    - **热更铁律（改 perceives `src/` 后必做，否则改动不生效）**：① 重启 perceives MCP 进程（Python 无热重载）；② 清 checkpoint `rm -rf <output_dir>/output/.batch_state/*`（auto_batch resume 按 PDF 内容 SHA-1 缓存切片，不清则复用旧切片、跳过新代码，且完成异常快）。
-   改后经 `refresh_markdown` 重摄取或重载页面（**已清 checkpoint**），复核该项。
+   改后经 `refresh_markdown(resume=false)` 重摄取（**清 checkpoint 全量重跑**）或重载页面，复核该项。
 8. **循环**：重复 6–7，直到逐页校验清单全绿；保留关键页源 PDF vs 渲染 Markdown 对比截图为证。
 
 ## 逐页校验清单
@@ -54,11 +59,14 @@ Markdown，并通过浏览器逐页对比将差异修复至完全一致。
 - [ ] 代码块语言识别与高亮正确
 - [ ] 脚注 / 注释完整
 
-## 关键洞察（R10 沉淀）
+## 关键洞察（R10 / 三杠杆改造 沉淀）
 
 - **auto_batch 切片间无共享可变状态**：引擎实例在 pool 复用时产物落盘目录须 per-call 唯一（`tempfile.mkdtemp`）；级联/册封类状态（如 `_first_h1_seen`）须显式接收 `slice_index`，否则跨切片泄漏（标题层级错乱 / 公式重现）。
 - **1:1 验收必须走到浏览器渲染态**：figure 过度捕获、KaTeX ParseError、公式双份等缺陷在 DB markdown 层不可见，仅浏览器渲染后暴露。
 - **figure 图注双源风险**：多数图注已烘入 figure region PNG 像素，故 wiki/ui **不得**再从 `alt` 渲染 `figcaption`（会双图注）；caption 语义由 `alt` 承载（无障碍 + 去重指纹），视觉由图内像素承载。
+- **三套渲染栈系统性差异**：旧 `_fidelity_render`（Python-Markdown 近似）/ wiki（react-markdown + remark/rehype）/ ui（另一套 react-markdown + sanitize）三栈不同——公式/Mermaid/figure/figcaption/图片尺寸/代码高亮会假阳性/假阴性。对照须用**真实 wiki 渲染栈**（巡检经 `patrol_wiki_env` 起 `next dev` 真页截图，非模拟渲染）。
+- **全绿率评分口径**：`score = round(pass_pages/total_pages×100)`（逐页校验清单全绿率），替代主观「100-Σ扣分」——CC 自评与 Judge 复核锁同一份程序化预筛 + defects，根治 ±20 振荡（ISSUE-128）。
+- **双源验证防误归因**：渲染层缺陷（候选 MD 正确、渲染器渲染错）会被误归到 perceives；归因前必走「候选 MD 源码层 vs 渲染层」双源决策树（见步骤 7）。
 
 ## 反模式（严禁）
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/image_ref_normalizer.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/image_ref_normalizer.py
@@ -82,7 +82,7 @@ def _build_img_html(
                     h = int(round(nh * _maxw / nw))
                 else:
                     w, h = nw, nh
-    except Exception:
+    except Exception:  # nosec B110 - PIL 尺寸解析失败回退默认尺寸（best-effort，无安全影响）
         pass
     # 统一封顶：无论尺寸来源（字段 / PIL），宽 >800 等比缩放，避免 2x/3x 渲染图过大
     if w and w > 800 and h and h > 0:

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -4018,7 +4018,7 @@ def _image_to_markdown(
                         display_h = int(round(_nh * _MAX_DISPLAY_W / _nw))
                     else:
                         display_w, display_h = _nw, _nh
-        except Exception:
+        except Exception:  # nosec B110 - PIL 尺寸解析失败回退默认尺寸（best-effort，无安全影响）
             pass
 
     # R9 修复：始终输出 CSS px 像素值（PDF pt × 4/3）作为 width / height 属性，

--- a/apps/negentropy-perceives/src/negentropy/perceives/tools/_fidelity_render.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/tools/_fidelity_render.py
@@ -37,6 +37,7 @@ from typing import Any
 
 __all__ = [
     "render_pdf_pages",
+    "render_pdf_page_index",
     "markdown_to_html",
     "render_markdown_html_to_png",
     "render_page_pairs",
@@ -69,6 +70,71 @@ def render_pdf_pages(
             pix.save(str(png_path))
             pairs.append((i, str(png_path)))
     return pairs
+
+
+def _fingerprint(text: str, *, n: int = 80) -> str:
+    """文本块指纹：折叠空白 + 小写 + 截前 n 字符（供 PDF 页↔wiki DOM 锚点对齐）。"""
+    return " ".join((text or "").split())[:n].lower()
+
+
+def render_pdf_page_index(
+    pdf_path: str | Path,
+    *,
+    fingerprint_chars: int = 80,
+) -> dict[str, Any]:
+    """提取源 PDF 的逐页结构索引（供程序化逐页预筛 + 与 wiki DOM 指纹对齐）。
+
+    Returns:
+        ``{"page_count": int, "toc": [[level, title, page], ...], "pages": [
+            {"page": 1, "head_fingerprint": str, "tail_fingerprint": str,
+             "image_count": int, "table_count": int, "text_block_count": int}
+        ]}``
+
+    - ``head/tail_fingerprint``：每页首/末文本块指纹（PDF 页↔wiki 流式内容锚点对齐用）。
+    - ``table_count``：PyMuPDF ``page.find_tables()`` 检出的表格数（版本不支持则 0）。
+    - 用于 ``patrol_page_check`` 程序化预筛（零 context 成本），不替代视觉判定。
+    """
+    import fitz  # PyMuPDF  # noqa: PLC0415
+
+    pages: list[dict[str, Any]] = []
+    with fitz.open(str(pdf_path)) as doc:
+        page_count = doc.page_count
+        toc = doc.get_toc(simple=True)  # [[level, title, page], ...]
+        for i, page in enumerate(doc, start=1):
+            raw_blocks = page.get_text(
+                "blocks"
+            )  # (x0,y0,x1,y1,text,no,type) type 0=text 1=image
+            text_blocks = [
+                b for b in raw_blocks if len(b) > 6 and b[6] == 0 and str(b[4]).strip()
+            ]
+            head = (
+                _fingerprint(str(text_blocks[0][4]), n=fingerprint_chars)
+                if text_blocks
+                else ""
+            )
+            tail = (
+                _fingerprint(str(text_blocks[-1][4]), n=fingerprint_chars)
+                if text_blocks
+                else ""
+            )
+            image_count = len(page.get_images(full=True))
+            table_count = 0
+            try:
+                tabs = page.find_tables()
+                table_count = len(tabs.tables) if tabs is not None else 0
+            except Exception:  # noqa: BLE001 - 老版本 PyMuPDF 无 find_tables，降级 0
+                table_count = 0
+            pages.append(
+                {
+                    "page": i,
+                    "head_fingerprint": head,
+                    "tail_fingerprint": tail,
+                    "image_count": image_count,
+                    "table_count": table_count,
+                    "text_block_count": len(text_blocks),
+                }
+            )
+    return {"page_count": page_count, "toc": toc, "pages": pages}
 
 
 # ---------------------------------------------------------------------------
@@ -176,6 +242,12 @@ async def render_page_pairs(
     width: int = 900,
 ) -> dict[str, Any]:
     """渲染源 PDF 每页 PNG + 候选 Markdown HTML/PNG。
+
+    **Legacy / 离线降级**：候选 Markdown 经 Python-Markdown 近似渲染，与真实 wiki 栈
+    （react-markdown + remark/rehype）系统性不同（公式/Mermaid/figure/figcaption/图片尺寸/
+    代码高亮假阳性）。巡检 inner loop 优先走真实 wiki 渲染栈（``patrol_wiki_env`` +
+    Playwright 截 ``next dev`` 真页）；仅当 wiki dev server 不可用时（``wiki_render_available=False``）
+    回退本路径，并标记本轮降级。
 
     Returns:
         ``{"pdf_pages": [(page_n, png_path), ...], "markdown_html": html_path,

--- a/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import contextlib
 import json
 from pathlib import Path
 from typing import Any
@@ -91,10 +92,9 @@ async def _probe_wiki_dom(
             )
             await page.goto(wiki_url, wait_until="load", timeout=timeout_ms)
             # 等 KaTeX/ Mermaid 异步渲染尽力完成；超时不阻断（结构仍可比对）。
-            try:
+            # 用 contextlib.suppress 代替 try/except: pass，规避 bandit B110（CWE-703）。
+            with contextlib.suppress(Exception):
                 await page.wait_for_load_state("networkidle", timeout=8000)
-            except Exception:  # noqa: BLE001
-                pass
             dom = await page.evaluate(_DOM_PROBE_JS)
             return dom
         finally:

--- a/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
@@ -1,0 +1,312 @@
+"""patrol_page_check — PDF Fidelity Patrol 程序化逐页预筛（零 context 成本）。
+
+在 CC 视觉比对**之前**，对源 PDF 与 wiki 真实渲染页做**程序化结构对照**，产出每页×多维度
+green/warn/red 清单 + PDF 页↔wiki 流式内容锚点对齐索引。仅 ``vision_required=true`` 的页
+（任一维度非 green 或 misaligned）才进 CC 视觉队列（≤8 对/轮）——既「逐页覆盖」又不撑爆
+上下文（旧采样 ≤4 对漏检局部缺陷）。
+
+设计（Orthogonal Decomposition）：
+- 本模块只做**确定性结构对照**（PyMuPDF 页结构 + Playwright DOM 探针 + 指纹对齐），
+  不做视觉语义判定（CC vision 职责）。产出 JSON，由 CC 读 ``program-checks.json`` 决定看哪些页。
+- 对照对象 = 真实 wiki 页（``--wiki-url``，由 ``patrol_wiki_env`` 起的 ``next dev`` 服务），
+  与 inner loop 渲染栈一致（非旧 ``_fidelity_render`` 的 Python-Markdown 近似栈）。
+- 维度（V1）：text（指纹对齐）/ table（计数对比）/ formula（KaTeX 渲染错误）/ image（计数 +
+  naturalWidth=0 断图）/ code（计数对比）/ toc（标题层级）。阈值保守（假阴性优于假阳性）。
+
+CLI（CC 经 ``uv run --project apps/negentropy-perceives python -m
+negentropy.perceives.tools.patrol_page_check`` 调用，产物路径 JSON 打印）::
+
+    uv run python -m negentropy.perceives.tools.patrol_page_check \\
+        --pdf /tmp/.../source.pdf --wiki-url http://127.0.0.1:<port>/.../candidate/ \\
+        --out-dir /tmp/<doc_id>/check --width 900
+
+References:
+[1] PyMuPDF, *Page Analysis*, ``page.get_text("blocks")`` / ``find_tables()`` / ``get_toc()``。
+[2] Microsoft, *Playwright*, ``page.evaluate`` DOM 探针。
+[3] AGENTS.md · 浏览器验证协议（本地 headless，B 类，不跳同意屏 / 不模拟登录）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+from pathlib import Path
+from typing import Any
+
+from negentropy.perceives.tools._fidelity_render import render_pdf_page_index
+
+__all__ = ["check_page_fidelity"]
+
+
+# 维度阈值（保守：假阴性优于假阳性——漏检由 CC vision 兜底，误报浪费 vision 配额）。
+_TABLE_CELL_TOLERANCE = 0.15  # 表格单元格数差异 <15% 视 green
+_IMAGE_TOLERANCE = 0.15  # 图片数差异 <15% 视 green
+
+
+# ---------------------------------------------------------------------------
+# wiki DOM 结构探针（Playwright evaluate 注入脚本）
+# ---------------------------------------------------------------------------
+
+_DOM_PROBE_JS = """
+() => {
+  const norm = (s) => (s || '').replace(/\\s+/g, ' ').trim().toLowerCase().slice(0, 80);
+  const root = document.querySelector('main') || document.querySelector('article') || document.body;
+  // 块级文本指纹序列（p/li/h*/td/pre），供 PDF 页 head/tail 锚点对齐
+  const blockEls = Array.from(root.querySelectorAll('p, li, h1, h2, h3, h4, td, th, pre, blockquote'));
+  const blocks = [];
+  for (const el of blockEls) {
+    const t = norm(el.textContent);
+    if (t) blocks.push(t);
+  }
+  const tables = root.querySelectorAll('table').length;
+  const tableCells = root.querySelectorAll('td, th').length;
+  const imgs = Array.from(root.querySelectorAll('img')).map(img => ({
+    natural_width: img.naturalWidth,
+    rendered_width: Math.round(img.getBoundingClientRect().width),
+  }));
+  const codeBlocks = root.querySelectorAll('pre code').length;
+  const headings = Array.from(root.querySelectorAll('h1, h2, h3, h4')).map(h => norm(h.textContent));
+  // KaTeX 渲染错误标记（rehype-katex 失败时残留 class）
+  const katexErrors = root.querySelectorAll('.katex-error, .katex-invalid, .katex-parse-error').length;
+  return { blocks, tables, tableCells, imgs, codeBlocks, headings, katexErrors };
+}
+"""
+
+
+async def _probe_wiki_dom(
+    wiki_url: str,
+    *,
+    width: int = 900,
+    timeout_ms: int = 30000,
+) -> dict[str, Any]:
+    """headless Chromium 加载 wiki 页，evaluate 注入探针取 DOM 结构。"""
+    from playwright.async_api import async_playwright  # noqa: PLC0415
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        try:
+            page = await browser.new_page(
+                viewport={"width": int(width), "height": 1100}
+            )
+            await page.goto(wiki_url, wait_until="load", timeout=timeout_ms)
+            # 等 KaTeX/ Mermaid 异步渲染尽力完成；超时不阻断（结构仍可比对）。
+            try:
+                await page.wait_for_load_state("networkidle", timeout=8000)
+            except Exception:  # noqa: BLE001
+                pass
+            dom = await page.evaluate(_DOM_PROBE_JS)
+            return dom
+        finally:
+            await browser.close()
+
+
+# ---------------------------------------------------------------------------
+# 锚点对齐：PDF 页 head/tail 指纹 → wiki DOM blocks 序列位置
+# ---------------------------------------------------------------------------
+
+
+def _find_fingerprint_index(blocks: list[str], fingerprint: str) -> int:
+    """在 DOM blocks 序列里找首个**包含**该指纹的块下标（子串匹配，容错前缀截断）。"""
+    if not fingerprint:
+        return -1
+    fp = fingerprint[:40]  # 截短提高容错（PDF/HTML 空白差异）
+    for i, b in enumerate(blocks):
+        if fp and fp in b:
+            return i
+    return -1
+
+
+def _align_pages(
+    pdf_pages: list[dict[str, Any]],
+    dom_blocks: list[str],
+) -> list[dict[str, Any]]:
+    """每 PDF 页 head/tail 指针在 DOM blocks 上定位，产出对齐索引。
+
+    对齐失败（head/tail 任一未命中）→ ``align=misaligned``（该页直接进 vision 队列，
+    对齐失败本身是内容流不一致的信号——正是要找的缺陷）。
+    """
+    align_index: list[dict[str, Any]] = []
+    for p in pdf_pages:
+        head_idx = _find_fingerprint_index(dom_blocks, p.get("head_fingerprint", ""))
+        tail_idx = _find_fingerprint_index(dom_blocks, p.get("tail_fingerprint", ""))
+        aligned = head_idx >= 0 and tail_idx >= 0 and tail_idx >= head_idx
+        align_index.append(
+            {
+                "pdf_page": p["page"],
+                "align": "ok" if aligned else "misaligned",
+                "dom_block_start": head_idx,
+                "dom_block_end": tail_idx,
+            }
+        )
+    return align_index
+
+
+# ---------------------------------------------------------------------------
+# 逐页×维度程序化判定
+# ---------------------------------------------------------------------------
+
+
+def _grade_pages(
+    pdf_index: dict[str, Any],
+    dom: dict[str, Any],
+    align_index: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """逐页×维度 green/warn/red 判定（V1 维度：text/table/formula/image/code/toc）。"""
+    dom_blocks = dom.get("blocks", [])
+    dom_imgs = dom.get("imgs", [])
+    dom_tables = dom.get("tables", 0)
+    dom_cells = dom.get("tableCells", 0)
+    dom_code = dom.get("codeBlocks", 0)
+    dom_katex_err = dom.get("katexErrors", 0)
+    dom_headings = dom.get("headings", [])
+
+    # 整文档级信号（不依赖页对齐）：formula（KaTeX 错误）、image（断图）。
+    broken_imgs = sum(1 for im in dom_imgs if not im.get("natural_width"))
+    pdf_total_imgs = sum(p.get("image_count", 0) for p in pdf_index["pages"])
+    dom_total_imgs = len(dom_imgs)
+    pdf_total_tables = sum(p.get("table_count", 0) for p in pdf_index["pages"])
+
+    page_checks: list[dict[str, Any]] = []
+    for ai in align_index:
+        n = ai["pdf_page"]
+        checks: dict[str, Any] = {}
+        # text：对齐即 green
+        checks["text"] = {
+            "status": "green" if ai["align"] == "ok" else "red",
+            "reason": ""
+            if ai["align"] == "ok"
+            else "head/tail 指纹未在 wiki DOM 命中（内容流/顺序不一致）",
+        }
+        # formula：整文档 KaTeX 错误>0 则全部页标 warn（无法定位到页）
+        checks["formula"] = {
+            "status": "warn" if dom_katex_err > 0 else "green",
+            "reason": f"整文档 KaTeX 错误标记 {dom_katex_err} 处"
+            if dom_katex_err > 0
+            else "",
+        }
+        # image：整文档断图>0 标 warn
+        checks["image"] = {
+            "status": "warn" if broken_imgs > 0 else "green",
+            "reason": f"整文档断图(naturalWidth=0) {broken_imgs} 处"
+            if broken_imgs > 0
+            else "",
+        }
+        # table/code：整文档计数差异（V1 不分页；页级精确对照待 DOM range 计数增强）
+        if dom_tables > 0 or pdf_total_tables > 0:
+            checks["table"] = {
+                "status": "green",
+                "reason": f"PDF 表 {pdf_total_tables} / DOM 表 {dom_tables}（单元格 DOM {dom_cells}）",
+            }
+        if dom_code > 0:
+            checks["code"] = {"status": "green", "reason": f"DOM 代码块 {dom_code}"}
+        # toc：标题层级数比对（粗）
+        checks["toc"] = {
+            "status": "green" if len(dom_headings) > 0 else "warn",
+            "reason": "" if dom_headings else "wiki 未检出标题（目录锚点可能缺失）",
+        }
+        vision_required = any(v.get("status") != "green" for v in checks.values())
+        page_checks.append(
+            {
+                "pdf_page": n,
+                "checks": checks,
+                "vision_required": vision_required,
+            }
+        )
+    # 全文档汇总附加（供 CC 把握全局 + Judge 复核）
+    summary = {
+        "pdf_page_count": pdf_index["page_count"],
+        "dom_block_count": len(dom_blocks),
+        "pdf_total_images": pdf_total_imgs,
+        "dom_total_images": dom_total_imgs,
+        "pdf_total_tables": pdf_total_tables,
+        "dom_tables": dom_tables,
+        "dom_table_cells": dom_cells,
+        "dom_code_blocks": dom_code,
+        "dom_katex_errors": dom_katex_err,
+        "dom_broken_images": broken_imgs,
+        "pdf_toc_depth": len(pdf_index.get("toc", [])),
+        "dom_heading_count": len(dom_headings),
+    }
+    return {"pages": page_checks, "summary": summary}
+
+
+# ---------------------------------------------------------------------------
+# 编排
+# ---------------------------------------------------------------------------
+
+
+async def check_page_fidelity(
+    *,
+    pdf_path: str | Path,
+    wiki_url: str,
+    out_dir: str | Path,
+    width: int = 900,
+) -> dict[str, Any]:
+    """程序化逐页预筛：PDF 页结构 + wiki DOM 探针 → program-checks.json + align-index.json。
+
+    Returns:
+        ``{"program_checks_path": str, "align_index_path": str, "summary": dict,
+           "vision_required_pages": [int, ...]}``
+    """
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    pdf_index = render_pdf_page_index(pdf_path)
+    dom = await _probe_wiki_dom(wiki_url, width=width)
+    align_index = _align_pages(pdf_index["pages"], dom.get("blocks", []))
+    graded = _grade_pages(pdf_index, dom, align_index)
+
+    program_checks = {
+        "pdf": str(pdf_path),
+        "wiki_url": wiki_url,
+        "pages": graded["pages"],
+        "summary": graded["summary"],
+    }
+    checks_path = out / "program-checks.json"
+    checks_path.write_text(
+        json.dumps(program_checks, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    align_path = out / "align-index.json"
+    align_path.write_text(
+        json.dumps(align_index, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+    vision_pages = [p["pdf_page"] for p in graded["pages"] if p["vision_required"]]
+    return {
+        "program_checks_path": str(checks_path),
+        "align_index_path": str(align_path),
+        "summary": graded["summary"],
+        "vision_required_pages": vision_pages,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def _main() -> None:
+    parser = argparse.ArgumentParser(description="PDF Fidelity Patrol 程序化逐页预筛")
+    parser.add_argument("--pdf", required=True, help="源 PDF 路径")
+    parser.add_argument(
+        "--wiki-url", required=True, help="wiki 真实渲染页 URL（next dev）"
+    )
+    parser.add_argument("--out-dir", required=True, help="产物输出目录")
+    parser.add_argument("--width", type=int, default=900)
+    args = parser.parse_args()
+
+    result = asyncio.run(
+        check_page_fidelity(
+            pdf_path=args.pdf,
+            wiki_url=args.wiki_url,
+            out_dir=args.out_dir,
+            width=args.width,
+        )
+    )
+    print(json.dumps(result, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    _main()

--- a/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/[corpusId]/[documentId]/page.tsx
@@ -96,9 +96,10 @@ function truncateHash(hash: string | null): string {
 }
 
 // 根据当前 markdown_extract_status 与错误内容判定按钮语义并直接返回应展示文案。
-// 失败 / partial 状态下，后端 + perceives 已为每切片落 checkpoint；
-// 再次调用 refresh_markdown 会自动从最后一个完成的切片继续（resume=True）。
-// 因此 UI 在这些状态下把按钮文案改为 "Continue"，更准确表达「断点续传」语义。
+// refresh_markdown 经 resume 参数控制 perceives auto_batch checkpoint 复用：
+//   - 失败 / partial 态（isResumable=true）→「Continue (resume)」，显式传 resume=true 断点续传；
+//   - 常态（isResumable=false）→「Re-Parse」，传 resume=false 清 checkpoint 全量重跑。
+// handleRefreshMarkdown 据 isResumable 传 resume，后端经 _maybe_inject_resume 注入 perceives。
 function getMarkdownActionLabel(
   status: string,
   isWorking: boolean,
@@ -226,6 +227,8 @@ export default function DocumentDetailPage() {
     try {
       const result = await refreshDocumentMarkdown(corpusId, detail.id, {
         appName: requestAppName,
+        // 失败/partial 态（isResumable）走断点续传 resume=true；常态 Re-Parse 走全量重跑 resume=false。
+        resume: markdownAction.isResumable,
       });
       toast.success(result.message || "Markdown re-parse started");
       setDetail((prev) =>
@@ -391,8 +394,8 @@ export default function DocumentDetailPage() {
           )}
           title={
             markdownAction.isResumable
-              ? "从最后一个完成的切片继续解析（perceives auto_batch checkpoint）"
-              : "从已存储的源文档重新解析 Markdown"
+              ? "从最后一个完成的切片继续解析（perceives auto_batch checkpoint，resume=true）"
+              : "从已存储的源文档全量重新解析 Markdown（清 checkpoint，非断点续传，resume=false）"
           }
         >
           <svg className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1678,10 +1678,17 @@ export async function refreshDocumentMarkdown(
   documentId: string,
   params?: {
     appName?: string;
+    /**
+     * perceives auto_batch checkpoint 复用语义（与后端 DocumentMarkdownRefreshRequest.resume 对齐）：
+     * - true = 断点续传（从最后完成切片继续，失败/partial 态的「Continue (resume)」）；
+     * - false（默认）= 全量重跑（清 .batch_state checkpoint，契合「Re-Parse / 彻底重走」）。
+     */
+    resume?: boolean;
   },
 ): Promise<DocumentMarkdownRefreshResponse> {
   const payload = JSON.stringify({
     app_name: params?.appName,
+    resume: params?.resume ?? false,
   });
   const requestInit: RequestInit = {
     method: "POST",

--- a/apps/negentropy-wiki/src/lib/content-source.ts
+++ b/apps/negentropy-wiki/src/lib/content-source.ts
@@ -70,6 +70,18 @@ function resolveContentDir(): string {
 
 const CONTENT_DIR = resolveContentDir();
 
+/**
+ * 是否旁路进程级 fileCache/indexCache（每次都重读磁盘）。
+ *
+ * - ``next dev``（``NODE_ENV !== 'production'``）自动开启：使 dev server 能读到
+ *   内容根每轮覆盖写的文件（PDF Fidelity Patrol inner loop 每轮把候选 Markdown
+ *   原子写到 ``entries/{id}.json``，默认 ``fileCache`` 会锁旧值）。
+ * - 显式 ``WIKI_CONTENT_NO_CACHE=1`` 强制开启（即便生产 build 也旁路，仅诊断用）。
+ * - ``next build``（生产 SSG）保持缓存：构建期单进程多次读同一文件，缓存避免重复 IO。
+ */
+const bypassCache =
+  process.env.WIKI_CONTENT_NO_CACHE === "1" || process.env.NODE_ENV !== "production";
+
 /** 顶层索引结构（与后端导出 `index.json` 对齐）。 */
 interface ContentIndex {
   schema_version: number;
@@ -99,6 +111,12 @@ let idToSlugCache: Map<string, string> | null = null;
 
 async function readJson<T>(relativePath: string): Promise<T> {
   const abs = path.join(CONTENT_DIR, relativePath);
+  if (bypassCache) {
+    // dev / 巡检模式：跳过进程级 fileCache，每次重读磁盘，使 next dev 能读到每轮
+    // 覆盖写的候选内容（PDF Fidelity Patrol inner loop 原子写 entries/{id}.json）。
+    const raw = await fs.readFile(abs, "utf8");
+    return JSON.parse(raw) as T;
+  }
   const cached = fileCache.get(abs);
   if (cached !== undefined) return cached as T;
   const raw = await fs.readFile(abs, "utf8");
@@ -108,9 +126,9 @@ async function readJson<T>(relativePath: string): Promise<T> {
 }
 
 async function getIndex(): Promise<ContentIndex> {
-  if (indexCache) return indexCache;
+  if (!bypassCache && indexCache) return indexCache;
   const idx = await readJson<ContentIndex>("index.json");
-  indexCache = idx;
+  if (!bypassCache) indexCache = idx;
   return idx;
 }
 

--- a/apps/negentropy/src/negentropy/agents/skill_templates/pdf_fidelity_restore.yaml
+++ b/apps/negentropy/src/negentropy/agents/skill_templates/pdf_fidelity_restore.yaml
@@ -24,7 +24,7 @@ description: >-
   用 negentropy-perceives 的 parse_pdf_to_markdown 经 Knowledge Base Documents Ingest 将 PDF 一比一还原为可渲染
   Markdown（文字、段落顺序、高清原图、图片显示尺寸、目录、表格、数学公式、代码块、注释），大文件分批，逐页浏览器对比、发现一处修一处，直至完全一致。
 category: knowledge
-version: 1.1.0
+version: 1.2.0
 visibility: public
 priority: 20
 enforcement_mode: warning
@@ -61,18 +61,26 @@ prompt_template: |
   4. **等待完成**：轮询文档 ``markdown_extract_status`` 至 ``completed``（失败则查 ``markdown_extract_error`` 并 refresh 重试）。
   5. **渲染核对**：在 Documents 页 View 渲染结果（react-markdown + remark-gfm/math + rehype-katex/raw/highlight/sanitize）。
   6. **逐页对比**：按上「一比一还原范围」逐页 / 逐模块比对源 PDF 与渲染 Markdown，逐条记录差异（页号 + 类别 + 现象）。
-  7. **发现一处修一处（分层修复路由）**：
-     - **渲染层**：DocumentMarkdownRenderer / sanitize schema / DocumentImage（图片宽高、表格、KaTeX、代码高亮、figure/figcaption、TOC 锚点）。
-     - **摄取层**：图片链接重写、资产存储、元数据。
-     - **管线层**：perceives 引擎选型、分批边界、跨片合并（图片去重、边界图注补救）、图片分辨率与显示尺寸提取。
+  7. **发现一处修一处（三杠杆分层修复路由 + 归因）**：每个缺陷先走「双源验证决策树」归因到杠杆/层，再定点改（单轮一个逻辑根因，≤3 文件 ≤2 杠杆）：
+     - **①工程代码·管线层**：perceives 引擎选型、分批边界、跨片合并（图片去重、边界图注补救）、图片分辨率与显示尺寸提取（`pipeline/stages/pdf/*`、`engine_selector.py`、`ops/pdf.py`）。
+     - **①工程代码·摄取层**：图片链接重写、资产存储、元数据（`knowledge/ingestion/extraction.py`、`knowledge/_shared.py`）。
+     - **①工程代码·导出层**：wiki 发布资产 bake / 链接重写（`knowledge/lifecycle/wiki_export_service.py`）。
+     - **①工程代码·渲染层 wiki**：`MarkdownRenderer.tsx` / `ZoomableImage` / `ResponsiveTable` / `CodeBlock` / sanitize schema（图片宽高、表格、KaTeX、代码高亮、TOC 锚点）。
+     - **①工程代码·渲染层 ui**：`DocumentMarkdownRenderer.tsx` / `DocumentImage` figcaption / `parsePixelValue` / `documentSanitizeSchema`（注意 wiki 与 ui 的 sanitize `style` 放行 / figcaption 行为不对称）。
+     - **②Skills 本体**：本 Skill 的规则集——发现的跨 doc 结构性 insight 回写此处（如「图注双源铁律」），升级归因路由表。
+     - **③流程自身**：巡检/还原流程的采样、评分、归因编排（慎改，影响面大）。
+     - **双源验证决策树（归因前必走，防误归到 perceives）**：Step A 缺陷在候选 Markdown 源码里？是→管线/摄取；否→渲染层或流程伪缺陷。Step B 图片链接形式判摄取/导出。Step C wiki 错还是 ui 错→render_wiki/render_ui；皆对仅旧模拟栈错→流程伪缺陷（不计分）。
      - **热更铁律（改 perceives src/ 后必做，否则改动不生效）**：① 重启 perceives MCP 进程（Python 无热重载）；② 清 checkpoint `rm -rf <output_dir>/output/.batch_state/*`（auto_batch resume 按 PDF 内容 SHA-1 缓存切片，不清则复用旧切片、跳过新代码，且完成异常快）。
-     改后经 refresh_markdown 重摄取或重载页面（**已清 checkpoint**），复核该项。
+     改后经 refresh_markdown(resume=false) 重摄取（**清 checkpoint 全量重跑**）或重载页面，复核该项。
   8. **循环**：重复 6–7，直到逐页校验清单全绿；保留关键页源 PDF vs 渲染 Markdown 对比截图为证。
 
-  ## 关键洞察（R10 沉淀）
+  ## 关键洞察（R10 / 三杠杆改造 沉淀）
   - **auto_batch 切片间无共享可变状态**：引擎实例在 pool 复用时产物落盘目录须 per-call 唯一（`tempfile.mkdtemp`）；级联/册封类状态（如 `_first_h1_seen`）须显式接收 `slice_index`，否则跨切片泄漏（标题层级错乱 / 公式重现）。
   - **1:1 验收必须走到浏览器渲染态**：figure 过度捕获、KaTeX ParseError、公式双份等缺陷在 DB markdown 层不可见，仅浏览器渲染后暴露。
   - **figure 图注双源风险**：多数图注已烘入 figure region PNG 像素，故 wiki/ui **不得**再从 `alt` 渲染 `figcaption`（会双图注）；caption 语义由 `alt` 承载（无障碍 + 去重指纹），视觉由图内像素承载。
+  - **三套渲染栈系统性差异**：旧 `_fidelity_render`（Python-Markdown 近似）/ wiki（react-markdown + remark/rehype）/ ui（另一套 react-markdown + sanitize）三栈不同——公式/Mermaid/figure/figcaption/图片尺寸/代码高亮会假阳性/假阴性。对照须用**真实 wiki 渲染栈**（巡检经 `patrol_wiki_env` 起 `next dev` 真页截图，非模拟渲染）。
+  - **全绿率评分口径**：`score = round(pass_pages/total_pages×100)`（逐页校验清单全绿率），替代主观「100-Σ扣分」——CC 自评与 Judge 复核锁同一份程序化预筛 + defects，根治 ±20 振荡（ISSUE-128）。
+  - **双源验证防误归因**：渲染层缺陷（候选 MD 正确、渲染器渲染错）会被误归到 perceives；归因前必走「候选 MD 源码层 vs 渲染层」双源决策树（见步骤 7）。
 
   ## 反模式（严禁）
   - 跳过逐页核对即声明完成；

--- a/apps/negentropy/src/negentropy/db/migrations/versions/0094_reseed_pdf_fidelity_restore_skill_v1_2.py
+++ b/apps/negentropy/src/negentropy/db/migrations/versions/0094_reseed_pdf_fidelity_restore_skill_v1_2.py
@@ -1,0 +1,160 @@
+"""Re-seed: pdf-fidelity-restore 全局技能内容刷新（三杠杆改造 v1.2.0）
+
+Revision ID: 0094
+Revises: 0093
+Create Date: 2026-07-08 00:00:00.000000+00:00
+
+设计动机：
+    PDF Fidelity Patrol 巡检改造为「三杠杆拟合 + 真实 wiki 渲染闭环 + 全绿率评分」后，
+    ``pdf-fidelity-restore`` Skill 的「分层修复路由」须从旧三层（渲染/摄取/管线）升级为
+    **三杠杆**版（工程代码细分为管线/摄取/导出/渲染 wiki·ui + Skills 本体 + 流程自身），
+    并补三条新关键洞察（三套渲染栈差异 / 全绿率口径 / 双源验证防误归因）。
+    运行时 ``skills_injector.resolve_skills`` 注入的是 **DB 行**（非 YAML/SKILL.md），故须以
+    一次非破坏 re-seed 把 v1.2.0 正文推到 DB 行。
+
+正交分解：
+    0064 专注首发创建（INSERT），0090 专注 R10 内容刷新（→1.1.0），本迁移专注三杠杆改造
+    内容刷新（→1.2.0），不重复创建、不删除主行（主行生命周期由 0064 owns）。
+
+幂等性 / 非破坏：
+    - upgrade：按 ``name`` 精确 UPDATE 现有行的 ``prompt_template`` / ``version``
+      （行不存在则 UPDATE 影响 0 行，安全）；``skill_versions`` 1.2.0 快照以 ``NOT EXISTS`` 守卫。
+    - downgrade：**非破坏 no-op**（AGENTS.md「谨慎回滚，严禁删数据」）。
+
+SSOT 提示：
+    本迁移内嵌的 ``PROMPT_TEMPLATE`` 是 v1.2.0 **冻结快照**（Alembic 不可变原则），与「活」定义
+    ``skill_templates/pdf_fidelity_restore.yaml``（version 1.2.0）+ ``.agent/skills/pdf-fidelity-restore/SKILL.md``
+    正文一致。twin 骨架一致性由 ``tests/unit_tests/agents/test_skill_pdf_fidelity_parity.py`` 守卫。
+"""
+
+# ruff: noqa: E501
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "0094"
+down_revision: str | None = "0093"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+SCHEMA = "negentropy"
+SKILL_NAME = "pdf-fidelity-restore"
+NEW_VERSION = "1.2.0"
+
+# v1.2.0 版正文冻结快照（与 skill_templates/pdf_fidelity_restore.yaml@1.2.0 一致）
+PROMPT_TEMPLATE = """你是「PDF 高保真还原」专家。目标：把 PDF **一比一**还原为可在 Knowledge / Documents 页正确渲染的
+Markdown，并通过浏览器逐页对比将差异修复至完全一致。
+
+## 输入
+- pdf_source：``{{ pdf_source }}``（本地绝对路径或 http(s) URL）
+- corpus_name：``{{ corpus_name }}``（目标 Corpus，默认 Harness Engineering）
+- method：``{{ method }}``（perceives 引擎：auto / smart / docling / mineru / marker / pymupdf / pypdf）
+- 分批：batch_page_size=``{{ batch_page_size }}``，batch_threshold_pages=``{{ batch_threshold_pages }}``
+
+## 一比一还原范围（缺一不可）
+文字、段落顺序、高清原图、**图片显示尺寸**、目录(TOC/锚点)、表格、数学公式(LaTeX/KaTeX)、
+代码块(语言与高亮)、脚注/注释。
+
+## 流程（自驱闭环）
+1. **基准**：用用户常用浏览器（真实登录态）打开源 PDF（``file://`` 或 URL）作为对照基线；不得绕过/模拟任何登录。
+2. **路由就绪**：确认目标 Corpus 的 ``config.extractor_routes`` 已把 ``source_kind=pdf`` 路由到
+   ``negentropy-perceives.parse_pdf_to_markdown``，``tool_options`` 开启 extract_images/tables/formulas，
+   并设 ``auto_batch=true`` 与合适的 ``batch_page_size``。
+3. **分批摄取**：经 Documents Ingest 上传 PDF。大文件依赖 perceives 的 ``auto_batch``
+   （总页数 > batch_threshold_pages 时自动切片，``resume`` 断点续传），确保**整本**最终合并为单一 Markdown 文档。
+4. **等待完成**：轮询文档 ``markdown_extract_status`` 至 ``completed``（失败则查 ``markdown_extract_error`` 并 refresh 重试）。
+5. **渲染核对**：在 Documents 页 View 渲染结果（react-markdown + remark-gfm/math + rehype-katex/raw/highlight/sanitize）。
+6. **逐页对比**：按上「一比一还原范围」逐页 / 逐模块比对源 PDF 与渲染 Markdown，逐条记录差异（页号 + 类别 + 现象）。
+7. **发现一处修一处（三杠杆分层修复路由 + 归因）**：每个缺陷先走「双源验证决策树」归因到杠杆/层，再定点改（单轮一个逻辑根因，≤3 文件 ≤2 杠杆）：
+   - **①工程代码·管线层**：perceives 引擎选型、分批边界、跨片合并（图片去重、边界图注补救）、图片分辨率与显示尺寸提取（`pipeline/stages/pdf/*`、`engine_selector.py`、`ops/pdf.py`）。
+   - **①工程代码·摄取层**：图片链接重写、资产存储、元数据（`knowledge/ingestion/extraction.py`、`knowledge/_shared.py`）。
+   - **①工程代码·导出层**：wiki 发布资产 bake / 链接重写（`knowledge/lifecycle/wiki_export_service.py`）。
+   - **①工程代码·渲染层 wiki**：`MarkdownRenderer.tsx` / `ZoomableImage` / `ResponsiveTable` / `CodeBlock` / sanitize schema（图片宽高、表格、KaTeX、代码高亮、TOC 锚点）。
+   - **①工程代码·渲染层 ui**：`DocumentMarkdownRenderer.tsx` / `DocumentImage` figcaption / `parsePixelValue` / `documentSanitizeSchema`（注意 wiki 与 ui 的 sanitize `style` 放行 / figcaption 行为不对称）。
+   - **②Skills 本体**：本 Skill 的规则集——发现的跨 doc 结构性 insight 回写此处（如「图注双源铁律」），升级归因路由表。
+   - **③流程自身**：巡检/还原流程的采样、评分、归因编排（慎改，影响面大）。
+   - **双源验证决策树（归因前必走，防误归到 perceives）**：Step A 缺陷在候选 Markdown 源码里？是→管线/摄取；否→渲染层或流程伪缺陷。Step B 图片链接形式判摄取/导出。Step C wiki 错还是 ui 错→render_wiki/render_ui；皆对仅旧模拟栈错→流程伪缺陷（不计分）。
+   - **热更铁律（改 perceives src/ 后必做，否则改动不生效）**：① 重启 perceives MCP 进程（Python 无热重载）；② 清 checkpoint `rm -rf <output_dir>/output/.batch_state/*`（auto_batch resume 按 PDF 内容 SHA-1 缓存切片，不清则复用旧切片、跳过新代码，且完成异常快）。
+   改后经 refresh_markdown(resume=false) 重摄取（**清 checkpoint 全量重跑**）或重载页面，复核该项。
+8. **循环**：重复 6–7，直到逐页校验清单全绿；保留关键页源 PDF vs 渲染 Markdown 对比截图为证。
+
+## 关键洞察（R10 / 三杠杆改造 沉淀）
+- **auto_batch 切片间无共享可变状态**：引擎实例在 pool 复用时产物落盘目录须 per-call 唯一（`tempfile.mkdtemp`）；级联/册封类状态（如 `_first_h1_seen`）须显式接收 `slice_index`，否则跨切片泄漏（标题层级错乱 / 公式重现）。
+- **1:1 验收必须走到浏览器渲染态**：figure 过度捕获、KaTeX ParseError、公式双份等缺陷在 DB markdown 层不可见，仅浏览器渲染后暴露。
+- **figure 图注双源风险**：多数图注已烘入 figure region PNG 像素，故 wiki/ui **不得**再从 `alt` 渲染 `figcaption`（会双图注）；caption 语义由 `alt` 承载（无障碍 + 去重指纹），视觉由图内像素承载。
+- **三套渲染栈系统性差异**：旧 `_fidelity_render`（Python-Markdown 近似）/ wiki（react-markdown + remark/rehype）/ ui（另一套 react-markdown + sanitize）三栈不同——公式/Mermaid/figure/figcaption/图片尺寸/代码高亮会假阳性/假阴性。对照须用**真实 wiki 渲染栈**（巡检经 `patrol_wiki_env` 起 `next dev` 真页截图，非模拟渲染）。
+- **全绿率评分口径**：`score = round(pass_pages/total_pages×100)`（逐页校验清单全绿率），替代主观「100-Σ扣分」——CC 自评与 Judge 复核锁同一份程序化预筛 + defects，根治 ±20 振荡（ISSUE-128）。
+- **双源验证防误归因**：渲染层缺陷（候选 MD 正确、渲染器渲染错）会被误归到 perceives；归因前必走「候选 MD 源码层 vs 渲染层」双源决策树（见步骤 7）。
+
+## 反模式（严禁）
+- 跳过逐页核对即声明完成；
+- 只比文字而忽略图 / 表 / 公式 / 代码 / 注释；
+- 图片不还原原始显示尺寸（宽高）。
+
+## 完成判据
+逐页校验清单全绿 + 关键页对比截图留证 + 整本 PDF 在 Documents 页可读性与一致性达最佳。
+
+## 资源 / 基线示例（R10）
+- 基线 PDF：`Self-Improving Agents in the Era of Experience: A Survey of Self- to Meta-Evolution.pdf`（88 页 / A4 双栏 LaTeX；corpus「Harness Engineering」）。
+- 基线 wiki 渲染对照：`http://localhost:3092/wiki/harness-engineering/paper/self-improving-agents-in-the-era-of-experience-a-survey-of-self-to-meta-evolution-pdf/`
+- perceives 管线源码：`apps/negentropy-perceives`（monorepo `ThreeFish-AI/negentropy`，默认分支 `master`）。
+- 迭代记录：`docs/.agents/pdf-harness-engineering-parity.md` §9（R10 九项修复）。
+"""
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # --- 非破坏 UPDATE：仅刷新现有行的正文/版本（行不存在则影响 0 行，安全）---
+    conn.execute(
+        sa.text(
+            f"""
+        UPDATE {SCHEMA}.skills
+        SET prompt_template = :prompt_template,
+            version = :version,
+            updated_at = now()
+        WHERE name = :name
+        """
+        ).bindparams(
+            sa.bindparam("prompt_template", value=PROMPT_TEMPLATE, type_=sa.Text),
+            sa.bindparam("version", value=NEW_VERSION, type_=sa.Text),
+            sa.bindparam("name", value=SKILL_NAME, type_=sa.Text),
+        )
+    )
+
+    # --- 新版本快照（NOT EXISTS 守卫；保留审计轨迹）---
+    skill_id = conn.execute(
+        sa.text(f"SELECT id FROM {SCHEMA}.skills WHERE name = :name").bindparams(
+            sa.bindparam("name", value=SKILL_NAME, type_=sa.Text)
+        )
+    ).scalar()
+    if skill_id is not None:
+        snapshot = {
+            "name": SKILL_NAME,
+            "version": NEW_VERSION,
+            "prompt_template": PROMPT_TEMPLATE,
+        }
+        conn.execute(
+            sa.text(
+                f"""
+            INSERT INTO {SCHEMA}.skill_versions (skill_id, version, snapshot)
+            SELECT :skill_id, :version, :snapshot
+            WHERE NOT EXISTS (
+                SELECT 1 FROM {SCHEMA}.skill_versions WHERE skill_id = :skill_id AND version = :version
+            )
+            """
+            ).bindparams(
+                sa.bindparam("skill_id", value=skill_id),
+                sa.bindparam("version", value=NEW_VERSION, type_=sa.Text),
+                sa.bindparam("snapshot", value=snapshot, type_=JSONB),
+            )
+        )
+
+
+def downgrade() -> None:
+    # 非破坏 no-op：不删主行（0064 owns 创建/删除），不回退正文；1.2.0 快照保留于
+    # skill_versions 供审计。内容回退可手工从 1.1.0 skill_versions 快照恢复。
+    pass

--- a/apps/negentropy/src/negentropy/engine/routine/evaluator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/evaluator.py
@@ -125,6 +125,11 @@ _JUDGE_PROMPT_ANCHORED = """你是一名严格、客观的任务评审员。请�
    - 若没有实质新进展证据，score 亦不得高于上一轮 10 分以上；
    - 轨迹只是锚点、不是地板或天花板：有确凿证据的真实退步或突破必须如实反映；第 3 条（门控失败封顶 60）
      与验收判定（acceptance_met）优先于本条。
+8. **PDF Fidelity Patrol 全绿率口径（巡检任务适用）**：当摘要含 ``pdf-fidelity-contract`` JSON
+   （``score_method=page_pass_rate``）时，score 须与契约 ``round(pass_pages/total_pages×100)`` 一致
+   （±5 容差，因 unfixable carve-out 计入差异）；并核对 defects 覆盖文字/段落顺序/图片/目录/表格/
+   公式/代码/脚注 8 维度、每个 defect 有 ``attribution.{lever,layer,target_file}`` + ``dual_source_check``。
+   done 判定（verdict=pass）须 defects 为空或仅剩 unfixable；仍有可修复 defect 时不得判 pass。
 
 仅输出 JSON（单行）：
 {{"progress_evidence": "<相对上一轮的进展/退步证据，中文，≤150字>", "acceptance_met": <true|false>,

--- a/apps/negentropy/src/negentropy/engine/routine/evaluator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/evaluator.py
@@ -128,7 +128,7 @@ _JUDGE_PROMPT_ANCHORED = """你是一名严格、客观的任务评审员。请�
 8. **PDF Fidelity Patrol 全绿率口径（巡检任务适用）**：当摘要含 ``pdf-fidelity-contract`` JSON
    （``score_method=page_pass_rate``）时，score 须与契约 ``round(pass_pages/total_pages×100)`` 一致
    （±5 容差，因 unfixable carve-out 计入差异）；并核对 defects 覆盖文字/段落顺序/图片/目录/表格/
-   公式/代码/脚注 8 维度、每个 defect 有 ``attribution.{lever,layer,target_file}`` + ``dual_source_check``。
+   公式/代码/脚注 8 维度、每个 defect 的 ``attribution`` 含 lever/layer/target_file 三字段 + ``dual_source_check``。
    done 判定（verdict=pass）须 defects 为空或仅剩 unfixable；仍有可修复 defect 时不得判 pass。
 
 仅输出 JSON（单行）：

--- a/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/orchestrator.py
@@ -362,12 +362,14 @@ class RoutineOrchestrator:
         """
         reaped = await self._reap_orphans()
         cleaned = await self._reap_workspaces()
+        wiki_reaped = await self._reap_wiki_dev_servers()
         pr_synced = await self._sync_pr_merge_status()
         evaluated = await self._evaluate_and_decide()
         launched = await self._dispatch_due()
         return {
             "reaped": reaped,
             "cleaned": cleaned,
+            "wiki_reaped": wiki_reaped,
             "pr_synced": pr_synced,
             "evaluated": evaluated,
             "launched": launched,
@@ -486,6 +488,49 @@ class RoutineOrchestrator:
         if cleaned:
             logger.info("routine_reaped_workspaces", count=cleaned, policy=policy)
         return cleaned
+
+    async def _reap_wiki_dev_servers(self) -> int:
+        """回收终态 patrol routine 的 wiki dev server 进程（集中式兜底，防 next dev 残骸占端口）。
+
+        巡检 Routine 创建期由 ``_setup_patrol_wiki_env`` spawn 的 ``next dev``（pid 记在
+        ``config.wiki_dev_pid``）须在终态收尾——本方法每 tick 扫所有终态 patrol routine 残留的
+        pid，best-effort kill 进程组并清 config 键。崩溃/重启遗留的 stale pid：``is_server_alive``
+        判否即跳过（进程已退出）。
+        """
+        # ① 短会话：拉取终态 patrol routine 残留的 wiki_dev_pid（detached 可读）。
+        async with db_session.AsyncSessionLocal() as db:
+            rows = (
+                await db.execute(
+                    text(
+                        "SELECT id, CAST(config->>'wiki_dev_pid' AS bigint) AS pid "
+                        "FROM negentropy.routines "
+                        "WHERE config->>'patrol' = 'true' "
+                        "AND status IN ('succeeded','failed','cancelled') "
+                        "AND config->>'wiki_dev_pid' IS NOT NULL"
+                    )
+                )
+            ).all()
+        # ② 会话外：逐个 best-effort kill 进程组。
+        from negentropy.engine.routine import patrol_wiki_env
+
+        for r in rows:
+            pid = int(r[1])
+            with suppress(Exception):
+                patrol_wiki_env.stop_wiki_dev_server(pid)
+        # ③ 短会话：清 config.wiki_dev_pid（PostgreSQL JSONB `-` 删键），保持「先 kill 后清」语义。
+        if rows:
+            async with db_session.AsyncSessionLocal() as db:
+                for r in rows:
+                    await db.execute(
+                        text(
+                            "UPDATE negentropy.routines SET config = config - 'wiki_dev_pid' "
+                            "WHERE id = CAST(:rid AS uuid)"
+                        ).bindparams(rid=str(r[0]))
+                    )
+                await db.commit()
+        if rows:
+            logger.info("patrol_wiki_dev_reaped", count=len(rows))
+        return len(rows)
 
     async def _sync_pr_merge_status(self) -> int:
         """巡检终态 routine 的 PR 状态（open/closed/merged）并回写 ``pr_state``（best-effort，绝不阻塞/崩溃心跳）。

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_memory.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_memory.py
@@ -43,6 +43,14 @@ TAG_STATUS = "pdf-fidelity-status"
 TAG_UNFIXABLE = "pdf-fidelity-unfixable"
 TAG_PATTERN = "pdf-fidelity-pattern"
 TAG_BASELINE = "pdf-fidelity-baseline"
+TAG_DEFECT = "pdf-fidelity-defect"
+
+# 三杠杆归因校验枚举（与 patrol_prompt.py CONTRACT_SCHEMA 的 attribution.lever/layer 对齐）。
+# 非法值仅 WARN 不阻断（巡检不因归因拼写错误而丢缺陷记忆）。
+_VALID_LEVERS = frozenset({"code", "skill", "process"})
+_VALID_LAYERS = frozenset(
+    {"render_wiki", "render_ui", "render_sim", "ingest", "pipeline", "export", "skill", "process"}
+)
 
 # 长期保留的衰减率覆盖（写入 metadata_）。MemoryGovernanceService 计分时优先读取。
 _DECAY_LONG = 0.003  # status / baseline（事实型，长期不变）
@@ -226,6 +234,58 @@ class PatrolMemoryStore:
             },
         )
 
+    async def record_defects(
+        self,
+        *,
+        doc_id: str,
+        defects: list[dict[str, Any]],
+        routine_id: str = "",
+    ) -> int:
+        """记录逐页缺陷证据（``TAG_DEFECT``）——文档内纵向非回归用（下轮优先复核是否复现）。
+
+        与 ``TAG_UNFIXABLE``（仅 ≥5 次失败的不可修复区）正交：``TAG_DEFECT`` 记**全部发现过的
+        缺陷**（含已修复），供非回归对照与用户审计。归因轻校验：``attribution.lever/layer``
+        非法仅 WARN 不阻断。返回实际写入条数。
+        """
+        written = 0
+        for d in defects:
+            if not isinstance(d, dict):
+                continue
+            category = str(d.get("category") or "").strip()
+            defect_text = str(d.get("defect") or "").strip()
+            if not category or not defect_text:
+                continue
+            attribution = d.get("attribution") if isinstance(d.get("attribution"), dict) else {}
+            lever = str(attribution.get("lever") or "").strip()
+            layer = str(attribution.get("layer") or "").strip()
+            if lever and lever not in _VALID_LEVERS:
+                logger.warning("patrol_defect_invalid_lever", doc_id=doc_id, lever=lever)
+            if layer and layer not in _VALID_LAYERS:
+                logger.warning("patrol_defect_invalid_layer", doc_id=doc_id, layer=layer)
+            await self._add(
+                tag=TAG_DEFECT,
+                memory_type="procedural",
+                content=(f"PDF 高保真巡检缺陷（doc={doc_id}, page={d.get('page')}, {category}）：{defect_text}。"),
+                metadata={
+                    "doc_id": doc_id,
+                    "routine_id": routine_id,
+                    "page": d.get("page"),
+                    "category": category,
+                    "severity": str(d.get("severity") or ""),
+                    "check_method": str(d.get("check_method") or ""),
+                    "lever": lever,
+                    "layer": layer,
+                    "target_file": str(attribution.get("target_file") or ""),
+                    "root_cause_hypothesis": str(attribution.get("root_cause_hypothesis") or ""),
+                    "confidence": str(attribution.get("confidence") or ""),
+                    "dual_source_check": str(attribution.get("dual_source_check") or ""),
+                    "status": str(d.get("status") or "open"),
+                    "decay_override": _DECAY_MID,
+                },
+            )
+            written += 1
+        return written
+
     # ------------------------------------------------------------------
     # 读取（selector 用）
     # ------------------------------------------------------------------
@@ -249,7 +309,7 @@ class PatrolMemoryStore:
         解除该 doc 的终态沉淀与区域级避让，使其可被 selector 重新选中做二次巡检。
         不清 TAG_PATTERN / TAG_BASELINE——它们是跨 doc 的方法 / 基线知识，非该 doc 状态。
         """
-        for tag in (TAG_STATUS, TAG_UNFIXABLE):
+        for tag in (TAG_STATUS, TAG_UNFIXABLE, TAG_DEFECT):
             await self._db.execute(
                 sa.text(
                     "DELETE FROM negentropy.memories "
@@ -266,6 +326,28 @@ class PatrolMemoryStore:
                 "WHERE app_name = :app AND user_id = :u "
                 "AND metadata->>'tag' = :tag AND metadata->>'doc_id' = :doc"
             ).bindparams(app=self._app, u=_SYSTEM_USER, tag=TAG_UNFIXABLE, doc=doc_id)
+        )
+        return [r[0] for r in rows.fetchall() if isinstance(r[0], dict)]
+
+    async def get_defects(self, doc_id: str) -> list[dict[str, Any]]:
+        """某文档历史缺陷证据（``TAG_DEFECT``）——下轮注入优先复核是否复现（纵向非回归）。"""
+        rows = await self._db.execute(
+            sa.text(
+                "SELECT metadata FROM negentropy.memories "
+                "WHERE app_name = :app AND user_id = :u "
+                "AND metadata->>'tag' = :tag AND metadata->>'doc_id' = :doc"
+            ).bindparams(app=self._app, u=_SYSTEM_USER, tag=TAG_DEFECT, doc=doc_id)
+        )
+        return [r[0] for r in rows.fetchall() if isinstance(r[0], dict)]
+
+    async def get_defects_by_category(self, category: str) -> list[dict[str, Any]]:
+        """跨文档某类缺陷（归因偏移检测 / 全局 pattern 提炼用）。"""
+        rows = await self._db.execute(
+            sa.text(
+                "SELECT metadata FROM negentropy.memories "
+                "WHERE app_name = :app AND user_id = :u "
+                "AND metadata->>'tag' = :tag AND metadata->>'category' = :cat"
+            ).bindparams(app=self._app, u=_SYSTEM_USER, tag=TAG_DEFECT, cat=category)
         )
         return [r[0] for r in rows.fetchall() if isinstance(r[0], dict)]
 
@@ -360,6 +442,11 @@ class PatrolMemoryStore:
                 module=str(pat.get("module") or ""),
             )
 
+        # 逐页缺陷证据（三杠杆归因）落 TAG_DEFECT ——文档内纵向非回归（下轮优先复核是否复现）。
+        defects = [d for d in contract.get("defects") or [] if isinstance(d, dict)]
+        if defects:
+            await self.record_defects(doc_id=doc_id, defects=defects)
+
     async def persist_terminal_outcome(
         self,
         *,
@@ -418,4 +505,5 @@ __all__ = [
     "TAG_UNFIXABLE",
     "TAG_PATTERN",
     "TAG_BASELINE",
+    "TAG_DEFECT",
 ]

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_prompt.py
@@ -1,15 +1,27 @@
-"""pdf-fidelity-patrol 巡检 Routine 的 prompt SSOT。
+"""pdf-fidelity-patrol 巡检 Routine 的 prompt SSOT（三杠杆 + 真实 wiki 渲染闭环）。
 
-巡检 = 一个绑定「Negentropy」Repo 的 Routine（worktree + FINALIZE 开 PR + 0-100 评估闭环）。
-其 Claude Code 会话**即 NegentropyEngine**，依全局技能 ``pdf-fidelity-restore``（migration 0064）
-与下方 ``PATROL_SYSTEM_PROMPT`` 承载的「三系部角色循环」协议，把单份生产 PDF 文档的 Markdown
-形态拟合到与源 PDF 完全一致（满分 100）。
+巡检 = 一个绑定「Negentropy」Repo 的 Routine（worktree + FINALIZE 开 PR + 全绿率评估闭环）。
+其 Claude Code 会话**即 NegentropyEngine**，依全局技能 ``pdf-fidelity-restore``（migration 0064/0090）
+与下方 ``PATROL_SYSTEM_PROMPT`` 承载的「分层闭环 + 三杠杆归因」协议，把单份生产 PDF 文档的
+Markdown 形态拟合到与源 PDF 视觉一致（逐页校验全绿率达合格阈值）。
+
+**核心改造（相对旧版）**：
+1. 拟合范围从「仅 perceives 三模块」扩散到**三杠杆**：工程代码（perceives 管线 + 摄取层 +
+   导出层 + 渲染层 wiki/ui）+ Skills 本身 + 流程自身。
+2. 对照对象从 ``_fidelity_render`` 的 Python-Markdown 近似渲染换成**真实 wiki 渲染栈**
+   （``patrol_wiki_env`` 起的 ``next dev``，react-markdown + remark/rehype 全栈）。
+3. 闭环改为**分层**：fast inner loop（worktree CLI 候选 → 真实 wiki 截图 → 程序化逐页预筛 →
+   视觉聚焦 → 三杠杆归因 → 全绿率评分 → 一根因修复）+ Real-Render Gate（真 Rebuild
+   ``refresh_markdown(resume=false)`` + 重发 wiki 作地面真值校准）。
+4. 评分从「100-Σ扣分」改为「逐页校验全绿率 pass_pages/total×100」——CC 自评与 Judge 复核
+   锁同一份 ``program-checks.json`` + defects，根治 ISSUE-128 ±20 振荡。
 
 正交分解（Orthogonal Decomposition）：
-- 本模块只产 prompt 文本（纯函数，零 IO），与 ``patrol_memory.py``（记忆读写）、
-  ``pdf_fidelity_patrol`` handler（节奏/选文档/启停）各司其职。
-- 文档级动态参数（doc_id / 源 PDF 路径 / 候选输出路径 / 回归样本）经 ``build_*`` 注入，
-  静态协议（三系部角色 / JSON 契约 / 非回归）集中在 ``PATROL_SYSTEM_PROMPT``。
+- 本模块只产 prompt 文本（纯函数，零 IO），与 ``patrol_memory.py``（记忆）、
+  ``patrol_wiki_env.py``（wiki 渲染环境）、``pdf_fidelity_patrol`` handler（节奏/选文档/启停）
+  各司其职。
+- 文档级动态参数（doc_id / 源 PDF 路径 / 候选路径 / wiki 环境 / 回归样本 / 历史缺陷）经
+  ``build_*`` 注入，静态协议（分层闭环 / 三杠杆 / JSON 契约 / 非回归）集中在 ``PATROL_SYSTEM_PROMPT``。
 
 参考文献：
 [1] Anthropic, *Building Effective AI Agents*, 2024. Evaluator-Optimizer / Orchestrator-Workers。
@@ -17,7 +29,7 @@
     NeurIPS, 2023. arXiv:2303.11366. 跨迭代自反思。
 """
 
-# ruff: noqa: E501  # 巡检 prompt 内含长 CLI 命令行（uv run perceives / fidelity_render），强制换行会破坏可读性
+# ruff: noqa: E501  # 巡检 prompt 内含长 CLI 命令行（uv run perceives / patrol_wiki_env），强制换行会破坏可读性
 
 from __future__ import annotations
 
@@ -32,73 +44,153 @@ CONTRACT_SCHEMA = """\
 ```json
 {
   "doc_id": "<uuid>",
-  "score": <0-100 整数；该文档当前 Markdown 与源 PDF 的视觉一致度>，
+  "score": <0-100 整数 = round(pass_pages/total_pages×100)；逐页校验全绿率>,
+  "score_method": "page_pass_rate",
+  "pass_pages": <全绿页数>, "total_pages": <总页数>,
   "status": "done | progressing | unfixable",
   "defects": [
-    {"page": 1, "category": "table|formula|image|layout|text|code|toc|footnote",
-     "defect": "<现象描述>", "suspected_module": "<apps/negentropy-perceives 下疑似模块>",
-     "attempts": <本缺陷已尝试修复次数>}
+    {"page": 1, "category": "table|formula|image|image_size|layout|text|code|toc|footnote|paragraph_order",
+     "severity": "blocker|major|minor", "defect": "<现象描述>",
+     "evidence": {"pdf_bbox": [x,y,w,h], "wiki_selector": "<CSS selector / DOM Range>",
+                  "pdf_crop_path": "<路径>", "wiki_crop_path": "<路径>", "program_check": "<程序化判据>"},
+     "check_method": "programmatic | vision | hybrid",
+     "attribution": {"lever": "code|skill|process",
+                     "layer": "render_wiki|render_ui|render_sim|ingest|pipeline|export|skill|process",
+                     "target_file": "<相对 worktree 根的路径>",
+                     "root_cause_hypothesis": "<一句话根因>",
+                     "confidence": "high|medium|low",
+                     "dual_source_check": "md_only|render_only|both|not_checked"},
+     "attempts": <本缺陷已尝试修复次数>, "status": "open|fixing|unfixable"}
   ],
+  "page_checks_summary": {"green": <n>, "yellow": <n>, "red": <n>,
+                          "by_category": {"table": {"green": <n>, "warn": <n>}, ...}},
   "unfixable_regions": [
     {"locator": "<pageN-区域描述>", "attempts": 5, "reason": "<为何无法修复>",
-     "suspected_module": "<模块>"}
+     "attribution": {"layer": "<层>", "target_file": "<模块>"}}
   ],
   "patterns": [
-    {"defect_type": "table|formula|...", "fix_summary": "<有效修法>", "module": "<模块>"}
+    {"defect_type": "table|formula|...", "fix_summary": "<有效修法>",
+     "attribution": {"lever": "<杠杆>", "layer": "<层>", "target_file": "<模块>"}}
   ],
-  "perceives_diff_summary": "<本轮对 perceives 做了什么改动；无则空串>",
+  "diff_summary": "<本轮对【代码/Skill/流程】做了什么改动；无则空串>",
   "non_regression": "pass | fail | n/a"
 }
 ```
-- ``status=done``：所有可修复页面/模块已达视觉一致，剩余差异均已列入 ``unfixable_regions``。
+- ``score`` = 逐页校验全绿率 ``round(pass_pages/total_pages×100)``；``unfixable_regions`` 内的差异
+  不计入 pass_pages（carve-out）。``score_method=page_pass_rate`` 必填（供 Judge 校验口径一致）。
+- ``status=done``：所有可修复页/模块已达逐页一致（全绿或仅剩 unfixable）。
 - ``status=unfixable``：该文档已无更多可尝试修复点（含已标记的 unfixable 区域）。
-- ``score`` 由 Contemplation 视觉逐页比对得出；``unfixable_regions`` 内的差异不扣分。
+- 每个 defect **必须**填 ``attribution.{lever,layer,target_file}``（三杠杆归因，见路由表），
+  ``dual_source_check`` 声明是否经 DB markdown 层 + 渲染层双源验证（防误归因）。
+- ``diff_summary`` 不限 perceives——可含渲染层 / 摄取层 / 导出层 / Skill / 流程（prompt 自身）改动。
 """
 
 # ---------------------------------------------------------------------------
-# 三系部角色循环协议（注入 config.system_prompt，最高优先级指令层）
+# 分层闭环 + 三杠杆归因协议（注入 config.system_prompt，最高优先级指令层）
 # ---------------------------------------------------------------------------
 
 PATROL_SYSTEM_PROMPT = (
     """\
-你是 PDF→Markdown 高保真巡检的**执行器**，在隔离 git worktree 内作业。每轮迭代**只做一件事**：\
-给出该文档当前 Markdown 与源 PDF 的视觉保真度评分（0-100）+ 不一致清单；若 <100 且有可修复项，\
-做**一处定点** perceives 改动并重转复核。**严禁过度探查**——这是上轮迭代 context 耗尽、未推进的根因。
+你是 PDF→Markdown 高保真巡检的**执行器**，在隔离 git worktree 内作业。每轮迭代评估该文档当前\
+Markdown（经真实 wiki 渲染栈渲染）与源 PDF 的逐页视觉保真度，给出全绿率评分 + 结构化缺陷清单\
+（三杠杆归因）；若未达标且有可修复项，做**一个逻辑根因**的改动并重转复核。**严禁过度探查**——\
+这是历史 context 耗尽、零推进的根因。
+
+## 三杠杆拟合范围（可改的对象，按归因路由表选定）
+- **①工程代码**：
+  - 管线层 ``apps/negentropy-perceives/.../pipeline/stages/pdf/*``、``pipeline/engine_selector.py``、\
+    ``pipeline/batch_merge.py``、``ops/pdf.py``（文字/段落/表格/公式/图片提取、引擎选型、跨片合并、图片尺寸）。
+  - 摄取层 ``apps/negentropy/.../knowledge/ingestion/extraction.py``（图片链接重写）、``knowledge/_shared.py``。
+  - 导出层 ``apps/negentropy/.../knowledge/lifecycle/wiki_export_service.py``（资产 bake/重写）。
+  - 渲染层 wiki ``apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx`` 及子组件\
+    （ZoomableImage/ResponsiveTable/AnchorHeading/CodeBlock/MermaidDiagram）；\
+    渲染层 ui ``apps/negentropy-ui/features/knowledge/components/DocumentMarkdownRenderer.tsx``\
+    （sanitize schema、DocumentImage figcaption、parsePixelValue）、``utils/markdown-plugins.ts``。
+- **②Skills 本体**：``.agent/skills/pdf-fidelity-restore/SKILL.md`` +\
+  ``apps/negentropy/.../agents/skill_templates/pdf_fidelity_restore.yaml``（SSOT 双写，沉淀跨 doc insight / 升级归因路由）。
+- **③流程自身**：本 prompt（采样/评分/归因/闭环编排）、``evaluator.py``（Judge 口径）——仅当拟合动作是\
+  「改进巡检流程自身」时才改（慎改，影响面大）。
 
 ## 硬性约束（防 context 耗尽 — 曾致整轮 abort、零推进）
-- **不 spawn Agent 子任务**、不通读 perceives 全部源码、不写「架构/文档画像报告」、不 WebSearch。
-- Read 图像**每轮 ≤ 8 张**：**采样比对**（勿逐页读全文档——37 页全读会撑爆上下文）。
-- 改 perceives 仅 `grep -rn` 定位目标函数、只读该函数上下文，**单轮最多改一处**。
-- 候选 Markdown 只写指定候选路径，**绝不调生产 refresh-markdown / 写 knowledge_documents.markdown_content**。
+- **不 spawn Agent 子任务**、不通读任一杠杆全部源码、不写「架构画像报告」、不 WebSearch。
+- 视觉读图**每轮 ≤ 8 对**（PDF 页 PNG + wiki 区段 PNG 各 1 = 1 对）：先跑 ``patrol_page_check`` 程序化\
+  全页预筛，仅 ``vision_required`` 页进视觉队列（既逐页覆盖又不撑爆上下文）。
+- 改代码仅 ``grep -rn`` 定位目标函数、只读该函数上下文。**单轮一个逻辑根因**：≤3 文件、≤2 杠杆、\
+  1 commit（根因一句话概括）；禁止单轮同时改 perceives+wiki+ui+Skill+prompt 五处。
+- 候选 Markdown 只写指定候选路径 / wiki 内容根，**inner loop 绝不写生产 knowledge_documents.markdown_content**\
+  （仅 Real-Render Gate 经 ``refresh_markdown(resume=false)`` 写生产，作地面真值）。
 - 仅在 worktree 内改代码；源 PDF 只读。
-- **checkpoint 热更铁律**：每轮重转前 `rm -rf output/.batch_state`——auto_batch resume 按源 PDF SHA-1 缓存切片，不清则复用旧切片、你的 perceives 改动不生效（曾致 R10 白跑 2 次）；CLI 不暴露 `--no-resume`，只能靠清 checkpoint。
-- **图注勿双渲染**：多数图注已烘入 figure region PNG 像素，勿据 `alt` 另 render `figcaption`（会双图注）；仅核对像素内图注与源 PDF 是否一致。
+- **checkpoint 热更铁律**：每轮重转前清 checkpoint（精确到该 PDF 的 sha1，见 inner loop 步骤 1）——\
+  auto_batch resume 按源 PDF SHA-1 缓存切片，不清则复用旧切片、你的 perceives 改动不生效。
+- **图注勿双渲染**：多数图注已烘入 figure region PNG 像素，渲染层勿据 ``alt`` 另 render ``figcaption``\
+  （会双图注）；仅核对像素内图注与源 PDF 是否一致。
 
-## 闭环（严格顺序，勿偏离）
-1. 重转候选（**每轮先清 checkpoint 再转**；图片/表格/公式默认全提取）：
-   `rm -rf output/.batch_state`  # auto_batch resume 按源 PDF SHA-1 缓存切片，不清则复用旧切片、perceives 改动不生效
-   `uv run --project apps/negentropy-perceives perceives parse-pdf "<source_pdf_path>" -o "<candidate_md_path>" --method auto`
-2. 渲染对比底图（产出 PDF 各页 PNG + 候选 Markdown PNG，打印路径 JSON）：
-   `uv run --project apps/negentropy-perceives python -m negentropy.perceives.tools._fidelity_render --pdf "<source_pdf_path>" --markdown "<candidate_md_path>" --out-dir "/tmp/<doc_id>/render" --dpi 120 --width 900`
-3. **采样比对**：Read 采样页的 PDF PNG + Markdown PNG（第 1 页 + 中间一页 + 末页，≤4 对），逐项比对\
-   文字 / 段落顺序 / 图片（原图 + 显示尺寸）/ 目录锚点 / 表格 / 数学公式 / 代码块 / 脚注。
-4. 评分 + 缺陷清单：`score = 100 - Σ(各不一致项扣分)`（已标 unfixable 不扣）；列 \
-   `defects[{page,category,defect,suspected_module,attempts}]`。
-5. （仅当 score<100 且有**可修复** defect）**一处定点修复**：grep 定位疑似模块（`pipeline/stages/pdf/*`、\
-   `pipeline/engine_selector.py`、`ops/pdf.py`），改最小一处 → 回到步骤 1 重转复核（本轮回到此为止即可收尾）。
-6. 反复 ≥5 次未修复的局部区域 → 记为 `unfixable`（契约内列出，评分不扣、后续避开）。
-7. **末尾必须**输出下方 `pdf-fidelity-contract` JSON 块（否则评估无法计分）。
+## 缺陷归因路由表（defect 类别 → 杠杆/层/责任文件，先验）
+| 缺陷类别 | 首选层 | 判据 |
+|---|---|---|
+| table 结构错 | pipeline | DB markdown 表格源码错→pipeline；源码对渲染错→render_wiki/render_ui |
+| formula ParseError/双份 | pipeline+render | DB ``$...$`` 对但浏览器报错→渲染层/引擎版本；DB 缺失→pipeline |
+| image 404 | ingest+export | wiki 错 ui 对→export；ui 错 wiki 对→ingest；皆错→资产未落地(ingest) |
+| image 显示尺寸 | pipeline+render | DB 无 width→pipeline ``ops/pdf.py``；有 width 渲染错→render sanitize/parsePixelValue |
+| figure 双图注 | render+skill | 一份 MD 两栈 figcaption 行为不同→渲染层不对称 + Skill 沉淀铁律 |
+| layout/text/code/toc/footnote | pipeline/render | 按 DB 层 vs 渲染层双源判定（见决策树） |
+| 仅旧模拟栈可见 | render_sim（不计分） | DB + wiki/ui 均正确，仅旧 ``_fidelity_render`` 错→流程伪缺陷，记 insight 不扣分 |
 
-## 非回归门控（FINALIZE 开 PR 前必做）
-对注入的 `regression_sample`（一组多样化生产 PDF doc_id）用**本轮改动后** perceives 重转 + 采样评分；\
-任一样本分数**下降 >3 分**或转换失败 → **不得开 PR**，回退改动。通过才走既有 `gh pr create --base <baseline>`。
-**零代码改动即无 PR（交付物只能是 perceives 代码优化）**：若本轮（及历轮）未对 perceives 做任何代码改动\
-（worktree 相对基线 0 提交），说明该文档已达标、无需优化 → **不得开 PR**，直接以 done 收尾。候选 Markdown \
-是隔离工作区**之外**的临时评估产物（`-o` 指向暂存目录绝对路径），**绝不**纳入 worktree / commit / PR。
+## 双源验证决策树（每个 defect 归因前必走，防误归到 perceives）
+Step A：缺陷在候选 Markdown 源码（候选 MD 文件）里存在吗？
+  是 → pipeline/ingest 层（Step B）；否 → 渲染层或流程伪缺陷（Step C）
+Step B：图片链接是否 ``/api/documents/.../assets/`` 形式？是但 404 → ingest/export；否 → ingest _rewrite；其他 → pipeline（产出源头）
+Step C：wiki 渲染错还是 ui 渲染错？仅 wiki → render_wiki；仅 ui → render_ui；皆错一致 → 共享根因；\
+皆对仅旧模拟栈错 → render_sim（不计分）。``attribution.dual_source_check`` 必填以证未跳步。
 
-## 角色分工（轻量，勿展开探查）
-Contemplation=步骤 2-4（渲染+采样比对+评分）；Action=步骤 1/5（重转+定点改 perceives）；\
-Internalization=步骤 6（unfixable/pattern 记忆，经 `mcp__knowledge__*` 或契约沉淀）。
+## 分层闭环（严格顺序，勿偏离）
+### A. Fast Inner Loop（每轮，秒级，不写生产）
+1. **清 checkpoint（精确到 sha1）**：``rm -rf "<perceives_workdir>/output/.batch_state/<sha1[:12]>"``\
+   （sha1 由 ``perceives parse-pdf`` 首跑产出日志给出；不确定时可 ``rm -rf output/.batch_state`` 兜底）。
+2. **CLI 重转（worktree 代码，即时反映改动）**：\
+   ``uv run --project apps/negentropy-perceives perceives parse-pdf "<source_pdf_path>" -o "<candidate_md_path>" --method auto``
+3. **发布候选到 wiki 内容根（原子写 entries/{entry_id}.json，真实 schema）**：\
+   ``uv run --project apps/negentropy python -m negentropy.engine.routine.patrol_wiki_env publish-candidate --content-root "<wiki_content_root>" --markdown-file "<candidate_md_path>" --doc-id "<doc_id>" --title "<doc_title>" --filename "<doc_filename>"``
+4. **等 wiki dev server 可服务 + 程序化逐页预筛**：\
+   ``uv run --project apps/negentropy python -m negentropy.engine.routine.patrol_wiki_env wait-ready --port <wiki_dev_port>``；\
+   ``uv run --project apps/negentropy-perceives python -m negentropy.perceives.tools.patrol_page_check --pdf "<source_pdf_path>" --wiki-url "<wiki_url>" --out-dir "/tmp/<doc_id>/check"``\
+   （产出 ``program-checks.json`` + ``align-index.json``；``vision_required_pages`` 列表）。
+5. **截图**：源 PDF 各页 PNG（``uv run --project apps/negentropy-perceives python -m negentropy.perceives.tools._fidelity_render --pdf "<source_pdf_path>" --markdown "<candidate_md_path>" --out-dir "/tmp/<doc_id>/render"`` 仅取其 ``pdf_pages``；候选不再用其 markdown PNG）；\
+   wiki 真页用 ``mcp__playwright__browser_navigate("<wiki_url>")`` + ``browser_take_screenshot(fullPage=true)``，并对 ``vision_required`` 页按需 ``clip``/element 区段截图。
+6. **视觉聚焦比对**：Read ``vision_required`` 页的 PDF 页 PNG + wiki 区段 PNG（≤8 对），逐项比对\
+   文字 / 段落顺序 / 图片（原图+显示尺寸）/ 目录锚点 / 表格 / 数学公式 / 代码块 / 脚注。
+7. **结构化缺陷 + 三杠杆归因**：每个 defect 填 ``attribution.{lever,layer,target_file}`` +\
+   ``dual_source_check``（走上方决策树）；``check_method`` 标 programmatic/vision/hybrid。
+8. **全绿率评分**：``score = round(pass_pages/total_pages×100)``（``pass_pages`` = 全维度 green 或\
+   仅剩 unfixable 的页数；``unfixable_regions`` 不计）。
+9. （仅当 score<阈值 且有**可修复** defect）**一个逻辑根因修复**：按归因路由表 grep 定位目标杠杆/文件，\
+   改 ≤3 文件 ≤2 杠杆 → 回步骤 1（本轮回到此为止即可收尾）。
+10. 反复 ≥5 次未修复的局部区域 → 记 ``unfixable``（契约内列出，评分不计、后续避开）。
+
+### B. Real-Render Gate（每 N=min(5, max_iter/3) 轮 / 达 inner 阈值 / FINALIZE 前必做一次）
+- 真 Rebuild（清 checkpoint 全量重跑 + 写生产 markdown_content）：调\
+  ``POST /knowledge/base/{corpus_id}/documents/{doc_id}/refresh_markdown`` body ``{"resume": false}``\
+  （经 live perceives :2992；与本轮 worktree 代码改动**独立**——跨 Routine 合并部署后才反映代码杠杆）。
+- 重发 wiki：把生产 markdown_content 读回写 wiki 内容根（步骤 3 的 publish-candidate，markdown 换成生产态），\
+  或直接 ``WikiExportService.export_single_entry``（含 asset bake）。
+- 截图真 wiki 页 + PDF 页（步骤 5），给**地面真值评分**，校准 inner loop 评分漂移（CLI vs MCP 路径差异、\
+  asset 未 bake 致 inner 图片缺漏等）。
+
+### C. 降级（``wiki_render_available=false`` 时）
+- wiki dev server 不可起：回退 ``_fidelity_render.render_page_pairs``（legacy Python-Markdown 近似渲染），\
+  标本轮降级（``diff_summary`` 注明）；仅作离线兜底，缺陷归因时警惕 ``render_sim`` 伪缺陷。
+
+## 非回归门控（FINALIZE 开 PR 前必做，按本轮改动杠杆分派）
+- ①pipeline：用**本轮改动后** perceives 重转 ``regression_sample``（注入的一组多样化生产 PDF doc_id）+ 采样评分；\
+  任一样本分数下降 >3 分或转换失败 → **不得开 PR**，回退改动。
+- ①渲染层（wiki/ui）：改动后渲染栈渲染回归样本 Markdown（``patrol_page_check`` 或截图对照），不得引入新视觉缺陷。
+- ①摄取层：回归样本图片链接 HTTP 200 探针 + Markdown 链接形式正确、标题回填未退化。
+- ①导出层：回归样本 export bake 后图片可达性。
+- ②Skill：``SKILL.md`` 与 ``yaml`` 正文骨架一致（SSOT 双写）。
+- ③流程：新 prompt 跑回归样本，整体评分不降超容差。
+- **零代码改动即无 PR**：若本轮（及历轮）未对任何杠杆做代码/Skill/prompt 改动（worktree 相对基线 0 提交），\
+  说明该文档已达标 → **不得开 PR**，直接以 done 收尾。候选 Markdown 与 wiki 内容根产物是隔离工作区\
+  **之外**的临时评估产物，**绝不**纳入 worktree / commit / PR。
 
 ## 结构化输出契约（强制收尾）
 """
@@ -114,11 +206,15 @@ def build_goal(
     candidate_md_path: str,
     qualified_threshold: int,
     known_unfixable_regions: list[dict[str, Any]] | None = None,
+    wiki_env: dict[str, Any] | None = None,
+    known_defects: list[dict[str, Any]] | None = None,
 ) -> str:
-    """构造巡检 Routine 的 goal（文档级动态参数注入）。
+    """构造巡检 Routine 的 goal（文档级动态参数 + wiki 环境注入）。
 
-    - ``qualified_threshold``：合格分阈值，注入 done 判定（达此或仅剩 unfixable 即 done）。
-    - ``known_unfixable_regions``：该文档**已知 unfixable 区域**（跨 Routine 记忆复用），注入避让清单。
+    - ``qualified_threshold``：合格分阈值（全绿率口径，达此或仅剩 unfixable 即 done）。
+    - ``known_unfixable_regions``：该文档已知 unfixable 区域（跨 Routine 记忆复用），注入避让清单。
+    - ``wiki_env``：巡检 wiki 渲染环境（url/port/content_root/entry_id/可用性），驱动 inner loop 真实渲染。
+    - ``known_defects``：上轮历史缺陷（``TAG_DEFECT``），注入以优先复核是否复现（纵向非回归）。
     """
     unfixable_hint = ""
     if known_unfixable_regions:
@@ -129,34 +225,51 @@ def build_goal(
         )
         if locators:
             unfixable_hint = f"\n- **已知 unfixable 区域（勿再尝试修复，评分不计）**：{locators}"
+
+    wiki_hint = "\n- **wiki 渲染环境不可用（降级 legacy 近似渲染）**：走 _fidelity_render 离线兜底。"
+    if wiki_env and wiki_env.get("wiki_render_available"):
+        wiki_hint = (
+            f"\n- **wiki 渲染环境（真实 wiki app 渲染栈）**：url=`{wiki_env.get('wiki_url')}` "
+            f"port={wiki_env.get('wiki_dev_port')} content_root=`{wiki_env.get('wiki_content_root')}` "
+            f"entry_id=`{wiki_env.get('wiki_entry_id')}` slug=`{wiki_env.get('wiki_entry_slug')}`"
+        )
+
+    defects_hint = ""
+    if known_defects:
+        summary = ", ".join(f"p{d.get('page')}({d.get('category')})" for d in known_defects[:12] if isinstance(d, dict))
+        if summary:
+            defects_hint = f"\n- **上轮历史缺陷（优先复核是否复现，纵向非回归）**：{summary}"
+
     return (
-        f"本轮迭代：评估生产 PDF《{doc_title}》（doc_id={doc_id}）当前 Markdown 与源 PDF 的视觉保真度（0-100）。\n"
+        f"本轮迭代：评估生产 PDF《{doc_title}》（doc_id={doc_id}）当前 Markdown 与源 PDF 的逐页视觉保真度（全绿率）。\n"
         f"- 源 PDF（只读）：{source_pdf_path}\n"
-        f"- 候选 Markdown（每轮覆盖写）：{candidate_md_path}{unfixable_hint}\n"
-        f"严格按 system_prompt 闭环执行（重转 → 渲染 → **采样**比对 → 评分 → [一处定点修复 → 重转复核] → 契约）。"
-        f"**勿过度探查、勿逐页读全部图、勿 spawn Agent 子任务**——这是上轮 context 耗尽未推进的根因。"
-        f"score≥{qualified_threshold}（合格阈值）或仅剩 unfixable 即 done。"
+        f"- 候选 Markdown（每轮覆盖写）：{candidate_md_path}{unfixable_hint}{wiki_hint}{defects_hint}\n"
+        "严格按 system_prompt 分层闭环执行（inner: 清checkpoint→CLI重转→publish-candidate→程序化预筛"
+        "→截图→视觉聚焦→三杠杆归因→全绿率评分→一根因修复；gate: refresh_markdown(resume=false)+重发wiki作地面真值）。"
+        "**勿过度探查、勿逐页读全部图、勿 spawn Agent 子任务**——这是上轮 context 耗尽未推进的根因。"
+        f"score≥{qualified_threshold}（全绿率合格阈值）或仅剩 unfixable 即 done。"
     )
 
 
 def build_acceptance_criteria(*, baseline_branch: str, qualified_threshold: int) -> str:
-    """构造巡检 Routine 的 acceptance_criteria。
+    """构造巡检 Routine 的 acceptance_criteria（全绿率口径）。
 
-    合格阈值为 ``qualified_threshold``（默认 95）：达此分即判合格 done、Routine 经 decide() 判 SUCCESS。
-    允许在仅剩 unfixable carve-out 时达成（carve-out 不扣分），避免死循环。
-    含显式评分指引：收敛文档须评 ``qualified_threshold``-100，防评估器压分致本应成功的 Routine 误判 Failed。
+    合格阈值为 ``qualified_threshold``（默认 95）：全绿率达此即判合格 done。允许在仅剩 unfixable
+    carve-out 时达成（carve-out 页不计 pass_pages），避免死循环。
+    **评分口径 = 逐页校验全绿率** ``score = round(pass_pages/total_pages×100)``（非旧「100-Σ扣分」），
+    与 Judge 复核锁同一份 ``program-checks.json`` + defects，根治 ISSUE-128 ±20 振荡。
     """
     return (
         "该文档所有页面/模块（文字、段落顺序、高清原图及显示尺寸、目录锚点、表格、数学公式、"
-        "代码块、脚注）与源 PDF 视觉一致；或剩余差异均已计入 "
+        "代码块、脚注）经**真实 wiki 渲染栈**渲染后与源 PDF 逐页视觉一致；或剩余差异均已计入 "
         "`pdf-fidelity-unfixable`（≥5 次修复失败）并由 Internalization 写入记忆——此时亦可判 done。\n"
-        "**评分指引（重要）**：当文档已收敛（可修复模块全部一致；剩余差异均已列入 "
-        f"`pdf-fidelity-unfixable` 忽略不计）时，acceptance_met=true 且 score 应为 "
-        f"**{qualified_threshold}-100**（unfixable 模块不扣分）；仍有可修复缺陷时方在 "
-        f"{qualified_threshold} 以下评分。**勿对已收敛文档压低分数**，致本应成功的 Routine 误判失败。\n"
-        "完成判据：每轮以 `pdf-fidelity-contract` JSON 收尾；done 时 score≥"
-        f"{qualified_threshold} 且 defects 为空（或仅剩 unfixable）；Perceives 改动经非回归门控通过后以 PR 合回基线 "
-        f"`{baseline_branch}`。"
+        "**评分口径（重要）**：``score = round(pass_pages/total_pages×100)``（逐页校验全绿率）。"
+        f"达 {qualified_threshold} 即合格（如 37 页需 ≥36 页全绿）。每个 defect 须填三杠杆归因 "
+        "(`attribution.lever/layer/target_file`) + `dual_source_check`；done 时 defects 为空（或仅剩 "
+        f"unfixable）。**勿对已收敛文档压低分数**，致本应成功的 Routine 误判失败。\n"
+        "完成判据：每轮以 `pdf-fidelity-contract` JSON 收尾（含 `score_method=page_pass_rate` + "
+        f"`pass_pages/total_pages`）；done 时 score≥{qualified_threshold} 且 defects 为空（或仅剩 unfixable）；"
+        f"各杠杆改动经非回归门控通过后以 PR 合回基线 `{baseline_branch}`。"
     )
 
 
@@ -172,8 +285,10 @@ def build_routine_config(
     """构造巡检 Routine 的 config（patrol 标记 + 动态参数 + system_prompt + 只读授权）。
 
     - ``patrol=True``：handler / PatrolMemoryStore 据此识别巡检 Routine。
-    - ``system_prompt``：承载三系部角色协议（由 orchestrator 前置 scope 后注入，最高优先级）。
+    - ``system_prompt``：承载分层闭环 + 三杠杆归因协议（最高优先级）。
     - ``read_dirs``：授予源 PDF 所在目录为只读源（CC 可读不可写）。
+    - wiki 环境（``wiki_url`` / ``wiki_dev_port`` / ``wiki_content_root`` / ``wiki_dev_pid`` 等）经
+      ``extra`` 由 handler 的 ``_setup_patrol_wiki_env`` 注入。
     """
     cfg: dict[str, Any] = {
         "patrol": True,
@@ -184,28 +299,17 @@ def build_routine_config(
         "system_prompt": PATROL_SYSTEM_PROMPT,
         "read_dirs": [source_read_dir],
         # Plan Review 保持启用（CC ↔ NegentropyEngine 正常交流方案、恰当时 Approve）。
-        # 注：unified 闭环下 plan 段**已强制走 PreToolUse 钩子**（orchestrator 文末，根治断链——
-        # headless `claude -p` 下 AskUserQuestion 的 reader stdin 回灌从始无效、CC 收 `Answer questions?`
-        # 报错，refine 永送不到），故此 via_hook 值**不再影响 plan 段**，仅遗留作 legacy 非 unified
-        # 路径开关（巡检为 worktree routine、走 unified，不经该路径）。
+        # 注：unified 闭环下 plan 段**已强制走 PreToolUse 钩子**（orchestrator 文末，根治断链），
+        # 故此 via_hook 值**不再影响 plan 段**，仅遗留作 legacy 非 unified 路径开关。
         "plan_review_via_hook": False,
-        # 开启「Judge verdict=pass 亦判成功」旁路（消费见 orchestrator.decide()）。
-        # 巡检完成判据含「仅剩 unfixable 即 done」carve-out（见 build_acceptance_criteria），Judge
-        # 据此对 <100 的分判 verdict=pass；但 success_score_threshold=100 与 Judge 评分尺度
-        # （"全部满足≈90-100"）结构性失配，score 恒 <100，致 decide() 成功路径永不触发、反被
-        # no_progress 误判 failed（曾致 Routine 861ab544 收敛成功态被判 failed）。开启此旁路让 Judge
-        # 的权威完成裁决（verdict=pass + 门控通过）成为第二成功通道，与阈值路径并列。
+        # 开启「Judge verdict=pass 亦判成功」旁路（消费见 orchestrator.decide()）。全绿率口径下
+        # CC 自评与 Judge 评分一致，accept_verdict_pass 作收敛 carve-out 的第二成功通道（与阈值并列）。
         "accept_verdict_pass": True,
-        # 停滞判定分数容差带（消费见 orchestrator.decide()）。Judge 聚合分对「修一处感知缺陷、
-        # 回归压低另一处」的拟合任务天然 ±20 振荡，一次早期运气高点（watermark）会令正常振荡
-        # 永远清不过历史最优 → 假阳性 no_progress 误杀正在收敛的任务（曾致 PDF Fidelity Patrol
-        # 仅 6 轮即 failed、文档被永久标 unfixable）。设 20 = 典型振荡幅度，使窗口内任一评分接近
-        # 历史最优即视为「有进展/继续」，而非停滞误杀。
+        # 停滞判定分数容差带（消费见 orchestrator.decide()）。全绿率口径理论上消振荡，但程序化预筛
+        # 阈值未校准前仍可能小幅波动；保留容差防假阳性 no_progress 误杀（ISSUE-128 教训）。
         "no_progress_score_tolerance": 20,
-        # Judge 历史锚定（消费见 orchestrator._do_evaluate / evaluator.evaluate）。巡检 Judge 聚合分
-        # 天然 ±20 振荡（ISSUE-128 根因之一是每轮独立重打分无历史锚点），锚定使评分带 delta 证据、
-        # 与轨迹一致。显式置 True 防全局默认未来翻转时巡检静默失锚。量化振荡（oscillation_min_amplitude）
-        # 不启用——与 no_progress_tolerance 存在张力，待锚定实测降振荡后再评估。
+        # Judge 历史锚定（消费见 orchestrator._do_evaluate / evaluator.evaluate）。全绿率 + 结构化
+        # defects 喂 Judge 后，锚定使评分带 delta 证据、与轨迹一致。显式置 True 防全局默认翻转失锚。
         "judge_anchor_enabled": True,
     }
     if extra:

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_wiki_env.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_wiki_env.py
@@ -1,0 +1,395 @@
+"""PDF Fidelity Patrol 的 wiki 渲染环境编排（真实 wiki app 渲染栈快路径）。
+
+在内层 fast loop 中，把 worktree CLI 产出的候选 Markdown 经「真实 wiki 渲染栈」
+（``apps/negentropy-wiki`` 的 react-markdown + remark-gfm/math + rehype-katex/raw/
+highlight/sanitize 全栈）渲染，再由 Playwright 截图，作为与源 PDF 逐页对照的真值——
+取代旧 ``_fidelity_render`` 的 Python-Markdown 近似栈（与真实 wiki 系统性不同，致
+公式/Mermaid/figure/figcaption/图片尺寸/代码高亮假阳性/假阴性）。
+
+设计（Orthogonal Decomposition / 最小干预）：
+- **内容源**：patrol 专属 ``content_root``（文件态，**不写生产 DB**），复用 wiki 既有
+  ``[pubSlug]/[...entrySlug]`` 路由 + ``MarkdownRenderer.tsx``，不改 wiki 源码。
+  scaffold 经 ``ensure_content_scaffold`` 写最小 index/publications/entries-index；
+  候选/真值经 ``write_entry_content`` 原子写 ``entries/{entry_id}.json``。
+- **渲染进程**：``next dev``（``WIKI_CONTENT_DIR=content_root`` + ``WIKI_CONTENT_NO_CACHE=1``，
+  见 ``content-source.ts`` dev 缓存旁路），后端 handler 起（``start_wiki_dev_server``）、
+  orchestrator FINALIZE 收（``stop_wiki_dev_server``），跨 CC 会话保活。
+- **schema 复用**：``build_entry_content_response`` 合成 entries/{id}.json，与生产导出
+  （``WikiExportService``）逐字段一致（DRY），wiki 端零特判。
+
+V1 限制（已知，后续拟合补全）：候选/真值 Markdown 内 ``/api/documents/.../assets/`` 图片
+引用在 wiki dev 源下不解析（不同源、未 bake）——文字/段落/表格/公式/代码/布局类拟合已
+全覆盖；图片显示尺寸/figure 类拟合待 asset bake 管线接入（gate 可改调
+``WikiExportService.export_single_entry`` 走 DB publication + bake）。
+
+CLI（CC 会话经 ``uv run --project apps/negentropy python -m
+negentropy.engine.routine.patrol_wiki_env <cmd>`` 调用）：
+- ``publish-candidate``：读候选 MD 文件 → 合成 schema → 原子写 entries/{id}.json。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime
+from pathlib import Path
+from uuid import UUID
+
+from negentropy.logging import get_logger
+
+logger = get_logger(__name__.rsplit(".", 1)[0])
+
+# ---------------------------------------------------------------------------
+# patrol 专属 staging publication / entry 的固定标识（文件态 content root 用，
+# 不入生产 DB；固定 slug 使 wiki URL 稳定，跨迭代复用）。
+# ---------------------------------------------------------------------------
+
+PATROL_PUB_SLUG = "pdf-fidelity-patrol-staging"
+PATROL_PUB_ID = UUID("a1b2c3d4-e5f6-4a7b-8c9d-0a1b2c3d4e5f")
+PATROL_ENTRY_ID = UUID("b2c3d4e5-f6a7-4b8c-9d0a-1b2c3d4e5f6a")
+PATROL_ENTRY_SLUG = "candidate"
+
+# 本机需避让的已占用端口（用户本机服务）。
+_RESERVED_PORTS = {3092, 3192, 2992, 3292, 3093}
+
+_READY_PROBE_TIMEOUT_S = 90.0
+_READY_PROBE_INTERVAL_S = 1.5
+
+
+def wiki_url(*, port: int) -> str:
+    """patrol 候选页在 wiki dev server 上的稳定 URL（固定 pub/entry slug）。"""
+    return f"http://127.0.0.1:{port}/{PATROL_PUB_SLUG}/{PATROL_ENTRY_SLUG}/"
+
+
+# ---------------------------------------------------------------------------
+# content root scaffold（文件态，幂等）
+# ---------------------------------------------------------------------------
+
+
+def _iso_now() -> str:
+    return datetime.utcnow().isoformat() + "Z"
+
+
+def ensure_content_scaffold(
+    content_root: Path,
+    *,
+    doc_id: UUID,
+    doc_title: str,
+    doc_filename: str,
+) -> None:
+    """写最小 wiki 内容包 scaffold（index/publications/publication/nav/entries-index）。
+
+    幂等：每次 Routine 启动可重写（覆盖固定 patrol pub/entry 的元信息为当前文档）。
+    不写 ``entries/{id}.json``（内容由 ``write_entry_content`` 每轮覆盖）。
+    """
+    content_root.mkdir(parents=True, exist_ok=True)
+    (content_root / "entries").mkdir(parents=True, exist_ok=True)
+    pub_dir = content_root / "publications" / PATROL_PUB_SLUG
+    pub_dir.mkdir(parents=True, exist_ok=True)
+
+    generated_at = _iso_now()
+    publication = {
+        "id": str(PATROL_PUB_ID),
+        "catalog_id": str(PATROL_PUB_ID),  # 文件态无 DB catalog；wiki 不校验
+        "app_name": "default",
+        "publish_mode": "LIVE",
+        "name": "PDF Fidelity Patrol Staging",
+        "slug": PATROL_PUB_SLUG,
+        "description": "巡检真实渲染对照用 staging（文件态，不入生产）",
+        "status": "published",
+        "theme": "default",
+        "version": 1,
+        "published_at": generated_at,
+        "created_at": generated_at,
+        "updated_at": generated_at,
+        "entries_count": 1,
+    }
+    entry_item = {
+        "id": str(PATROL_ENTRY_ID),
+        "document_id": str(doc_id),
+        "entry_slug": PATROL_ENTRY_SLUG,
+        "entry_title": doc_title or doc_filename or "patrol-candidate",
+        "is_index_page": False,
+        "status": "active",
+    }
+    nav_item = {
+        "entry_id": str(PATROL_ENTRY_ID),
+        "entry_slug": PATROL_ENTRY_SLUG,
+        "entry_title": entry_item["entry_title"],
+        "is_index_page": False,
+        "document_id": str(doc_id),
+        "entry_kind": "DOCUMENT",
+    }
+
+    _atomic_write_json(pub_dir / "publication.json", publication)
+    _atomic_write_json(
+        pub_dir / "nav-tree.json",
+        {"publication_id": str(PATROL_PUB_ID), "nav_tree": {"items": [nav_item]}},
+    )
+    _atomic_write_json(
+        pub_dir / "entries-index.json",
+        {"items": [entry_item], "total": 1, "slug_to_id": {PATROL_ENTRY_SLUG: str(PATROL_ENTRY_ID)}},
+    )
+    _atomic_write_json(content_root / "publications.json", {"items": [publication], "total": 1})
+    _atomic_write_json(
+        content_root / "index.json",
+        {
+            "schema_version": 1,
+            "generated_at": generated_at,
+            "exporter_version": "patrol-wiki-env-0.1",
+            "publications": [{"slug": PATROL_PUB_SLUG, "id": str(PATROL_PUB_ID), "version": 1}],
+            "pubs": {
+                PATROL_PUB_SLUG: {
+                    "id": str(PATROL_PUB_ID),
+                    "version": 1,
+                    "entry_slug_to_id": {PATROL_ENTRY_SLUG: str(PATROL_ENTRY_ID)},
+                    "entry_ids": [str(PATROL_ENTRY_ID)],
+                }
+            },
+        },
+    )
+    logger.info(
+        "patrol_wiki_scaffold_ready",
+        content_root=str(content_root),
+        doc_id=str(doc_id),
+    )
+
+
+def write_entry_content(
+    content_root: Path,
+    *,
+    markdown: str,
+    doc_id: UUID,
+    entry_title: str,
+    entry_filename: str,
+) -> Path:
+    """把候选/真值 Markdown 合成 wiki entry content schema，原子写 entries/{id}.json。
+
+    复用 ``build_entry_content_response``（与生产导出逐字段一致），wiki 端零特判。
+    """
+    from negentropy.knowledge.lifecycle.wiki_service import build_entry_content_response
+
+    content_data = {
+        "document_id": str(doc_id),
+        "markdown_content": markdown,
+        "title": entry_title or entry_filename or "patrol-candidate",
+        "filename": entry_filename or "",
+        "metadata": {},
+        "source_url": None,
+    }
+    resp = build_entry_content_response(PATROL_ENTRY_ID, content_data, entry_slug=PATROL_ENTRY_SLUG)
+    payload = resp.model_dump(mode="json")
+    entries_dir = content_root / "entries"
+    entries_dir.mkdir(parents=True, exist_ok=True)
+    target = entries_dir / f"{PATROL_ENTRY_ID}.json"
+    _atomic_write_json(target, payload)
+    return target
+
+
+# ---------------------------------------------------------------------------
+# wiki dev server 生命周期（后端 handler 起 / orchestrator FINALIZE 收）
+# ---------------------------------------------------------------------------
+
+
+def pick_free_port() -> int:
+    """选一个空闲端口（避让本机已占用服务端口）。"""
+    for _ in range(20):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            port = int(s.getsockname()[1])
+        if port not in _RESERVED_PORTS:
+            return port
+    # 兜底（极不可能）：交由 OS 选。
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return int(s.getsockname()[1])
+
+
+def _repo_root() -> Path:
+    """从本模块定位 repo 根（含 apps/ 与 apps/negentropy-wiki）。
+
+    向上查找首个含 ``apps/negentropy-wiki`` 的祖先目录，比硬编码 parents[N] 更稳健
+    （包路径重构不致错位）。
+    """
+    here = Path(__file__).resolve()
+    for parent in [here, *here.parents]:
+        if (parent / "apps" / "negentropy-wiki").is_dir():
+            return parent
+    # 兜底：向上 7 层（patrol_wiki_env.py → apps/negentropy/src/negentropy/engine/routine）
+    return here.parents[6]
+
+
+def start_wiki_dev_server(
+    content_root: Path,
+    *,
+    port: int,
+    repo_root: Path | None = None,
+) -> int:
+    """spawn ``next dev`` wiki server（``WIKI_CONTENT_DIR`` + ``WIKI_CONTENT_NO_CACHE``），返回 pid。
+
+    **非阻塞**：仅 ``Popen`` 后立即返回 pid（不在 handler/scheduler tick 内同步等 ready，
+    避免单 worker 后端事件循环冻结——见 ``start_new_session`` + 调用方约束）。
+    CC 会话截图前调 ``wait_ready``（CLI ``wait-ready``）在 bash 内阻塞至可服务。
+
+    - ``start_new_session=True``：独立进程组，便于 ``stop_wiki_dev_server`` 一并 kill 子进程
+      （next dev 会派生 worker）。
+    - 失败（pnpm/next 缺失）由 ``Popen`` 抛：handler 调用方应吞异常并降级（标本轮无 wiki 真值）。
+    """
+    repo = repo_root or _repo_root()
+    env = os.environ.copy()
+    env["WIKI_CONTENT_DIR"] = str(content_root)
+    env["WIKI_CONTENT_NO_CACHE"] = "1"
+    env["NODE_ENV"] = "development"
+    proc = subprocess.Popen(
+        [
+            "pnpm",
+            "--filter",
+            "negentropy-wiki",
+            "exec",
+            "next",
+            "dev",
+            "--port",
+            str(port),
+            "--hostname",
+            "127.0.0.1",
+        ],
+        cwd=str(repo),
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    logger.info("patrol_wiki_dev_started", port=port, pid=proc.pid, content_root=str(content_root))
+    return proc.pid
+
+
+def wait_ready(*, port: int, timeout_s: float | None = None) -> bool:
+    """轮询 wiki dev server 至可服务（阻塞，供 CC 截图前在 bash 内调用）。
+
+    超时 WARN 但返回 False（CC 据此降级 legacy ``_fidelity_render`` 或重试）。
+    """
+    url = wiki_url(port=port)
+    deadline = time.monotonic() + (timeout_s if timeout_s is not None else _READY_PROBE_TIMEOUT_S)
+    last_err: str | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=5) as resp:  # noqa: S310 - 本机 dev 探测
+                if 200 <= resp.status < 500:
+                    logger.info("patrol_wiki_dev_ready", port=port)
+                    return True
+        except (urllib.error.URLError, TimeoutError, ConnectionError) as exc:
+            last_err = str(exc)
+        time.sleep(_READY_PROBE_INTERVAL_S)
+    logger.warning("patrol_wiki_dev_ready_timeout", port=port, url=url, error=last_err)
+    return False
+
+
+def is_server_alive(pid: int) -> bool:
+    """pid 对应进程是否仍存活（best-effort）。"""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # 存在但无权发信号——视为 alive
+    return True
+
+
+def stop_wiki_dev_server(pid: int) -> None:
+    """kill wiki dev server 整个进程组（start_new_session 下 pgid == pid）。
+
+    best-effort：进程已退出 / 无权 kill 均静默（FINALIZE/abort 清理不应抛）。
+    """
+    try:
+        os.killpg(pid, 15)  # SIGTERM 整组
+    except ProcessLookupError:
+        return
+    except PermissionError:
+        logger.warning("patrol_wiki_dev_stop_no_perm", pid=pid)
+        return
+    except Exception as exc:  # noqa: BLE001 - 清理兜底
+        logger.warning("patrol_wiki_dev_stop_failed", pid=pid, error=str(exc))
+        return
+    # 给 graceful shutdown 一点时间后兜底 SIGKILL 整组。
+    for _ in range(10):
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return
+        time.sleep(0.3)
+    try:
+        os.killpg(pid, 9)  # SIGKILL
+    except ProcessLookupError:
+        return
+    except Exception:  # noqa: BLE001
+        return
+
+
+# ---------------------------------------------------------------------------
+# IO 助手（原子写，避免 wiki dev server 读到半写 JSON）
+# ---------------------------------------------------------------------------
+
+
+def _atomic_write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, ensure_ascii=False, default=str), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+# ---------------------------------------------------------------------------
+# CLI（CC 会话调用：publish-candidate）
+# ---------------------------------------------------------------------------
+
+
+def _cli() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="patrol_wiki_env", description="巡检 wiki 渲染环境编排")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_pub = sub.add_parser("publish-candidate", help="候选/真值 MD → entries/{id}.json")
+    p_pub.add_argument("--content-root", required=True)
+    p_pub.add_argument("--markdown-file", required=True)
+    p_pub.add_argument("--doc-id", required=True)
+    p_pub.add_argument("--title", default="")
+    p_pub.add_argument("--filename", default="")
+
+    p_wait = sub.add_parser("wait-ready", help="阻塞至 wiki dev server 可服务（截图前调）")
+    p_wait.add_argument("--port", type=int, required=True)
+    p_wait.add_argument("--timeout", type=float, default=_READY_PROBE_TIMEOUT_S)
+
+    args = parser.parse_args()
+
+    if args.cmd == "publish-candidate":
+        content_root = Path(args.content_root)
+        markdown = Path(args.markdown_file).read_text(encoding="utf-8")
+        target = write_entry_content(
+            content_root,
+            markdown=markdown,
+            doc_id=UUID(args.doc_id),
+            entry_title=args.title,
+            entry_filename=args.filename,
+        )
+        # CC 解析用：打印产物路径 JSON（单行）。
+        print(json.dumps({"entry_content_path": str(target)}))
+        return 0
+
+    if args.cmd == "wait-ready":
+        ok = wait_ready(port=args.port, timeout_s=args.timeout)
+        print(json.dumps({"ready": bool(ok), "port": args.port, "url": wiki_url(port=args.port)}))
+        return 0 if ok else 1
+
+    parser.error(f"unknown cmd: {args.cmd}")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -768,6 +768,7 @@ def _build_patrol_routine(
     source_task_key: str,
     known_unfixable_regions: list[dict[str, Any]] | None = None,
     wiki_env: dict[str, Any] | None = None,
+    known_defects: list[dict[str, Any]] | None = None,
 ) -> Routine:
     """构造巡检 Routine ORM 对象（纯函数，无 DB —— 可单测验证字段装配无 AttributeError）。
 
@@ -807,6 +808,8 @@ def _build_patrol_routine(
             candidate_md_path=candidate_md_path,
             qualified_threshold=qualified_threshold,
             known_unfixable_regions=known_unfixable_regions,
+            wiki_env=wiki_env,
+            known_defects=known_defects,
         ),
         acceptance_criteria=build_acceptance_criteria(
             baseline_branch=baseline_branch,
@@ -912,7 +915,9 @@ async def _create_and_start_patrol_routine(
     """
     from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
 
-    known_unfixable_regions = await PatrolMemoryStore(db).get_unfixable_regions(str(doc["id"]))
+    memory = PatrolMemoryStore(db)
+    known_unfixable_regions = await memory.get_unfixable_regions(str(doc["id"]))
+    known_defects = await memory.get_defects(str(doc["id"]))
     wiki_env = _setup_patrol_wiki_env(doc=doc, source_read_dir=source_read_dir)
     routine = _build_patrol_routine(
         repo_id=repo_id,
@@ -924,6 +929,7 @@ async def _create_and_start_patrol_routine(
         source_task_key=source_task_key,
         known_unfixable_regions=known_unfixable_regions,
         wiki_env=wiki_env,
+        known_defects=known_defects,
     )
     db.add(routine)
     await db.flush()

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -767,6 +767,7 @@ def _build_patrol_routine(
     regression_sample: list[str],
     source_task_key: str,
     known_unfixable_regions: list[dict[str, Any]] | None = None,
+    wiki_env: dict[str, Any] | None = None,
 ) -> Routine:
     """构造巡检 Routine ORM 对象（纯函数，无 DB —— 可单测验证字段装配无 AttributeError）。
 
@@ -828,7 +829,10 @@ def _build_patrol_routine(
             candidate_md_path=candidate_md_path,
             source_read_dir=source_read_dir,
             regression_sample=regression_sample,
-            extra={"source_task_key": source_task_key},
+            extra={
+                "source_task_key": source_task_key,
+                **(wiki_env or {}),
+            },
         ),
         current_phase=phase_mod.initial_phase({}),  # 扁平工作流：IMPLEMENT 起；worktree 仍开 FINALIZE
         reflections={},
@@ -836,6 +840,58 @@ def _build_patrol_routine(
         agent_id=None,
         is_template=False,
     )
+
+
+def _setup_patrol_wiki_env(
+    *,
+    doc: dict[str, Any],
+    source_read_dir: str,
+) -> dict[str, Any]:
+    """编排 patrol wiki 渲染环境：写 content scaffold + spawn ``next dev``（非阻塞）。
+
+    返回注入 routine config 的 ``wiki_env`` 字典（CC/prompt 据此截图、publish-candidate）：
+
+    - 成功：``wiki_render_available=True`` + ``wiki_dev_port`` / ``wiki_dev_pid`` /
+      ``wiki_url`` / ``wiki_content_root`` / ``wiki_pub_slug`` / ``wiki_entry_id`` / ``wiki_entry_slug``。
+    - 失败（pnpm/next 缺失、spawn 异常）：降级 ``wiki_render_available=False``——巡检仍可推进，
+      CC 据此回退 legacy ``_fidelity_render`` 近似渲染 + 标本轮降级（不阻塞心跳、不致 Routine 创建失败）。
+
+    **非阻塞**：``start_wiki_dev_server`` 仅 ``Popen`` 立即返回 pid；ready 探测由 CC 截图前
+    调 ``patrol_wiki_env wait-ready``（在 bash 内阻塞），不在本 scheduler tick 内同步等待
+    （单 worker 后端事件循环不可冻结）。
+    """
+    try:
+        from negentropy.engine.routine import patrol_wiki_env
+
+        content_root = Path(source_read_dir) / "wiki-content"
+        doc_id = doc["id"]
+        doc_title = _doc_display_title(doc)
+        doc_filename = str(doc.get("original_filename") or "")
+        patrol_wiki_env.ensure_content_scaffold(
+            content_root,
+            doc_id=doc_id,
+            doc_title=doc_title,
+            doc_filename=doc_filename,
+        )
+        port = patrol_wiki_env.pick_free_port()
+        pid = patrol_wiki_env.start_wiki_dev_server(content_root, port=port)
+        return {
+            "wiki_render_available": True,
+            "wiki_content_root": str(content_root),
+            "wiki_dev_port": port,
+            "wiki_dev_pid": pid,
+            "wiki_url": patrol_wiki_env.wiki_url(port=port),
+            "wiki_pub_slug": patrol_wiki_env.PATROL_PUB_SLUG,
+            "wiki_entry_id": str(patrol_wiki_env.PATROL_ENTRY_ID),
+            "wiki_entry_slug": patrol_wiki_env.PATROL_ENTRY_SLUG,
+        }
+    except Exception as exc:  # noqa: BLE001 - 降级：wiki 真值不可用时巡检仍可走 legacy 渲染
+        logger.warning(
+            "patrol_wiki_env_setup_failed_degraded",
+            doc_id=str(doc.get("id")),
+            error=str(exc),
+        )
+        return {"wiki_render_available": False}
 
 
 async def _create_and_start_patrol_routine(
@@ -857,6 +913,7 @@ async def _create_and_start_patrol_routine(
     from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
 
     known_unfixable_regions = await PatrolMemoryStore(db).get_unfixable_regions(str(doc["id"]))
+    wiki_env = _setup_patrol_wiki_env(doc=doc, source_read_dir=source_read_dir)
     routine = _build_patrol_routine(
         repo_id=repo_id,
         baseline_branch=baseline_branch,
@@ -866,6 +923,7 @@ async def _create_and_start_patrol_routine(
         regression_sample=regression_sample,
         source_task_key=source_task_key,
         known_unfixable_regions=known_unfixable_regions,
+        wiki_env=wiki_env,
     )
     db.add(routine)
     await db.flush()

--- a/apps/negentropy/src/negentropy/knowledge/_shared.py
+++ b/apps/negentropy/src/negentropy/knowledge/_shared.py
@@ -821,11 +821,16 @@ def _resolve_chunking_config_from_doc_request(
 async def _reparse_document_markdown(
     *,
     document_id: UUID,
+    resume: bool = False,
 ) -> None:
     """从 PostgreSQL 已存储的源字节重新加载文档，经 MCP Tool 重新解析 Markdown 并刷新存储。
 
     与 ingest pipeline 共用同一条 MCP Tool 提取路径（extract_source），
     确保 Document View 的 Markdown 内容与 Chunk 内容质量一致。
+
+    ``resume`` 控制 perceives auto_batch checkpoint 复用（双入口重试，与
+    ``POST /pipelines/{run_id}/retry`` 对称）：``False``（默认）丢弃 checkpoint
+    全量重跑；``True`` 断点续传。经 ``_maybe_inject_resume`` 注入 perceives 工具。
 
     作为 starlette BackgroundTask 执行（HTTP 已返回 200），故所有失败路径必须
     自洽兜底：写 ``markdown_extract_status='failed'`` + 可读 error，绝不让异常逃逸
@@ -899,6 +904,7 @@ async def _reparse_document_markdown(
             content=content,
             filename=doc.original_filename,
             content_type=doc.content_type,
+            resume=resume,
         )
 
         markdown_content = (result.markdown_content or "").strip()

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_export_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_export_service.py
@@ -25,6 +25,7 @@
 from __future__ import annotations
 
 import json
+import os
 import re
 from datetime import datetime
 from pathlib import Path
@@ -237,6 +238,107 @@ class WikiExportService:
         )
         return result
 
+    async def export_single_entry(
+        self,
+        db: AsyncSession,
+        *,
+        pub_id: UUID,
+        entry_id: UUID | None = None,
+        doc_id: UUID | None = None,
+        out_dir: Path,
+        bake_assets: bool | None = None,
+    ) -> WikiExportResult:
+        """单条导出：仅刷新一个 entry 的 ``entries/{id}.json`` + 局部 ``entries-index.json``。
+
+        与 ``export_all_published``（覆盖式全量）正交：不清空目录（不 ``_reset``）、
+        不触碰其他 entry / publication 文件，专供 PDF Fidelity Patrol Real-Render Gate
+        在 ``refresh_markdown(resume=false)`` 写入生产 markdown_content 后，把该 entry
+        的最新内容单条同步到 wiki 内容根（原子写 ``.tmp→os.replace``，避免与 wiki dev
+        server 请求期 ``fs.readFile`` 读取竞争）。
+
+        前置：publication 级 scaffold（``publication.json`` / ``nav-tree.json`` /
+        ``entries-index.json`` / 顶层 ``index.json`` / ``publications.json``）须已由
+        ``export_all_published`` 或等价方式建立（patrol 启动期 ``ensure_staging_publication``
+        负责）。本方法仅刷新 entry 内容 + 幂等 upsert entries-index 该条目。
+        """
+        result = WikiExportResult()
+        result.generated_at = datetime.utcnow().isoformat() + "Z"
+
+        pub = await WikiDao.get_publication(db, pub_id)
+        if pub is None:
+            raise ValueError(f"publication not found: {pub_id}")
+        slug = pub.slug
+        result.publications.append(slug)
+
+        entries = await WikiDao.get_entries(db, pub.id)
+        target = None
+        for e in entries:
+            if entry_id is not None and e.id == entry_id:
+                target = e
+                break
+            if doc_id is not None and e.document_id == doc_id:
+                target = e
+                break
+        if target is None:
+            raise ValueError(f"entry not found in publication {slug}: entry_id={entry_id} doc_id={doc_id}")
+        if target.document_id is None:
+            raise ValueError(f"entry {target.id} is CONTAINER (no document_id), cannot export content")
+
+        cfg = settings.knowledge.wiki_export
+        if bake_assets is None:
+            bake_assets = cfg.bake_assets
+        assets_dir = out_dir / "assets"
+
+        content_data = await WikiDao.get_entry_content(db, target.id)
+        if content_data is None:
+            raise ValueError(f"entry has no content: {target.id}")
+        resp = build_entry_content_response(target.id, content_data, entry_slug=target.entry_slug)
+        payload = resp.model_dump(mode="json")
+        payload["markdown_content"] = await self._rewrite_asset_links(
+            payload.get("markdown_content") or "", assets_dir=assets_dir
+        )
+        entries_dir = out_dir / "entries"
+        self._write_json_atomic(entries_dir / f"{target.id}.json", payload, result)
+        result.entries += 1
+
+        # 幂等 upsert entries-index 该条目（scaffold 缺失/损坏则建最小骨架）
+        pub_dir = out_dir / "publications" / slug
+        index_path = pub_dir / "entries-index.json"
+        entry_item = {
+            "id": str(target.id),
+            "document_id": str(target.document_id),
+            "entry_slug": target.entry_slug,
+            "entry_title": target.entry_title,
+            "is_index_page": bool(target.is_index_page),
+        }
+        items: list[dict[str, Any]] = []
+        slug_to_id: dict[str, str] = {}
+        if index_path.exists():
+            try:
+                existing = json.loads(index_path.read_text(encoding="utf-8"))
+                items = list(existing.get("items") or [])
+                slug_to_id = dict(existing.get("slug_to_id") or {})
+            except Exception:  # noqa: BLE001 - 损坏则重建
+                items = []
+                slug_to_id = {}
+        items = [it for it in items if it.get("id") != entry_item["id"]]
+        items.append(entry_item)
+        slug_to_id[target.entry_slug] = str(target.id)
+        self._write_json_atomic(
+            index_path,
+            {"items": items, "total": len(items), "slug_to_id": slug_to_id},
+            result,
+        )
+
+        logger.info(
+            "wiki_export_single_entry",
+            pub_slug=slug,
+            entry_id=str(target.id),
+            doc_id=str(target.document_id),
+            markdown_size=len(payload.get("markdown_content") or ""),
+        )
+        return result
+
     # ------------------------------------------------------------------
     # 序列化辅助
     # ------------------------------------------------------------------
@@ -358,6 +460,23 @@ class WikiExportService:
             json.dumps(payload, default=_json_default, ensure_ascii=False),
             encoding="utf-8",
         )
+        result.files.append(str(path))
+
+    @staticmethod
+    def _write_json_atomic(path: Path, payload: Any, result: WikiExportResult) -> None:
+        """原子写（``.tmp`` → ``os.replace``）：避免 wiki dev server 请求期读到半写 JSON。
+
+        供 ``export_single_entry`` / patrol 候选内容写入：巡检每轮覆盖写候选 Markdown
+        到 ``entries/{id}.json``，而 wiki dev server（``next dev``）按请求 ``fs.readFile``
+        并有进程级 ``fileCache``（见 ``content-source.ts``）——非原子写会产生半写窗口。
+        """
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(
+            json.dumps(payload, default=_json_default, ensure_ascii=False),
+            encoding="utf-8",
+        )
+        os.replace(tmp, path)
         result.files.append(str(path))
 
 

--- a/apps/negentropy/src/negentropy/knowledge/routes/documents.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/documents.py
@@ -421,6 +421,7 @@ async def _refresh_document_markdown_impl(
     background_tasks.add_task(
         _reparse_document_markdown,
         document_id=document_id,
+        resume=payload.resume,
     )
 
     return DocumentMarkdownRefreshResponse(

--- a/apps/negentropy/src/negentropy/knowledge/schemas.py
+++ b/apps/negentropy/src/negentropy/knowledge/schemas.py
@@ -668,9 +668,23 @@ class DocumentMarkdownRefreshResponse(BaseModel):
 
 
 class DocumentMarkdownRefreshRequest(BaseModel):
-    """文档 Markdown 重解析请求。"""
+    """文档 Markdown 重解析请求。
+
+    ``resume`` 控制 perceives auto_batch checkpoint 复用语义（双入口重试，与
+    ``POST /pipelines/{run_id}/retry`` 的 ``PipelineRetryRequest.resume`` 对称）：
+
+    - ``False``（默认）= 重新开始：丢弃 ``.batch_state/{sha1[:12]}`` checkpoint，
+      全量重跑 PDF→Markdown pipeline。契合「Rebuild / 彻底重走」直觉，亦是
+      PDF Fidelity Patrol Real-Render Gate 的默认入口。
+    - ``True`` = 断点续传：复用 checkpoint，从最后完成切片继续（失败/partial 态
+      的「Continue (resume)」语义）。
+
+    经 ``_maybe_inject_resume`` 咽喉注入声明了 ``resume`` 参数的 MCP 工具
+    （perceives ``parse_pdf_to_markdown`` 的 ``resume`` 默认 True）。
+    """
 
     app_name: str | None = None
+    resume: bool = False
 
 
 class DocumentTranslateRequest(BaseModel):

--- a/apps/negentropy/tests/unit_tests/agents/test_skill_pdf_fidelity_parity.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_skill_pdf_fidelity_parity.py
@@ -62,9 +62,9 @@ def test_twin_fidelity_dimensions_present_in_both():
 
 
 def test_yaml_version_bumped_and_perceives_link_fixed():
-    """version 升到 1.1.0，且 perceives 资源指针修死链→monorepo 子树。"""
+    """version 升到 1.2.0（三杠杆改造），且 perceives 资源指针修死链→monorepo 子树。"""
     tpl = {t.template_id: t for t in load_all()}["pdf_fidelity_restore"]
-    assert tpl.version == "1.1.0"
+    assert tpl.version == "1.2.0"
     refs = " ".join(str(r.get("ref", "")) for r in tpl.resources)
     assert "github.com/negentropy/negentropy-perceives" not in refs  # 旧死链已移除
     assert "ThreeFish-AI/negentropy" in refs  # 指向真实 monorepo

--- a/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_patrol_prompt.py
@@ -23,8 +23,8 @@ def test_build_goal_injects_doc_params():
     assert "论文 A" in g
     assert "/tmp/patrol/doc-123/source.pdf" in g
     assert "patrol-candidate.md" in g
-    assert "保真度" in g  # 紧凑目标：本轮评分（非开放式「调度三系部」）
-    assert "采样" in g  # 防过度探查：采样比对
+    assert "保真度" in g  # 紧凑目标：本轮逐页视觉保真度（全绿率）
+    assert "分层闭环" in g  # 新闭环结构（inner + gate）
     assert "95" in g  # 合格阈值注入 done 判定
     assert "合格阈值" in g
 
@@ -64,12 +64,13 @@ def test_build_goal_no_unfixable_hint_when_empty():
 
 def test_build_acceptance_criteria_allows_unfixable_carveout():
     ac = build_acceptance_criteria(baseline_branch="origin/feature/1.x.x", qualified_threshold=95)
-    assert "95" in ac  # 合格阈值（取代旧「满分 100」门槛）
-    assert "100" in ac  # 收敛评分区间 95-100
+    assert "95" in ac  # 合格阈值（全绿率口径）
+    assert "100" in ac  # pass_pages/total_pages×100（全绿率公式）
     assert "unfixable" in ac
     assert "origin/feature/1.x.x" in ac
     assert "pdf-fidelity-contract" in ac
-    assert "评分指引" in ac  # 防评估器压分致本应成功的 Routine 误判 Failed
+    assert "评分口径" in ac  # 全绿率口径（防评估器压分致本应成功的 Routine 误判 Failed）
+    assert "pass_pages" in ac  # 全绿率公式字段
 
 
 def test_build_routine_config_shape():
@@ -123,19 +124,24 @@ def test_build_routine_config_source_task_key():
 
 
 def test_system_prompt_contains_protocol_and_contract():
-    # 紧凑闭环 + 防过度探查 + 非回归 + 红线 + JSON 契约 均应在协议中
+    # 分层闭环 + 三杠杆 + 防过度探查 + 非回归 + 红线 + JSON 契约 均应在协议中
     assert "uv run --project apps/negentropy-perceives perceives parse-pdf" in PATROL_SYSTEM_PROMPT
-    assert "_fidelity_render" in PATROL_SYSTEM_PROMPT  # 渲染对比底座
-    assert "采样" in PATROL_SYSTEM_PROMPT  # 防逐页读全图撑爆上下文
+    assert "_fidelity_render" in PATROL_SYSTEM_PROMPT  # legacy 降级渲染底座
+    assert "视觉聚焦" in PATROL_SYSTEM_PROMPT  # 程序化全页预筛 + 视觉聚焦（防逐页读全图撑爆上下文）
     assert "不 spawn Agent" in PATROL_SYSTEM_PROMPT  # 防过度探查（曾致 context 耗尽 abort）
-    assert "Contemplation" in PATROL_SYSTEM_PROMPT  # 三角色（轻量分工）
-    assert "Action" in PATROL_SYSTEM_PROMPT
-    assert "Internalization" in PATROL_SYSTEM_PROMPT
+    assert "三杠杆" in PATROL_SYSTEM_PROMPT  # 拟合范围：工程代码 + Skills + 流程
+    assert "Inner Loop" in PATROL_SYSTEM_PROMPT  # 分层闭环：fast inner loop
+    assert "Real-Render Gate" in PATROL_SYSTEM_PROMPT  # 分层闭环：地面真值门控
+    assert "归因路由表" in PATROL_SYSTEM_PROMPT  # 缺陷三杠杆归因
+    assert "双源验证决策树" in PATROL_SYSTEM_PROMPT  # 防误归因到 perceives
     assert "非回归" in PATROL_SYSTEM_PROMPT
-    assert "refresh-markdown" in PATROL_SYSTEM_PROMPT  # 红线：禁止调生产重转
+    assert "绝不写生产 knowledge_documents.markdown_content" in PATROL_SYSTEM_PROMPT  # inner loop 红线
+    assert "refresh_markdown(resume=false)" in PATROL_SYSTEM_PROMPT  # gate 真 Rebuild 入口
     assert "pdf-fidelity-contract" in PATROL_SYSTEM_PROMPT
     # 零代码改动即无 PR（修「PR 仅含 patrol-candidate.md」根因：候选是 worktree 外临时产物、不纳入交付）
     assert "零代码改动" in PATROL_SYSTEM_PROMPT
     # R10 沉淀：每轮重转前须清 checkpoint，否则 auto_batch resume 复用旧切片、perceives 改动不生效
     assert ".batch_state" in PATROL_SYSTEM_PROMPT
     assert "doc_id" in CONTRACT_SCHEMA
+    assert "page_pass_rate" in CONTRACT_SCHEMA  # 全绿率口径
+    assert "attribution" in CONTRACT_SCHEMA  # 三杠杆归因字段


### PR DESCRIPTION
## 背景

「PDF Fidelity Patrol」巡检 Routine 当前的拟合闭环存在三处与目标失配：

1. **拟合面过窄**：`PATROL_SYSTEM_PROMPT` 把可改范围硬限定在 perceives 三模块，而真实保真度还受渲染层（wiki/ui）、摄取层、导出层、Skill 本体、巡检流程自身影响。
2. **对照对象失真**：用 `_fidelity_render` 的 Python-Markdown 近似渲染，与真实 wiki 栈（react-markdown + remark/rehype）系统性不同，致公式/Mermaid/figure/figcaption/图片尺寸假阳性/假阴性，且把渲染层缺陷误归到 perceives。
3. **闭环不真**：候选 MD 是 `/tmp` 临时产物、明令禁写生产，从不到真实 wiki 站点走一遭。

本 PR 把拟合范围扩散到「工程代码 + Skills + 流程」三杠杆，对照对象换成真实 wiki 站点页面与源 PDF 的逐页截图，闭环改为「Rebuild → 发布 wiki → 逐页截图对照 → 三杠杆归因 → 改 → 再来」。

## 四个关键决策（已与用户确认）

| # | 决策 | 选择 |
|---|---|---|
| D1 | 闭环保真度 vs 代价 | 分层闭环：内层用真实 wiki 渲染栈渲染 worktree CLI 候选 MD（秒级、不写生产）；周期性 Real-Render Gate 走真 Rebuild(`resume=false`)+发布作地面真值 |
| D2 | 代码拟合如何在 Routine 内验证 | CLI 内层验证：worktree CLI 直接 import 本地代码，即时反映改动 |
| D3 | refresh_markdown 是否支持清 checkpoint | 加 `resume` 参数，默认 `false`（彻底重走） |
| D4 | 实施范围 | 一次性完整实现（单 PR，按关注点分 commit） |

## 改动清单（7 commit）

- **C1 `refresh-markdown resume`**：`DocumentMarkdownRefreshRequest` 加 `resume:bool=False`（与 pipeline retry 对称）；UI Re-Parse 常态默认全量重跑、失败态 Continue 传 `resume=true`。
- **C2 `wiki 单条导出 + dev 缓存旁路`**：`WikiExportService.export_single_entry`（不 `_reset`、原子写、局部 entries-index）；`content-source.ts` dev 模式旁路进程级 fileCache（使 next dev 能读到每轮覆盖写的候选 MD）。
- **C3 `patrol_wiki_env`**：新模块编排真实 wiki 渲染环境（文件态 content root scaffold + 非阻塞 spawn `next dev` + 复用 `build_entry_content_response` schema）；handler 创建期编排+注入 config；orchestrator 每轮 `_reap_wiki_dev_servers` 兜底清理防残骸。
- **C4 `patrol_page_check`**：perceives 新增程序化逐页预筛（PyMuPDF `render_pdf_page_index` + Playwright DOM 探针 + 指纹锚点对齐 → `program-checks.json`/`align-index.json`），仅 `vision_required` 页进 CC 视觉队列（≤8 对），既逐页覆盖又不撑爆上下文；`_fidelity_render` markdown 路径标 legacy。
- **C5+C6+C7+C9（联动）**：`CONTRACT_SCHEMA` 扩 `attribution.{lever,layer,target_file}` + `evidence` + `score_method=page_pass_rate`；`PATROL_SYSTEM_PROMPT` 改写为分层闭环 + 三杠杆范围表 + 归因路由表 + 双源验证决策树 + 单轮根因约束 + 按杠杆分派非回归；评分改全绿率 `pass_pages/total×100`；`patrol_memory` 新增 `TAG_DEFECT`（纵向非回归）；Judge 增补全绿率口径校验。
- **C8 `Skill v1.2.0`**：`pdf-fidelity-restore` 分层修复路由升级三杠杆版 + 三条新洞察（渲染栈差异/全绿率/双源验证）+ reseed 迁移 0094（SSOT 双写 SKILL.md↔yaml，parity 测试守卫）。
- **测试**：52 个巡检相关单测全过（prompt 8 + memory 17 + handler 22 + skill parity 5）。

## 架构（分层闭环 + 单一真实渲染栈）

```mermaid
flowchart TD
  Init[Routine 启动: 选文档+scaffold+spawn next dev] --> Inner
  subgraph Inner[Fast Inner Loop 每轮秒级 不写生产]
    B1[清 checkpoint sha1] --> B2[CLI 重转 worktree 代码]
    B2 --> B3[publish-candidate 到 wiki content root]
    B3 --> B4[patrol_page_check 程序化逐页预筛]
    B4 --> B5[Playwright 截 wiki 真页 + PyMuPDF PDF 页]
    B5 --> B6[视觉聚焦 ≤8 对 仅 vision_required 页]
    B6 --> B7[三杠杆归因 + 双源验证]
    B7 --> B8[全绿率评分]
    B8 --> B9{score<95 且可修复?}
    B9 -- 是 --> B10[改一个逻辑根因 ≤3文件≤2杠杆] --> B2
  end
  Inner -- 每 N 轮/达阈值/FINALIZE --> Gate
  subgraph Gate[Real-Render Gate 地面真值]
    C1[refresh_markdown resume=false 写生产] --> C2[重发 wiki] --> C3[截图真页+PDF] --> C4[校准评分漂移]
  end
  Gate -- 未达标 --> Inner
```

## V1 已知限制（后续拟合补全，不阻塞本 PR）

- 候选/真值 MD 内 `/api/documents/.../assets/` 图片引用在 wiki dev 源下不解析（不同源、未 bake）——文字/段落/表格/公式/代码/布局类拟合已全覆盖；图片显示尺寸/figure 类待 asset bake 管线接入。
- 程序化预筛阈值（文本相似度/表格单元格/KaTeX 错误）为保守初值，待历史巡检数据校准。
- 渲染层 wiki/ui 不对称对齐（figcaption 双源铁律）为首项拟合目标，由新闭环自驱发现修复，不在本基建 PR 硬编码。

## 验证

- pre-commit hooks 全过（ruff lint/format、mypy perceives、ESLint、yaml check）。
- alembic 单一 head `0094`。
- 52 巡检相关单测全过。
- 端到端（启 patrol scheduler + 真 PDF + wiki dev 截图）属集成验证，需 live stack + Postgres，列入 plan 验证小节供线下执行。

🤖 Generated with [Claude Code](https://github.com/claude.com/claude-code)