### PR TITLE
fix(patrol): selector 排除已删除文档 + 源 blob 丢失优雅降级（source_unavailable）

### DIFF
--- a/apps/negentropy-ui/app/knowledge/documents/_components/PatrolStatusBadge.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/_components/PatrolStatusBadge.tsx
@@ -1,11 +1,12 @@
 /**
  * PDF Fidelity Patrol 巡检态徽标（Documents 列表「巡检状态」列用）。
  *
- * 4 态映射（对齐后端 ``knowledge_documents.patrol_status`` 列，SSOT）：
+ * 5 态映射（对齐后端 ``knowledge_documents.patrol_status`` 列，SSOT）：
  * - ``null``/缺省 → 未巡检（muted 中性）
  * - ``in_progress`` → 正在巡检（sky + 脉冲点）
  * - ``unfixable`` → 巡检失败（red）
  * - ``done`` → 拟合成功（emerald）+ 拟合分数
+ * - ``source_unavailable`` → 源文件缺失（amber；源 blob 永久丢失，patrol 跳过）
  *
  * 配色对齐黄金标准 ``app/interface/routine/_components/status-style.ts``（routineStatusClass）
  * 与巡检语义表 ``features/scheduler/patrol-reason.ts``；分数上色复用 ``scoreColorClass``。
@@ -13,7 +14,13 @@
 import { scoreColorClass } from "@/components/transcript/status-shared";
 import { cn } from "@/lib/utils";
 
-export type PatrolStatus = "in_progress" | "done" | "unfixable" | null | undefined;
+export type PatrolStatus =
+  | "in_progress"
+  | "done"
+  | "unfixable"
+  | "source_unavailable"
+  | null
+  | undefined;
 
 const BADGE_BASE =
   "inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold whitespace-nowrap";
@@ -27,6 +34,8 @@ export function patrolStatusBadgeClass(status: PatrolStatus): string {
       return "bg-emerald-500/15 text-emerald-800 dark:text-emerald-200";
     case "unfixable":
       return "bg-red-500/15 text-red-800 dark:text-red-200";
+    case "source_unavailable":
+      return "bg-amber-500/15 text-amber-800 dark:text-amber-200";
     default:
       return "bg-muted/60 text-text-secondary";
   }
@@ -41,6 +50,8 @@ export function patrolStatusLabel(status: PatrolStatus): string {
       return "拟合成功";
     case "unfixable":
       return "巡检失败";
+    case "source_unavailable":
+      return "源文件缺失";
     default:
       return "未巡检";
   }

--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -762,7 +762,8 @@ export default function DocumentsPage() {
                                 </button>
                                 {isPdfDocument(doc) &&
                                   (doc.patrol_status === "done" ||
-                                    doc.patrol_status === "unfixable") && (
+                                    doc.patrol_status === "unfixable" ||
+                                    doc.patrol_status === "source_unavailable") && (
                                     <button
                                       onClick={() => void handleResetPatrol(doc)}
                                       disabled={resettingId === doc.id}

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1364,8 +1364,9 @@ export interface KnowledgeDocument {
    * - `in_progress` = 正在巡检
    * - `unfixable` = 巡检失败
    * - `done` = 拟合成功
+   * - `source_unavailable` = 源文件缺失（源 blob 永久丢失，patrol 跳过）
    */
-  patrol_status?: "in_progress" | "done" | "unfixable" | null;
+  patrol_status?: "in_progress" | "done" | "unfixable" | "source_unavailable" | null;
   /** 巡检 best_score 峰值（done/unfixable 携带）。 */
   patrol_score?: number | null;
   /** 当前巡检态归属 Routine（cancelled 回退幂等守卫）。 */

--- a/apps/negentropy-ui/features/scheduler/patrol-reason.ts
+++ b/apps/negentropy-ui/features/scheduler/patrol-reason.ts
@@ -15,7 +15,8 @@ export type PatrolReason =
   | "in_progress"
   | "patrol_disabled"
   | "routine_disabled"
