### PR TITLE
feat(patrol): 收紧 PDF 高保真巡检合格阈值 95→99;

### DIFF
--- a/apps/negentropy/src/negentropy/config/config.default.yaml
+++ b/apps/negentropy/src/negentropy/config/config.default.yaml
@@ -225,7 +225,7 @@ routine:
   patrol_max_iterations_per_doc: 400         # 单文档巡检 Routine 迭代硬上限（×50：原 8）
   patrol_max_cost_usd_per_doc: 1500.0        # 单文档成本熔断（USD）；×50（原 30）容许数百轮深度拟合收敛（原 5 致 2 轮撞顶）
   patrol_regression_sample_size: 6           # 非回归基线样本数
-  patrol_qualified_score_threshold: 95       # 巡检文档「合格」分阈值；best_score≥此值→done 推进(success_score_threshold 同步取此)，否则 unfixable 尽力(亦推进)
+  patrol_qualified_score_threshold: 99       # 巡检文档「合格」分阈值；best_score≥此值→done 推进(success_score_threshold 同步取此)，否则 unfixable 尽力(亦推进)
 
 # --- Knowledge 配置 ---
 knowledge:

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -379,7 +379,7 @@ class RoutineSettings(BaseSettings):
         description="非回归基线样本数（首次巡检时分层抽取的生产 PDF 文档数）。",
     )
     patrol_qualified_score_threshold: int = Field(
-        default=95,
+        default=99,
         ge=0,
         le=100,
         description="巡检文档「合格」分阈值（0-100）。巡检 Routine 的 success_score_threshold 取此值——"

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -872,7 +872,7 @@ def _build_patrol_routine(
         max_iterations=settings.routine.patrol_max_iterations_per_doc,
         max_cost_usd=settings.routine.patrol_max_cost_usd_per_doc,
         deadline_at=None,
-        success_score_threshold=qualified_threshold,  # 合格阈值（默认 95）：收敛即 SUCCESS，不再误标 Failed
+        success_score_threshold=qualified_threshold,  # 合格阈值（默认 99）：收敛即 SUCCESS，不再误标 Failed
         no_progress_patience=3,  # per-Routine DB 列默认值（非 RoutineSettings 属性）
         approval_mode="auto",
         config=build_routine_config(

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_handler.py
@@ -364,7 +364,7 @@ def test_build_patrol_routine_constructs_without_attribute_error():
     )
     # 关键字段装配正确（与 routine_api.create_routine 口径对齐）
     assert routine.no_progress_patience == 3  # per-Routine 默认，非 settings
-    assert routine.success_score_threshold == 95  # 合格阈值（patrol_qualified_score_threshold；原 100→收敛即 SUCCESS）
+    assert routine.success_score_threshold == 99  # 合格阈值（patrol_qualified_score_threshold；原 100→收敛即 SUCCESS）
     assert routine.status == "running"
     assert routine.repository_id == repo_id
     assert routine.baseline_branch == "origin/feature/1.x.x"

--- a/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_pdf_fidelity_patrol_integration.py
@@ -77,7 +77,7 @@ async def test_create_and_start_patrol_routine_persists_real_row(db_engine):
         assert row.repository_id == repo_id
         assert row.baseline_branch == "origin/feature/1.x.x"
         assert row.no_progress_patience == 3  # per-Routine 默认（非 settings）—— 回归点
-        assert row.success_score_threshold == 95  # 合格阈值（patrol_qualified_score_threshold；原 100→收敛即 SUCCESS）
+        assert row.success_score_threshold == 99  # 合格阈值（patrol_qualified_score_threshold；原 100→收敛即 SUCCESS）
         assert row.max_iterations == 400  # settings.routine.patrol_max_iterations_per_doc（×50：原 8）
         assert row.max_cost_usd == 1500.0  # patrol 专属预算（×50：原 30；非全局 default_max_cost_usd=5）
         assert row.owner_id == "system"
@@ -408,25 +408,25 @@ async def _status_memory(db_engine, doc_id):
 
 
 async def test_finalize_failed_high_score_marks_done_and_advances(db_engine):
-    """failed best_score=97 ≥ 95 → done(score=97)，doc 进 skip_ids（推进生效，不再死循环）。"""
+    """failed best_score=99 ≥ 99 → done(score=99)，doc 进 skip_ids（推进生效，不再死循环）。"""
     from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
 
     factory = _sf(db_engine)
-    _, doc_id = await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=97)
+    _, doc_id = await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=99)
     async with factory() as db:
         n = await patrol._finalize_terminal_patrols(db)
         await db.commit()
     assert n >= 1
 
     row = await _status_memory(db_engine, doc_id)
