### PR TITLE
feat(negentropy-wiki): Markdown 代码块/公式/Mermaid 注入 notranslate 跳过浏览器翻译;

### DIFF
--- a/apps/negentropy-wiki/src/components/markdown/CodeBlock.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/CodeBlock.tsx
@@ -37,7 +37,9 @@ export function CodeBlock({ children, className, codeText }: CodeBlockProps) {
       >
         {copied ? "已复制" : "复制"}
       </button>
-      <pre ref={preRef}>
+      {/* notranslate：Chrome / Google 翻译整棵跳过代码内容，避免 `true`、变量名等被误翻。
+          仅标 <pre>，语言标签与「复制」按钮仍随页面翻译。 */}
+      <pre ref={preRef} className="notranslate">
         <code className={className}>{children}</code>
       </pre>
     </div>

--- a/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
@@ -6,6 +6,7 @@ import rehypeRaw from "rehype-raw";
 import rehypeSanitize, { defaultSchema } from "rehype-sanitize";
 import rehypeKatex from "rehype-katex";
 import rehypeHighlight from "rehype-highlight";
+import { rehypeNotranslate } from "./rehype-notranslate";
 import { CodeBlock } from "./CodeBlock";
 import { AnchorHeading } from "./AnchorHeading";
 import { ResponsiveTable } from "./ResponsiveTable";
@@ -55,6 +56,8 @@ export function MarkdownRenderer({ content }: MarkdownRendererProps) {
           rehypeKatex,
           rehypeSlug,
           rehypeHighlight,
+          // 末尾运行：为代码/公式等注入 notranslate class，跳过浏览器翻译（须在 rehypeKatex 之后）。
+          rehypeNotranslate,
         ]}
         components={{
           h1: ({ id, children }) => <AnchorHeading level={1} id={id}>{children}</AnchorHeading>,

--- a/apps/negentropy-wiki/src/components/markdown/MermaidDiagram.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/MermaidDiagram.tsx
@@ -51,13 +51,16 @@ export function MermaidDiagram({ code }: MermaidDiagramProps) {
     return (
       <div className="wiki-mermaid-error">
         <p className="wiki-mermaid-error-title">Mermaid Error</p>
-        <pre className="wiki-mermaid-error-code">{code}</pre>
+        {/* notranslate：报错回退展示的是原始 mermaid 源码，不应被浏览器翻译。 */}
+        <pre className="wiki-mermaid-error-code notranslate">{code}</pre>
       </div>
     );
   }
 
   return (
-    <div className="wiki-mermaid-diagram">
+    // notranslate：运行期注入的 SVG 子树继承容器豁免，翻译引擎整体跳过，
+    // 防止节点文字被翻译后长度变化打乱图表布局。
+    <div className="wiki-mermaid-diagram notranslate">
       <div dangerouslySetInnerHTML={{ __html: svg }} />
     </div>
   );

--- a/apps/negentropy-wiki/src/components/markdown/rehype-notranslate.ts
+++ b/apps/negentropy-wiki/src/components/markdown/rehype-notranslate.ts
@@ -1,0 +1,83 @@
+import type { Plugin } from "unified";
+import { visit, SKIP } from "unist-util-visit";
+
+/**
+ * rehypeNotranslate —— 为「不需要翻译的内容块」注入 Google 翻译约定的 `notranslate` class，
+ * 使 Chrome / Google 翻译在翻译整页时跳过这些块及其子树，避免误翻。
+ *
+ * 本插件只负责**无 React 组件钩子**的两类块：
+ *  - 行内代码（裸 <code>，父节点非 <pre>）：如 `useState`、`true`、`git commit`。
+ *  - KaTeX 公式（rehype-katex 输出的原始 HTML）：块级 `.katex-display` / 行内 `.katex`。
+ *
+ * Fenced 代码块与 Mermaid 走各自的 React 组件（CodeBlock / MermaidDiagram）内注入，
+ * 不在此处理——因为 fenced <code> 的 className 会被 CodeBlock 用于计算语言标签，
+ * 在此追加 class 会污染标签显示。
+ *
+ * 挂载位置须在 `rehypeKatex` 之后（保证 `.katex` 节点已生成）。`className` 位于
+ * rehype-sanitize 默认白名单内，故无需扩展 sanitize schema，也不受插件顺序中 sanitize 的影响。
+ */
+const NOTRANSLATE = "notranslate";
+
+/** 最小 hast element 结构（仅用到 tagName / properties.className）；避免直接依赖 `hast` 类型包。 */
+interface HastElement {
+  type: "element";
+  tagName: string;
+  properties?: {
+    className?: string | number | (string | number)[];
+    [key: string]: unknown;
+  };
+}
+
+function isElement(node: unknown): node is HastElement {
+  return (
+    typeof node === "object" &&
+    node !== null &&
+    (node as { type?: unknown }).type === "element" &&
+    typeof (node as { tagName?: unknown }).tagName === "string"
+  );
+}
+
+/** 判断某节点是否为 <pre> element（返回布尔而非类型谓词，避免对 parent 收窄成 never）。 */
+function isPreElement(node: unknown): boolean {
+  return isElement(node) && node.tagName === "pre";
+}
+
+/** 读取 element 上的 class 令牌数组（兼容 string / string[] / 缺省）。 */
+function classTokens(node: HastElement): string[] {
+  const cn = node.properties?.className;
+  if (Array.isArray(cn)) return cn.map(String);
+  if (typeof cn === "string") return cn.split(/\s+/).filter(Boolean);
+  return [];
+}
+
+/** 幂等地把 `notranslate` 追加到 element 的 className。 */
+function addNotranslate(node: HastElement): void {
+  const tokens = classTokens(node);
+  if (tokens.includes(NOTRANSLATE)) return;
+  tokens.push(NOTRANSLATE);
+  const props = node.properties ?? (node.properties = {});
+  props.className = tokens;
+}
+
+export const rehypeNotranslate: Plugin = () => (tree) => {
+  visit(tree, (node, _index, parent) => {
+    if (!isElement(node)) return;
+    const tokens = classTokens(node);
+
+    // 公式：命中 KaTeX 最外层节点即豁免整棵，SKIP 避免下钻内部（含 MathML）造成冗余标记。
+    // 块级结构为 span.katex-display > span.katex，SKIP 于外层即可覆盖内层。
+    if (tokens.includes("katex-display") || tokens.includes("katex")) {
+      addNotranslate(node);
+      return SKIP;
+    }
+
+    // 行内代码：裸 <code> 且父节点非 <pre>（fenced 的内层 code 交给 CodeBlock 组件处理）。
+    if (node.tagName === "code" && !isPreElement(parent)) {
+      addNotranslate(node);
+    }
+
+    return undefined;
+  });
+};
+
+export default rehypeNotranslate;

--- a/apps/negentropy-wiki/tests/components/MarkdownRenderer.test.tsx
+++ b/apps/negentropy-wiki/tests/components/MarkdownRenderer.test.tsx
@@ -78,4 +78,52 @@ describe("MarkdownRenderer", () => {
     expect(style?.width).not.toBe("100%");
     expect(style?.maxWidth).toBe("100%");
   });
+
+  // notranslate：块级豁免——代码块/公式等不参与浏览器翻译，正文其余仍可翻译。
+  describe("notranslate 块级豁免", () => {
+    it("fenced 代码块的 <pre> 带 notranslate，内层 <code> 不污染（语言标签不受影响）", () => {
+      const md = "```js\nconst enabled = true;\n```";
+      const { container } = render(<MarkdownRenderer content={md} />);
+
+      const pre = container.querySelector(".wiki-code-block pre");
+      expect(pre).not.toBeNull();
+      expect(pre?.classList.contains("notranslate")).toBe(true);
+
+      // 内层 code 不应被追加 notranslate（否则会污染 CodeBlock 的语言标签计算）。
+      const code = container.querySelector(".wiki-code-block code");
+      expect(code).not.toBeNull();
+      expect(code?.classList.contains("notranslate")).toBe(false);
+    });
+
+    it("行内代码的 <code> 带 notranslate", () => {
+      const md = "使用 `useState` 钩子管理状态。";
+      const { container } = render(<MarkdownRenderer content={md} />);
+
+      const inlineCode = container.querySelector("code");
+      expect(inlineCode).not.toBeNull();
+      expect(inlineCode?.textContent).toBe("useState");
+      expect(inlineCode?.classList.contains("notranslate")).toBe(true);
+      // 行内代码不进 pre，应为裸 code。
+      expect(inlineCode?.closest("pre")).toBeNull();
+    });
+
+    it("块级公式 $$...$$ 的 .katex-display 带 notranslate", () => {
+      // 独占成行的 $$ 围栏才会被 remark-math 解析为 display 公式（同行 $$...$$ 是行内）。
+      const md = "$$\nE = mc^2\n$$";
+      const { container } = render(<MarkdownRenderer content={md} />);
+
+      const display = container.querySelector(".katex-display");
+      expect(display).not.toBeNull();
+      expect(display?.classList.contains("notranslate")).toBe(true);
+    });
+
+    it("行内公式 $...$ 的 .katex 带 notranslate", () => {
+      const md = "质能方程 $E=mc^2$ 广为人知。";
+      const { container } = render(<MarkdownRenderer content={md} />);
+
+      const katex = container.querySelector(".katex");
+      expect(katex).not.toBeNull();
+      expect(katex?.classList.contains("notranslate")).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：Wiki 站点正文容器 `.wiki-markdown-body` 刻意允许整页翻译，但 Chrome「翻译此页」会误翻 fenced 代码块（如 `true`）、行内代码（如 `useState`）、KaTeX 公式（MathML 文本被改写致公式错乱）与 Mermaid 图表（节点文字变长打乱 SVG 布局）。
- 关联上下文：与既有「整页允许翻译」决策（`MarkdownRenderer.tsx` 注释 + `MarkdownRenderer.test.tsx` 断言锁定）互补，采用**块级豁免**——代码/公式/图表跳过翻译，正文其余仍可翻译。

# 核心变更
- `CodeBlock.tsx`：fenced 代码块内层 `<pre>` 追加 `notranslate`；语言标签与「复制」按钮仍随页面翻译。
- 新增 `rehype-notranslate.ts` 自定义 rehype 插件：为行内代码（裸 `<code>` 且父节点非 `<pre>`）与 KaTeX 公式（最外层 `.katex-display` / `.katex`）追加 `notranslate`，命中 KaTeX 即 `SKIP` 不再下钻，幂等。
- `MarkdownRenderer.tsx`：插件挂到 rehype 链末尾（须在 `rehypeKatex` 之后）；用本地最小 hast 结构类型规避 `hast` 类型包在 pnpm 下不可解析的问题。
- `MermaidDiagram.tsx`：渲染图容器 `.wiki-mermaid-diagram` 与报错回退源码 `<pre>` 追加 `notranslate`。
- `MarkdownRenderer.test.tsx`：新增 4 条断言覆盖 fenced 代码块、行内代码、块级与行内公式；保留原「容器无 translate 属性、允许翻译」断言。

> 采用 `class="notranslate"`（Google/Chrome 翻译均识别的标准令牌）；`className` 已在 rehype-sanitize 白名单内，**无需改 sanitize schema**，也不引入 `translate="no"` 属性。

# 风险与回滚
- 主要风险：低。仅向 class 追加令牌，不改 DOM 结构/样式/逻辑，不影响「整页允许翻译」语义。
- 回滚方式：revert 单个 commit（`7de75bca`）。

# 验证证据
- 单元测试：`pnpm --filter negentropy-wiki test` → **108/108 通过**（新增 4 条断言实际驱动真实 react-markdown + rehype 管线，非 mock）。
- 集成测试：N/A（纯前端 wiki 静态站点）。
- E2E/Workflow：`tsc --noEmit` 我的文件零类型错误（仅剩与本次无关的存量报错）；`pnpm --filter negentropy-wiki lint` **0 errors**；pre-commit 钩子（含 `next lint`）全 Passed。
- 覆盖率/关键截图：未截图；建议合并前实机回归。

# 影响范围
- 前端：`apps/negentropy-wiki` Markdown 渲染层（CodeBlock / MermaidDiagram / MarkdownRenderer + 新插件）；SSG 构建期写入静态 HTML，Mermaid 容器构建期成型、SVG 运行期注入并继承豁免。
- 后端：无。
- GitHub Actions / 文档：无。

# Next Best Action
- 合并前可选实机回归：本地 `pnpm --filter negentropy-wiki dev`，打开含代码/公式/Mermaid 的词条，Chrome「翻译成 English」确认三者保持原文、正文被正常翻译。