-  | "stage_source_pdf_failed";
+  | "stage_source_pdf_failed"
+  | "stage_source_pdf_unavailable";
 
 export const PATROL_REASON_LABEL: Record<PatrolReason, string> = {
   spawned: "已派生 Routine",
@@ -25,6 +26,7 @@ export const PATROL_REASON_LABEL: Record<PatrolReason, string> = {
   patrol_disabled: "巡检已禁用",
   routine_disabled: "Routine 子系统未启用",
   stage_source_pdf_failed: "源 PDF 预取失败",
+  stage_source_pdf_unavailable: "源文件缺失·已跳过",
 };
 
 /** 徽标 tailwind class（成功 / 警示 / 中性 / 错误）。 */
@@ -36,6 +38,7 @@ export const PATROL_REASON_STYLE: Record<PatrolReason, string> = {
   patrol_disabled: "bg-muted text-text-secondary",
   routine_disabled: "bg-muted text-text-secondary",
   stage_source_pdf_failed: "bg-red-500/10 text-red-700 dark:text-red-300",
+  stage_source_pdf_unavailable: "bg-amber-500/10 text-amber-700 dark:text-amber-300",
 };
 
 const ORDER: PatrolReason[] = [
@@ -46,6 +49,7 @@ const ORDER: PatrolReason[] = [
   "patrol_disabled",
   "routine_disabled",
   "stage_source_pdf_failed",
+  "stage_source_pdf_unavailable",
 ];
 
 export function isPatrolReason(value: unknown): value is PatrolReason {

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -174,12 +174,8 @@ async def _run_patrol_tick(*, task_key: str) -> HandlerResult:
     try:
         source_pdf_path, source_read_dir = await _stage_source_pdf(doc_id=doc_id, uri=doc["content_uri"])
     except Exception as exc:
-        logger.warning("patrol_stage_source_pdf_failed", doc_id=doc_id, error=str(exc))
-        return HandlerResult(
-            status="failed",
-            error=f"stage source pdf failed: {exc}",
-            metrics={"reason": "stage_source_pdf_failed", "doc_id": doc_id},
-        )
+        # 源 PDF 预取失败分类（活性韧性）——永久丢失标记 source_unavailable 终态，瞬态维持 failed 重试。
+        return await _handle_stage_source_failure(doc_id=doc_id, exc=exc)
 
     # 确保回归基线集 + 创建并启动巡检 Routine
     async with AsyncSessionLocal() as db:
@@ -657,7 +653,11 @@ async def _has_running_patrol(db) -> bool:
 
 
 async def _select_next_pending_doc(db, *, skip_ids: set[str] | None = None) -> dict[str, Any] | None:
-    """选最早入库、未巡检（``patrol_status IS NULL``）的 PDF 文档（content_type=pdf 且转换已完成）。
+    """选最早入库、未巡检（``patrol_status IS NULL``）的 **active** PDF 文档。
+
+    前置资格（文档级，对齐全仓 ``status == "active"`` 约定，见 ``storage/service.py`` 列查询）：
+    ``app_name`` / ``status = 'active'``（排除软删文档——其源 blob 可能已随删除清除）/ ``content_type``
+    ILIKE pdf / ``markdown_extract_status = 'completed'``。
 
     巡检资格判定的两道正交守卫：
       - **巡检态门控**（SSOT）：``patrol_status IS NULL`` = 未巡检入选；``in_progress``/``done``/
@@ -682,6 +682,7 @@ async def _select_next_pending_doc(db, *, skip_ids: set[str] | None = None) -> d
         "SELECT id, content_uri, original_filename, display_name, metadata->>'title' "
         "FROM negentropy.knowledge_documents "
         "WHERE app_name = :app "
+        "AND status = 'active' "
         "AND COALESCE(content_type,'') ILIKE '%pdf%' "
         "AND markdown_extract_status = 'completed' "
         "AND patrol_status IS NULL "
@@ -707,11 +708,16 @@ async def _select_next_pending_doc(db, *, skip_ids: set[str] | None = None) -> d
 
 
 async def _select_regression_sample(db, *, size: int) -> list[str]:
-    """分层抽取近 ``size`` 份已转换 PDF 作为回归基线样本（doc_id 字符串列表）。"""
+    """分层抽取近 ``size`` 份已转换 **active** PDF 作为回归基线样本（doc_id 字符串列表）。
+
+    ``status = 'active'`` 与 ``_select_next_pending_doc`` 对齐——避免把已删除文档（源 blob 可能已
+    清除）当作生产基线样本。
+    """
     rows = await db.execute(
         sa.text(
             "SELECT id::text FROM negentropy.knowledge_documents "
             "WHERE app_name = :app "
+            "AND status = 'active' "
             "AND COALESCE(content_type,'') ILIKE '%pdf%' "
             "AND markdown_extract_status = 'completed' "
             "ORDER BY created_at DESC LIMIT :n"
@@ -751,6 +757,48 @@ async def _stage_source_pdf(*, doc_id: str, uri: str) -> tuple[str, str]:
         data = await get_blob_storage().download(uri)
         source_path.write_bytes(data)
     return str(source_path), str(doc_dir)
+
+
+async def _handle_stage_source_failure(*, doc_id: str, exc: Exception) -> HandlerResult:
+    """源 PDF 预取失败的分类处理（活性韧性）；``_run_patrol_tick`` except 中直接 ``return await``。
+
+    - **永久丢失**（``StorageError``「Blob not found」，如已删除文档 blob 已清除）→ 标记
+      ``source_unavailable`` 终态：selector ``patrol_status IS NULL`` 即排除，不再每 tick 重选
+      卡死队列 / 累积 consecutive_failures 触发任务禁用；本 tick 优雅 ``ok`` 继续。
+    - **瞬态错误**（其余 ``StorageError``，如 DB 抖动 ``Failed to download``）→ 维持 ``failed``，
+      下一 tick 重试，不永久标记（避免误杀可恢复故障）。
+
+    ``source_unavailable`` 文档可经「重置为未拟合」清回 NULL 在 blob 恢复后重试。
+    """
+    from negentropy.storage import StorageError
+
+    logger.warning("patrol_stage_source_pdf_failed", doc_id=doc_id, error=str(exc))
+    if isinstance(exc, StorageError) and "Blob not found" in str(exc):
+        async with AsyncSessionLocal() as wdb:
+            await wdb.execute(
+                sa.text(
+                    "UPDATE negentropy.knowledge_documents "
+                    "SET patrol_status = 'source_unavailable', patrol_score = NULL, "
+                    "    patrol_routine_id = NULL, patrol_updated_at = NOW() "
+                    "WHERE id = CAST(:doc_id AS uuid)"
+                ).bindparams(doc_id=doc_id)
+            )
+            await wdb.commit()
+        logger.warning("patrol_doc_source_unavailable", doc_id=doc_id, error=str(exc))
+        return HandlerResult(
+            status="ok",
+            output_summary=f"source pdf unavailable, doc marked source_unavailable: doc={doc_id}",
+            metrics={
+                "reason": "stage_source_pdf_unavailable",
+                "doc_id": doc_id,
+                PATROL_LIFECYCLE_KEY: PATROL_LIFECYCLE_IDLE,
+            },
+        )
+    return HandlerResult(
+        status="failed",
+        error=f"stage source pdf failed: {exc}",
+        metrics={"reason": "stage_source_pdf_failed", "doc_id": doc_id},
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/apps/negentropy/src/negentropy/models/perception.py
+++ b/apps/negentropy/src/negentropy/models/perception.py
@@ -139,6 +139,7 @@ class KnowledgeDocument(Base, UUIDMixin, TimestampMixin):
 
     # PDF Fidelity Patrol 巡检态（SSOT：文档级巡检状态权威源）
     # NULL=未巡检 / in_progress=巡检中 / unfixable=失败 / done=拟合成功
+    # / source_unavailable=源文件缺失（源 blob 永久丢失，patrol 跳过；可「重置为未拟合」重试）
     # 详见 docs/.agents/pdf-fidelity-patrol-status.md 与迁移 0092。
     patrol_status: Mapped[str | None] = mapped_column(
         String(20),

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
@@ -135,11 +135,12 @@ def test_select_next_pending_doc_reads_patrol_status_column():
 
 
 def test_select_next_pending_doc_sql_contains_per_doc_uniqueness_guard():
-    """Fix A：emitted SQL 必含「一文一活跃巡检」NOT EXISTS 守卫（排除 cancelled）；命名门控已移除（防回归）。
+    """Fix A：selector SQL 守卫不变量（NOT EXISTS / status='active' / patrol_status IS NULL）。
 
     FakeDB 不解析 SQL，仅以串存在性守护不变量防回归——后续重构若误删 NOT EXISTS / 把 cancelled 纳入
     阻塞，或误加回「命名门控」（display_name/metadata.title 非空预筛，会误排未巡检但无标题文档致
-    Scheduler 误报「无待检」），本断言即失败。真实 SQL 语义由集成测试覆盖。
+    Scheduler 误报「无待检」），或漏掉 status='active'（会选中软删文档→源 blob 丢失），本断言即失败。
+    真实 SQL 语义由集成测试覆盖。
     """
     import asyncio
 
@@ -149,6 +150,7 @@ def test_select_next_pending_doc_sql_contains_per_doc_uniqueness_guard():
     # 命名门控已移除：巡检资格不再预筛 display_name/metadata.title（命名下沉至 _doc_display_title）
     assert "COALESCE(NULLIF(display_name, ''), NULLIF(metadata->>'title', '')) IS NOT NULL" not in stmt
     assert "patrol_status IS NULL" in stmt  # 巡检态 SSOT 列（仅未巡检入选）
+    assert "AND status = 'active'" in stmt  # 仅 active 文档入选（排除软删，其源 blob 可能已清除）
     assert "NOT EXISTS" in stmt
     assert "config->>'patrol'" in stmt
     assert "config->>'doc_id'" in stmt
@@ -257,10 +259,29 @@ def test_run_patrol_tick_carries_lifecycle_markers():
     body = inspect.getsource(patrol._run_patrol_tick)
     # 源码中以标识符形式出现（非常量值）：spawn + in_progress = 2 处 in_flight
     assert body.count("PATROL_LIFECYCLE_IN_FLIGHT") >= 2
-    # no_pending_docs + repo_not_configured = 2 处 idle
+    # no_pending_docs + repo_not_configured = 2 处 idle（stage 失败的 idle 在 _handle_stage_source_failure）
     assert body.count("PATROL_LIFECYCLE_IDLE") >= 2
-    # stage_failed 是真失败（不打标记，走既有 failed 分支）
-    assert "stage_source_pdf_failed" in body
+    # stage 失败委托给 _handle_stage_source_failure（分类 + source_unavailable 标记见其专项白盒测试）
+    assert "_handle_stage_source_failure" in body
+
+
+def test_handle_stage_source_failure_branches_present():
+    """白盒：_handle_stage_source_failure 含两分支（活性韧性）。
+
+    - 永久 ``StorageError``「Blob not found」→ 标记 ``source_unavailable`` 终态 + ``ok`` + idle。
+    - 瞬态 ``StorageError``（如 ``Failed to download``）→ 维持 ``failed`` 重试，不永久标记。
+
+    防后续重构误删分类 / 把永久错误退回 failed（致队列卡死）/ 把瞬态错误误标终态（误杀可恢复文档）。
+    """
+    import inspect
+
+    body = inspect.getsource(patrol._handle_stage_source_failure)
+    assert "StorageError" in body
+    assert "Blob not found" in body  # 永久错误判定串（postgres_client.py:105 稳定文案）
+    assert "patrol_status = 'source_unavailable'" in body  # 永久分支标记终态 UPDATE
+    assert "stage_source_pdf_unavailable" in body  # 永久分支 reason（ok）
+    assert "stage_source_pdf_failed" in body  # 瞬态分支 reason（failed）
+    assert "PATROL_LIFECYCLE_IDLE" in body  # 永久分支 ok+idle（不累加 consecutive_failures）
 
 
 def test_finalize_terminal_patrols_branches_present():

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
@@ -590,6 +590,96 @@ async def test_select_next_pending_doc_includes_untitled_pdf(db_engine):
         assert eligible.fetchone() is not None  # no-title 未巡检 PDF 资格通过（命名门控不再拦截）
 
 
+async def test_select_next_pending_doc_excludes_deleted_doc(db_engine):
+    """回归：``status='deleted'`` 的 PDF 即便 patrol_status NULL 也不入选（源 blob 可能已随删除清除）。
+
+    复现并锁死「选中已删除文档 → Blob not found → 整 tick failed 卡死队列」根因——selector 须
+    ``status = 'active'`` 门控（对齐全仓文档查询约定）。测试库累积，故断言「该 deleted doc 不满足
+    selector 资格谓词」。
+    """
+    doc_id = await _seed_pdf_document(db_engine, original_filename="patrol-deleted.pdf")
+    factory = _sf(db_engine)
+    async with factory() as db:
+        await db.execute(
+            text("UPDATE negentropy.knowledge_documents SET status='deleted' WHERE id=:d"),
+            {"d": doc_id},
+        )
+        await db.commit()
+    async with factory() as db:
+        eligible = await db.execute(
+            text(
+                "SELECT 1 FROM negentropy.knowledge_documents "
+                "WHERE id = :d AND status = 'active' "
+                "  AND app_name = :app AND COALESCE(content_type,'') ILIKE '%pdf%' "
+                "  AND markdown_extract_status = 'completed' AND patrol_status IS NULL "
+                "  AND NOT EXISTS (SELECT 1 FROM negentropy.routines r "
+                "    WHERE r.config->>'patrol'='true' "
+                "      AND r.config->>'doc_id'=knowledge_documents.id::text "
+                "      AND r.status<>'cancelled')"
+            ),
+            {"d": doc_id, "app": settings.app_name},
+        )
+        assert eligible.fetchone() is None  # deleted → status='active' 门控排除
+
+
+# ---------------------------------------------------------------------------
+# Fix 3 活性韧性：源 blob 永久丢失 → source_unavailable 终态 + ok；瞬态 → failed 重试
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_stage_source_failure_marks_unavailable_on_blob_not_found(db_engine, monkeypatch):
+    """Fix 3 行为：源 blob 永久丢失（StorageError「Blob not found」）→ 标记 source_unavailable + ok。
+
+    文档由此被 selector（patrol_status IS NULL）排除，不再每 tick 重选卡死队列；本 tick 优雅 ok
+    （不累加 consecutive_failures、不触发任务禁用）。
+
+    注：``_handle_stage_source_failure`` 内部用模块级 ``AsyncSessionLocal``（import 时绑定生产
+    factory，``patch_db_globals`` autouse 仅改 ``db_session``/``db_deps`` 不及 ``patrol``），故此处显式
+    patch 到测试引擎工厂（参见 memory ``service-asyncsessionlocal-ci-cross-loop``）。
+    """
+    from negentropy.storage import StorageError
+
+    monkeypatch.setattr(patrol, "AsyncSessionLocal", _sf(db_engine))
+    doc_id = await _seed_pdf_document(db_engine, original_filename="patrol-blob-missing.pdf")
+    result = await patrol._handle_stage_source_failure(
+        doc_id=str(doc_id),
+        exc=StorageError("Blob not found: pgblob://knowledge/negentropy/library/x.pdf"),
+    )
+    assert result.status == "ok"
+    assert result.metrics["reason"] == "stage_source_pdf_unavailable"
+    assert result.metrics["doc_id"] == str(doc_id)
+    factory = _sf(db_engine)
+    async with factory() as db:
+        row = await db.execute(
+            text("SELECT patrol_status FROM negentropy.knowledge_documents WHERE id=:d"),
+            {"d": doc_id},
+        )
+        assert row.fetchone()[0] == "source_unavailable"  # 终态标记 → selector 即排除
+
+
+async def test_handle_stage_source_failure_fails_on_transient_error(db_engine):
+    """Fix 3 行为：瞬态 StorageError（如 DB 抖动 ``Failed to download``）→ 维持 failed，不永久标记。
+
+    doc 的 patrol_status 保持原状（未巡检 NULL），下一 tick 可重试——避免误杀可恢复故障。
+    """
+    from negentropy.storage import StorageError
+
+    doc_id = await _seed_pdf_document(db_engine, original_filename="patrol-transient.pdf")
+    result = await patrol._handle_stage_source_failure(
+        doc_id=str(doc_id),
+        exc=StorageError("Failed to download blob pgblob://x: connection reset"),
+    )
+    assert result.status == "failed"
+    assert result.metrics["reason"] == "stage_source_pdf_failed"
+    factory = _sf(db_engine)
+    async with factory() as db:
+        row = await db.execute(
+            text("SELECT patrol_status FROM negentropy.knowledge_documents WHERE id=:d"),
+            {"d": doc_id},
+        )
+        assert row.fetchone()[0] is None  # 未永久标记，保持未巡检可重试
+
+
 # ---------------------------------------------------------------------------
 # 巡检态 SSOT 列（knowledge_documents.patrol_status）+ 「重置为未拟合」API
 # ---------------------------------------------------------------------------

--- a/docs/.agents/pdf-fidelity-patrol-status.md
+++ b/docs/.agents/pdf-fidelity-patrol-status.md
@@ -14,7 +14,7 @@
 
 **目标**：文档级巡检状态迁为 `KnowledgeDocument` 持久列（权威读源 SSOT），Documents 列表新增「巡检状态」列，并提供「重置为未拟合」操作。
 
-## 2. 四态机
+## 2. 五态机
 
 `knowledge_documents.patrol_status` 列的值域（NULL 语义为核心）：
 
@@ -24,6 +24,7 @@
 | 正在巡检 | `in_progress` | spawn 巡检 Routine 时刻写入 | NULL（清空历史分） |
 | 巡检失败 | `unfixable` | 终态沉淀（best_score < 95 阈值 或 契约未 done） | best_score 峰值 |
 | 拟合成功 · {score} | `done` | 终态沉淀（best_score ≥ 95 或 契约自报 done） | best_score 峰值 |
+| 源文件缺失 | `source_unavailable` | 源 blob 永久丢失（巡检预取 `StorageError`「Blob not found」，**未 spawn**）patrol 跳过 | NULL |
 
 合格阈值常量 [`patrol_qualified_score_threshold=95`](../../apps/negentropy/src/negentropy/config/routine.py)（env `NE_ROUTINE_PATROL_QUALIFIED_SCORE_THRESHOLD`）。非 PDF 文档巡检状态列显示「—」（巡检仅针对 PDF，判据 `content_type ILIKE '%pdf%'`）。
 
@@ -36,6 +37,8 @@ stateDiagram-v2
     正在巡检 --> 未巡检: Routine cancelled（双守卫回退 NULL）
     拟合成功 --> 未巡检: 用户「重置为未拟合」
     巡检失败 --> 未巡检: 用户「重置为未拟合」
+    未巡检 --> 源文件缺失: stage 源 blob 永久丢失（Blob not found，未 spawn）
+    源文件缺失 --> 未巡检: 用户「重置为未拟合」（blob 恢复后重试）
 ```
 
 ## 3. 写入路径（dual-write 过渡 → Phase 2 SSOT）
@@ -96,10 +99,13 @@ sequenceDiagram
 
 [`_select_next_pending_doc`](../../apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py) 的候选门控（缺一不可）：
 
-1. `content_type ILIKE '%pdf%'`（PDF 文档）
-2. `markdown_extract_status = 'completed'`（转换完成）
-3. **`patrol_status IS NULL`**（4 态语义：仅未巡检入选；**替换**旧 `id NOT IN :skip` 的 Memory skip_ids 路径）
-4. `NOT EXISTS` 非 cancelled 巡检 Routine（一文一活跃巡检并发互斥；与 `patrol_status` 正交保留）
+1. `status = 'active'`（排除软删文档——其源 blob 可能已随删除清除；对齐全仓文档查询 `status == "active"` 约定）
+2. `content_type ILIKE '%pdf%'`（PDF 文档）
+3. `markdown_extract_status = 'completed'`（转换完成）
+4. **`patrol_status IS NULL`**（5 态语义：仅未巡检入选；**替换**旧 `id NOT IN :skip` 的 Memory skip_ids 路径）
+5. `NOT EXISTS` 非 cancelled 巡检 Routine（一文一活跃巡检并发互斥；与 `patrol_status` 正交保留）
+
+> **源 blob 永久丢失韧性**：当选中的 active 文档源 blob 确已丢失（`_stage_source_pdf` 抛 `StorageError`「Blob not found」）时，[`_handle_stage_source_failure`](../../apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py) 标记 `source_unavailable` 终态并令 tick 优雅 `ok` 继续——不整 tick failed 卡死队列、不累积 `consecutive_failures` 触发任务禁用；瞬态错误（如 `Failed to download`）仍维持 failed 下一 tick 重试，不误杀可恢复文档。
 
 > **命名关注正交下沉**至 [`_doc_display_title`](../../apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py)（`display_name` → `metadata.title` → `original_filename` 三级兜底，复用 `resolve_effective_display_name`）：巡检资格不因缺名而被否决。历史「命名门控」（要求 `display_name`/`metadata.title` 非空）曾在此预筛，致未巡检但无标题文档被永久跳过而 Scheduler 误报「无待检 PDF 文档」，已移除——仅剩原始文件名（含 arxiv-ID 如 `2603.05344v3.pdf`）时仍发起巡检，Routine 名暂以文件名兜底，待更优名源出现（用户改名 / Fix B 标题回填）由 [`_collapse_superseded_patrols`](../../apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py) 自愈取消旧 Routine、下 tick 以更优名重建。
 >


### PR DESCRIPTION
## 问题现象

PR #1073 移除命名门控后，patrol 选中 `2603.05344v3.pdf` 执行即报：

```
stage source pdf failed: Blob not found: pgblob://knowledge/negentropy/library/2603.05344v3.pdf
```

且该 tick `status="failed"`、文档未标记终态 → 下一 tick 重选同一文档 → 无限失败循环，卡死整个巡检队列、累积 `consecutive_failures` 可能触发任务禁用。而 Documents 页看不到该 URI（因页面过滤 `deleted`）。

## 根因（线上库数据 + 源码双重证实）

`knowledge_documents` 里 `2603.05344v3.pdf` 有**两条**同 `file_hash` 记录：

| | active 记录 | deleted 记录（patrol 选中） |
|---|---|---|
| `status` | active | **deleted** |
| `content_uri` | `…/43bacd7e-…/…pdf` | `…/library/…pdf`（blob 已随删除清除） |
| `patrol_status` | done | NULL（未巡检） |
| `created_at` | 2026-04-24 | 2026-06-11（更古老 → 先被选） |

`_select_next_pending_doc` 与 `_select_regression_sample` **从不按 `status` 过滤**——全仓其余文档查询一律 `status == "active"`（`storage/service.py:378,532,556`、`knowledge/service.py:1717`）。selector 选中 `deleted` 那条 → 源 blob 已不存在（`postgres_client.py:105` `Blob not found`）→ 整 tick failed。

## 改动

### Fix 1+2（根因）— selector 与回归样本排除非 active
两处 SQL 增加 `AND status = 'active'`（对齐全仓约定）。已删除 / 任何非 active 文档永不入选。

### Fix 3（活性韧性 + 精确语义）— 源 blob 丢失优雅降级 + 新增 `source_unavailable` 态
抽 `_handle_stage_source_failure` 分类源 PDF 预取失败（`_run_patrol_tick` except 中 `return await`）：

- **永久丢失**（`StorageError`「Blob not found」）→ 标记 `source_unavailable` 终态 + tick 优雅 `ok` 继续：selector `patrol_status IS NULL` 即排除，不再卡死队列 / 不累加 `consecutive_failures`。
- **瞬态错误**（其余 `StorageError`，如 DB 抖动 `Failed to download`）→ 维持 `failed` 下一 tick 重试，不永久标记（避免误杀可恢复故障）。

新增第 5 态 `source_unavailable`（**无需迁移**：`patrol_status` 无约束 `VARCHAR(20)`）。reconcile/finalize/collapse 均不触碰它（无 routine→无 winner），仅「重置为未拟合」可清回 NULL 重试。

| 文件 | 变更 |
|---|---|
| `pdf_fidelity_patrol.py` | selector + 回归样本加 `status='active'`；抽 `_handle_stage_source_failure` |
| `perception.py` | `patrol_status` 列注释补第 5 态 |
| `PatrolStatusBadge.tsx` / `knowledge-api.ts` / `page.tsx` / `patrol-reason.ts` | 前端适配 `source_unavailable`（徽标/类型/重置按钮/reason） |
| `pdf-fidelity-patrol-status.md` | 5 态机 + selector status 门控 + 韧性说明 |

## 验证

- ✅ 后端单测 + 集成 **54 passed**（含 deleted 排除 / source_unavailable 标记 / 瞬态 failed 三条新回归）
- ✅ Ruff lint/format、ESLint 全通过
- ✅ 前端 tsc：所改 4 文件零新增错误（既有 `@negentropy/agents-chat-core/protocol` 报错与本改动无关）
- ✅ 线上库只读复跑 post-fix selector：**仅**命中 active 的 `Loop-Engineering-IEEE.pdf`；deleted 的 `2603.05344v3.pdf`（`7f7d5283`）与已 done 的 active 副本（`4a43aba4`）均排除

## 风险与边界

- **无迁移**：`source_unavailable` 直接写入既有 VARCHAR(20)；既有 4 态语义不受影响。
- **瞬态保护**：仅 `Blob not found`（永久）才落 `source_unavailable`；DB 抖动等瞬态错误维持 failed 重试。
- **重置逃生口**：`source_unavailable` 文档可经「重置为未拟合」清回 NULL 在 blob 恢复后重试。
- **不触碰**：`patrol_status` 其余 4 态语义、reconcile/finalize/collapse/reset 既有逻辑、blob 存储本体。已删除的重复文档（`7f7d5283`）无需清理（Fix 1 后 patrol 不可见，软删保留审计）。

## 生效路径

PR 合入 `origin/feature/1.x.x` 并部署后（线上引擎自主仓 :3292 启动），下一轮 patrol tick 应 `patrol_routine_started` 派生 `Loop-Engineering-IEEE.pdf`（取代 failed 循环）。

🤖 Generated with [Claude Code](https://github.com/anthropic)