### PR TITLE
fix(negentropy-ui): Corpus Documents 列表 Name 列溢出截断 + 侧栏回退按钮美化

### DIFF
--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -1069,7 +1069,7 @@ export default function KnowledgeBasePage() {
                                 <td className="px-4 py-3">
                                   <button
                                     type="button"
-                                    className="block min-w-0 text-left"
+                                    className="block w-full min-w-0 cursor-pointer text-left"
                                     onClick={() => syncQueryState({ view: "corpus", corpusId: selectedCorpusId, tab: "document-chunks", documentId: doc.id })}
                                   >
                                     <TextTooltip content={effectiveDocumentName(doc)}>

--- a/apps/negentropy-ui/app/knowledge/base/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/base/page.tsx
@@ -13,6 +13,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { ChevronLeft } from "lucide-react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { toast } from "@/lib/activity-toast";
 import {
@@ -968,12 +969,15 @@ export default function KnowledgeBasePage() {
                 data-testid="corpus-sidebar"
                 className="flex h-full flex-col rounded-2xl border border-border bg-card p-4 shadow-sm"
               >
-                <button
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mb-3 -ml-1.5 self-start"
+                  leftIcon={<ChevronLeft className="h-4 w-4" aria-hidden />}
                   onClick={() => syncQueryState({ view: "overview", corpusId: null, tab: null, documentId: null })}
-                  className={outlineButtonClassName("neutral", "mb-3 rounded px-2 py-1 text-xs")}
                 >
-                  ← Back
-                </button>
+                  Back
+                </Button>
                 <div className="mb-3 text-sm font-semibold">{selectedCorpus?.name || "Corpus"}</div>
                 <div className="space-y-2 text-xs">
                   <button


### PR DESCRIPTION
## 背景

Knowledge / Knowledge Base → Corpus → Document 子页的 Documents 列表存在两处 UI 问题：

1. **Name 列溢出**：首列 Name 文本过长（或浏览器变窄）时，未按「UI 表格设计规范」单行截断（`...`）+ Tooltip，而是直接溢出、覆盖 SOURCE / SIZE / STATUS 等列，视觉重叠。
2. **回退按钮**：左上角侧栏「← Back」为占满宽度的描边按钮 + 字符箭头，需简化美化、改用 `chevron-left` 图标。

两处改动均在 `apps/negentropy-ui/app/knowledge/base/page.tsx`。

## 根因（Name 列溢出）

```tsx
<td className="px-4 py-3">
  <button type="button" className="block min-w-0 text-left" onClick={...}>
    <TextTooltip content={...}><span className="block truncate ...">{name}</span></TextTooltip>
  </button>
</td>
```

- 同行其他列用共享原语 `TruncatedCell`：`<span class="block min-w-0 truncate">` 是 `<td>` 直接子元素 → `width:auto(block)` 拉满 `table-fixed` 的 `w-[30%]` 列宽 → 正常截断。
- Name 列为保留**点击导航语义**（进入 document-chunks）用 `<button>` 包了一层。但 `<button>` 的 `width:auto` 即便 `display:block` 仍解析为 `fit-content`（表单控件特例），按内容宽度撑开 → 内层 `span.truncate` 无可截断基准 → 长名溢出覆盖邻列。
- 缺一行 `w-full`。

## 改动

### 1. fix：Name 列加 `w-full`（最小干预，`c08b7ec5`）
为 `<button>` 增补 `w-full`（+ `cursor-pointer`），将按钮宽度钉死在 `table-fixed` 的 `w-[30%]` 列宽 → 恢复 `span.truncate` 截断 + 既有溢出感知 `TextTooltip`（仅 `scrollWidth > clientWidth` 才弹，消除冗余提示）。**不动** `TruncatedCell` / `TextTooltip` 共享原语（避免波及全仓 ~20 处消费方，YAGNI）。

### 2. style：回退按钮紧凑 Ghost + chevron-left（`efaccee6`）
「← Back」改用设计系统 `Button`（`variant="ghost"` / `size="sm"`）+ `lucide-react` `ChevronLeft` 图标 + 「Back」文字：
- 去边框、左对齐（`-ml-1.5`）、`self-start` 按内容自适应、悬浮显底（`hover:bg-muted`），视觉更精致现代；
- 复用本文件已 import 的 `Button` 与项目统一图标库 `lucide-react`（无 tabler 依赖），chevron-left（path `m15 18-6-6 6-6`）与提供参考的 tabler 同形，对齐 `Pagination` / `PanelRail` 既有用法。

## 验证（Evidence-Based）

- **typecheck + lint 全绿**；pre-commit hooks（ESLint）两次提交均 Passed。
- **dev 实机回归**（工作区 `next dev :3193`，借已认证 Chrome，Corpus 「Sinestesia of Cognition」→ Documents）：
  - DOM 测量：Name 单元格 `<button>` 加 `w-full` 后 `btnWidth` = `<td>` 内容宽（423 = 455 − 32px padding），**不溢出邻列**；
  - 合成长名（400 字）测试：`span.truncate` 截断（`scrollWidth 3955 > clientWidth 423`）、`btnRight 474 < nextCol 490`（不越列）；短名不截断、不弹冗余 Tooltip；
  - 真实名「浪潮之巅 2019（第四版）」在 980px 窄视口下不截断、不溢出（列宽足够时的正确表现）；
  - 点击 Name 仍正确跳转 document-chunks（导航语义未破）；回退按钮显示为 `‹ Back` Ghost、点击返回 overview。

## 不改动范围

- 不动 `TruncatedCell.tsx` / `TextTooltip.tsx` / `table-styles.ts`（共享原语，全仓消费）。
- 不回溯 document-chunks 面板的「Back to Documents」与 document 详情路由的 back 按钮（独立布局/路由，非本截图所指）。
- 不改 `<colgroup>` 列宽（已合 100%，非本 bug 成因）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)