-    assert row is not None and row.st == "done" and row.sc == "97"
+    assert row is not None and row.st == "done" and row.sc == "99"
 
     async with factory() as db:
         assert doc_id in await PatrolMemoryStore(db).get_skip_doc_ids()
 
 
 async def test_finalize_failed_low_score_marks_unfixable_and_advances(db_engine):
-    """failed best_score=52 < 95 → unfixable(score=52)，doc 仍进 skip_ids（尽力亦推进）。"""
+    """failed best_score=52 < 99 → unfixable(score=52)，doc 仍进 skip_ids（尽力亦推进）。"""
     from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
 
     factory = _sf(db_engine)
@@ -441,14 +441,14 @@ async def test_finalize_failed_low_score_marks_unfixable_and_advances(db_engine)
 
 
 async def test_finalize_progressing_contract_advances(db_engine):
-    """末轮 progressing 契约 + best_score=96 ≥ 95 → done（核心：progressing 不再致死循环）。"""
+    """末轮 progressing 契约 + best_score=99 ≥ 99 → done（核心：progressing 不再致死循环）。"""
     from negentropy.engine.routine.patrol_memory import PatrolMemoryStore
 
     factory = _sf(db_engine)
     _, doc_id = await _seed_terminal_patrol_with_outcome(
         db_engine,
         status="failed",
-        best_score=96,
+        best_score=99,
         contract_summary=_contract_summary(score=80, status="progressing"),
     )
     async with factory() as db:
@@ -461,7 +461,7 @@ async def test_finalize_progressing_contract_advances(db_engine):
 
 
 async def test_finalize_missing_contract_falls_back_to_best_score(db_engine):
-    """末轮无 evaluated summary（契约缺失）+ best_score=88 < 95 → unfixable（best_score 兜底沉淀）。"""
+    """末轮无 evaluated summary（契约缺失）+ best_score=88 < 99 → unfixable（best_score 兜底沉淀）。"""
     _, doc_id = await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=88)
     factory = _sf(db_engine)
     async with factory() as db:
@@ -493,16 +493,16 @@ async def test_finalize_cancelled_does_not_persist_status(db_engine):
 
 
 async def test_finalize_multiple_routines_same_doc_best_wins(db_engine):
-    """同 doc 两条终态 Routine（best_score 52 与 97）→ 最终 done(score=97)（ORDER BY best_score 最佳拟合胜出）。"""
+    """同 doc 两条终态 Routine（best_score 52 与 99）→ 最终 done(score=99)（ORDER BY best_score 最佳拟合胜出）。"""
     doc_id = str(uuid.uuid4())
     await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=52, doc_id=doc_id)
-    await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=97, doc_id=doc_id)
+    await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=99, doc_id=doc_id)
     factory = _sf(db_engine)
     async with factory() as db:
         await patrol._finalize_terminal_patrols(db)
         await db.commit()
     row = await _status_memory(db_engine, doc_id)
-    assert row is not None and row.st == "done" and row.sc == "97"
+    assert row is not None and row.st == "done" and row.sc == "99"
 
 
 async def _seed_knowledge_pdf(db_engine, *, filename):
@@ -545,7 +545,7 @@ async def test_select_advances_after_done(db_engine):
     await _seed_knowledge_pdf(db_engine, filename="patrol-advance-b.pdf")  # 保证至少一份 pending
 
     # A 经一次终态 Routine 标 done
-    await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=97, doc_id=str(doc_a))
+    await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=99, doc_id=str(doc_a))
     async with factory() as db:
         await patrol._finalize_terminal_patrols(db)
         await db.commit()
