### PR TITLE
fix(perceives/formatter): 中文 PDF 保真修复（人名译名伪公式 + 标题末尾句号）

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -916,6 +916,22 @@ class MarkdownFormatter:
     # 保守阈值最大程度规避对数学密集文档的回归风险。
     _PROSE_MATH_MIN_WORDS = 3
     _PROSE_MATH_WORD_RE = re.compile(r"[A-Za-z]{3,}")
+    # CJK 散文伪公式判定：中文文档里外国人名译名（如「约翰·诺伊曼」「冯·诺伊曼」）
+    # 的间隔号「·」被公式引擎 LaTeX 化为 ``\cdot`` 并整名包进 inline ``$...$``。
+    # 此类 body 无 ASCII 字母词，``_PROSE_MATH_WORD_RE`` 阈值恒不命中，故补 CJK 判定。
+    # 含 CJK 字形（含日韩）即强信号——真实数学公式不含 CJK。
+    _CJK_CHAR_RE = re.compile(r"[一-鿿㐀-䶿぀-ヿ가-힯]")
+    # 真实数学结构护栏：body 含这些结构命令时即便夹杂 CJK 也保留（防误伤真公式）。
+    # 覆盖分式/求和/积分/根号/极限/上下标 _{}^{}/Greek 字母/关系符/集合运算等。
+    _REAL_MATH_CMD_RE = re.compile(
+        r"\\(?:frac|dfrac|tfrac|binom|sum|int|oint|sqrt|lim|log|sin|cos|tan|cot|"
+        r"partial|nabla|dot|ddot|vec|hat|bar|tilde|overline|underline|"
+        r"stackrel|overset|underset|mathbb|mathcal|mathrm|mathbf|operatorname|"
+        r"begin|alpha|beta|gamma|delta|theta|lambda|mu|sigma|omega|phi|psi|"
+        r"epsilon|eta|zeta|nu|tau|rho|kappa|chi|le|ge|ne|approx|equiv|propto|"
+        r"rightarrow|leftarrow|subset|supset|subseteq|cup|cap|notin|forall|exists)\b"
+        r"|_\{|\^\{"
+    )
 
     def _unwrap_prose_math(self, markdown_content: str) -> str:
         """撤销把散文（作者-单位行 / 关键词等）误包成 inline ``$...$`` 数学的失真。
@@ -938,6 +954,15 @@ class MarkdownFormatter:
 
         def _maybe_unwrap(m: "re.Match[str]") -> str:
             body = m.group(1)
+            # CJK 散文伪公式：body 含 CJK 字形 + ``\cdot`` 且无真实数学结构 → 解包。
+            # 兜底中文人名译名（「约翰·诺伊曼」等）被引擎整名包成 inline $...$ 的失真：
+            # 此类 body 无 ASCII 字母词，下方 ASCII 散文阈值对 CJK 恒不命中。
+            if (
+                self._CJK_CHAR_RE.search(body)
+                and "\\cdot" in body
+                and not self._REAL_MATH_CMD_RE.search(body)
+            ):
+                return body.replace("\\cdot", "·")
             if len(self._PROSE_MATH_WORD_RE.findall(body)) < self._PROSE_MATH_MIN_WORDS:
                 return m.group(0)
             # ^{...} → <sup>...</sup>；裸 ^x → <sup>x</sup>；\cdot → ·

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -734,6 +734,12 @@ class MarkdownFormatter:
             while prev_math != markdown_content:
                 prev_math = markdown_content
                 markdown_content = _merge_math_once(markdown_content)
+            # 标题末尾多余中文句号「。」剥离：docling 提取大事记/年表条目
+            # （如「## 1875 贝尔和沃森发明电话。」）时把陈述句末句号带入标题
+            # 文本，与源 PDF（标题无句号，如 AT&T 大事记框）失真。中文出版规范
+            # 标题末尾不加标点；仅剥离末尾中文句号「。」，保留「？」「！」等可能
+            # 表语气的标点，英文「.」不处理（章节编号/缩写可能合法结尾）。
+            markdown_content = re.sub(r"(?m)^(#{1,6} .*?)。+$", r"\1", markdown_content)
             return markdown_content
         except Exception as e:
             logger.warning(f"Error in fidelity-safe formatting: {str(e)}")

--- a/apps/negentropy-perceives/tests/unit/test_formatter_heading_period.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_heading_period.py
@@ -1,0 +1,43 @@
+"""标题末尾多余中文句号「。」剥离的回归测试 (format_fidelity_safe)。
+
+背景：docling 提取大事记/年表条目（如「## 1875 贝尔和沃森发明电话。」）时
+把陈述句末句号带入标题文本，与源 PDF（标题无句号）失真。中文出版规范标题
+末尾不加标点；``format_fidelity_safe`` 在 return 前剥离末尾中文句号，保留
+「？」「！」等语气标点与英文「.」。
+"""
+
+from negentropy.perceives.markdown.formatter import MarkdownFormatter
+
+
+def _fidelity(md: str) -> str:
+    return MarkdownFormatter().format_fidelity_safe(md)
+
+
+def test_strips_trailing_chinese_period():
+    out = _fidelity("## 1875 贝尔和沃森发明电话。")
+    assert "贝尔和沃森发明电话" in out
+    assert "电话。" not in out
+
+
+def test_strips_multiple_trailing_periods():
+    out = _fidelity("## 某标题。。")
+    assert "某标题。" not in out
+    assert "某标题" in out
+
+
+def test_preserves_question_mark():
+    out = _fidelity("## 为什么衰落？")
+    assert "为什么衰落？" in out
+
+
+def test_preserves_english_period():
+    # 英文「.」不处理（章节编号 / 缩写可能合法结尾）
+    out = _fidelity("## See Section 1.2.")
+    assert "Section 1.2." in out
+
+
+def test_preserves_body_sentence_period():
+    out = _fidelity("## 标题。\n正文句号应保留。\n")
+    assert "正文句号应保留。" in out
+    assert "## 标题。" not in out
+    assert "## 标题" in out


### PR DESCRIPTION
巡检文档《浪潮之巅 2019（第四版）》（939 页中文书籍）视觉保真度修复，两处定点改动。

## 变更

### 1. 解包中文人名译名被误判为公式的 inline 伪公式 (4030b946)
中文 PDF 外国人名译名间隔号「·」被公式引擎 LaTeX 化为 ``\cdot`` 并整名包进 inline ``$...$``（如「约翰·诺伊曼」→ ``$约翰\cdot 诺伊曼$``）。``_unwrap_prose_math`` 补 CJK 判定分支：body 含 CJK 字形 + ``\cdot`` 且无真实数学结构（``_REAL_MATH_CMD_RE`` 护栏：frac/sum/_{}^{}/Greek 等）即解包并 ``\cdot→·``，真实公式完整保留。

### 2. 剥离标题末尾多余中文句号「。」(ea043693)
docling 提取中文书籍大事记/年表条目（如「## 1875 贝尔和沃森发明电话。」）时把陈述句末句号带入标题文本，与源 PDF（标题无句号）失真；全书 212 处。``format_fidelity_safe``（auto_batch 合并产物最终后处理出口）在 return 前补一处 ``re.sub`` 剥离末尾中文句号「。」，保留「？」「！」语气标点与英文「.」（编号/缩写合法结尾）；正文句号不误伤（2824 处保留）。

## 验证
- 实测复核候选 md：212 处标题句号 → 0；328 处伪公式 → 1 处（孤立 ``$\cdot$``）
- 5 个新增回归测试（``test_formatter_heading_period.py``）+ 246 个 formatter 相关单测全绿
- ruff format / ruff lint / mypy 全绿；perceives unit 1952 passed
- 改动保守：仅作用于 CJK 标题/伪公式场景，对非中文、真实数学公式、正文零影响

## 说明
- ``test_config.py`` 3 个失败为基线预存配置漂移（``concurrent_requests`` 默认 32 vs 断言 16，基线提交 49c6eed7），与本 PR 改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)