@@ -718,14 +718,14 @@ async def test_finalize_writes_patrol_status_column(db_engine):
     factory = _sf(db_engine)
     doc_done = await _seed_knowledge_pdf(db_engine, filename="patrol-col-done.pdf")
     doc_unfix = await _seed_knowledge_pdf(db_engine, filename="patrol-col-unfix.pdf")
-    await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=97, doc_id=str(doc_done))
+    await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=99, doc_id=str(doc_done))
     await _seed_terminal_patrol_with_outcome(db_engine, status="failed", best_score=52, doc_id=str(doc_unfix))
     async with factory() as db:
         await patrol._finalize_terminal_patrols(db)
         await db.commit()
     done_row = await _patrol_column(db_engine, doc_done)
     unfix_row = await _patrol_column(db_engine, doc_unfix)
-    assert done_row[0] == "done" and done_row[1] == 97
+    assert done_row[0] == "done" and done_row[1] == 99
     assert unfix_row[0] == "unfixable" and unfix_row[1] == 52
 
 
@@ -743,7 +743,7 @@ async def test_reset_patrol_status_clears_column_and_cancels_routines(db_engine,
     monkeypatch.setattr("negentropy.storage.service.AsyncSessionLocal", factory)
     doc_id = await _seed_knowledge_pdf(db_engine, filename="patrol-reset.pdf")
     routine_id, _ = await _seed_terminal_patrol_with_outcome(
-        db_engine, status="failed", best_score=97, doc_id=str(doc_id)
+        db_engine, status="failed", best_score=99, doc_id=str(doc_id)
     )
     async with factory() as db:
         await patrol._finalize_terminal_patrols(db)


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：PDF Fidelity Patrol 派生 Routine 的合格分阈值偏低（95），收紧到 99 以提升 PDF→Markdown 保真度的合格门槛。
- 关联上下文/Issue/文档：阈值定义于 `RoutineSettings.patrol_qualified_score_threshold`，运行时由 handler 写入 Routine 的 `success_score_threshold` 列，作用于 `decide()` 判 SUCCESS 与终态沉淀（done/unfixable）。

# 核心变更
- 配置层 `patrol_qualified_score_threshold`：Pydantic Field 默认值（`config/routine.py`）与 `config.default.yaml` 显式值同步 95→99；handler 行内注释同步订正（保单一事实源）。
- 连带修订编码旧阈值的测试：`test_pdf_fidelity_patrol_handler.py` 默认值断言 `==95`→`==99`；`test_pdf_fidelity_patrol_integration.py` 中 5 个 done 路径用例（`best_score` 96/97→99、score 断言、docstring 阈值数字）。

# 风险与回滚
- 主要风险：终态分类上移——`best_score ∈ [95, 98]` 的文档由 `done` 翻为 `unfixable`（尽力推进，仍进 skip_ids 不死循环）；评分路径（逐页全绿率）更难直接命中 99，但有 `accept_verdict_pass` / `no_progress_score_tolerance=20` / `judge_anchor` 三重防误杀兜底，巡检仍正常收敛。
- 回滚方式：将 `patrol_qualified_score_threshold` 改回 95 即可；派生 Routine 按 tick 重建，新阈值下一轮派生自动生效，无需数据迁移。

# 验证证据
- 单元测试：`test_pdf_fidelity_patrol_handler.py` 全 passed（含默认值断言 `== 99`）。
- 集成测试：`test_pdf_fidelity_patrol_integration.py` 31 passed（含 5 个阈值边界用例的连带修正）。
- E2E/Workflow：无（纯配置阈值调整 + 测试同步）。
- 覆盖率/关键截图：grep 回归确认无残留 `success_score_threshold == 95` 默认断言；pre-commit hooks 全通过（ruff lint/format、yaml/toml 检查等）。

# 影响范围
- 前端：无。
- 后端：仅影响 PDF Fidelity Patrol 派生 Routine 的合格阈值（常规 Routine 默认 85 不受影响）。
- GitHub Actions / 文档：无。

# Next Best Action
- 上线后观察收紧到 99 的实际收敛表现：若大量文档长期卡在 [95, 98] 仅判 unfixable、而 `accept_verdict_pass` 兜底覆盖不足，可评估微调阈值或放宽旁路触发条件。
