### PR TITLE
feat(negentropy-ui): 人机交互转录向 Conductor 再次对齐（机侧徽章/用户头像/耗时计时/长消息折叠）

### DIFF
--- a/apps/negentropy-ui/app/home-body.tsx
+++ b/apps/negentropy-ui/app/home-body.tsx
@@ -376,6 +376,10 @@ export function HomeBody({
   // 并发 runId 隔离 — 记录当前活跃的 runId，过滤旧 run 的残留事件，防止双气泡。
   // doSend 时写入新 runId，RUN_FINISHED/RUN_ERROR 后清空。
   const activeRunIdRef = useRef<string | null>(null);
+  // 当前 run 的开始时刻（epoch ms）—— doSend 时写入、run 终止/取消时清空；透传给
+  // StudioTranscript 的在途态计时（对齐 Conductor 耗时）。用 state（非 ref）以触发重渲染，
+  // 让计时值流入 WorkingIndicator（activeRunIdRef 仅事件过滤用，无需重渲染，故仍为 ref）。
+  const [runStartedAtMs, setRunStartedAtMs] = useState<number | null>(null);
   const perThreadLlmRef = useRef<Record<string, string | null>>({});
   const perThreadThinkingRef = useRef<Record<string, boolean>>({});
   // 「无 session 时」用户预先选择的模型，待 startNewSession 后转入 perThreadLlmRef[newId]。
@@ -649,6 +653,7 @@ export function HomeBody({
       ) {
         // run 终止后清空活跃 runId，允许后续 run 的事件通过。
         activeRunIdRef.current = null;
+        setRunStartedAtMs(null);
         scheduleSessionHydration(sessionId, {
           reason: "run_terminal",
           runId:
@@ -717,6 +722,7 @@ export function HomeBody({
       userCancelledAtRef.current = Date.now();
       // 用户主动取消时清空活跃 runId，允许后续 run 立即开始。
       activeRunIdRef.current = null;
+      setRunStartedAtMs(null);
       try {
         agent.abortRun();
       } catch (error) {
@@ -867,6 +873,8 @@ export function HomeBody({
       const runId = randomUUID();
       // 设置活跃 runId，过滤旧 run 的残留事件（并发隔离）。
       activeRunIdRef.current = runId;
+      // 记录 run 开始时刻，供在途态耗时计时（与 activeRunIdRef 同步清空）。
+      setRunStartedAtMs(Date.now());
       const messageId = crypto.randomUUID();
       const createdAt = new Date();
       const newMessage = {
@@ -943,6 +951,7 @@ export function HomeBody({
         }
       } catch (error) {
         activeRunIdRef.current = null;
+        setRunStartedAtMs(null);
         setConnectionWithMetrics("error");
         addLog("error", "run_agent_failed", { message: String(error) });
         console.warn("Failed to run agent", error);
@@ -1418,6 +1427,7 @@ export function HomeBody({
                 effectiveConnection === "connecting" ||
                 effectiveConnection === "streaming"
               }
+              workingElapsedStartMs={runStartedAtMs ?? undefined}
               highlightedNodeIds={search.matchingNodeIds}
               scrollToNodeId={search.currentMatchNodeId}
               suggestions={STUDIO_SUGGESTIONS}

--- a/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationAuditDrawer.tsx
@@ -125,7 +125,14 @@ export function IterationAuditDrawer({
         {loading && merged.length === 0 ? (
           <TimelineSkeleton />
         ) : merged.length > 0 ? (
-          <IterationEventTimeline events={merged} live={isInFlight} openingPrompt={iteration?.prompt ?? null} />
+          <IterationEventTimeline
+            events={merged}
+            live={isInFlight}
+            openingPrompt={iteration?.prompt ?? null}
+            workingElapsedStartMs={
+              isInFlight && iteration?.started_at ? Date.parse(iteration.started_at) : undefined
+            }
+          />
         ) : (
           !error && <EmptyState iteration={iteration} />
         )}

--- a/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/IterationEventTimeline.tsx
@@ -24,12 +24,15 @@ export function IterationEventTimeline({
   events,
   live,
   openingPrompt,
+  workingElapsedStartMs,
 }: {
   events: RoutineIterationEventDTO[];
   /** 是否处于在途实时态（显示 LIVE 脉冲；驱动工具行运行态）。 */
   live?: boolean;
   /** 迭代任务 prompt（人下发给 CC 的任务）——非空时合成为开场「人→机」task_dispatch 回合。 */
   openingPrompt?: string | null;
+  /** 在途态计时起点（epoch ms，由 ``iteration.started_at`` 派生）——透传给 WorkingIndicator。 */
+  workingElapsedStartMs?: number;
 }) {
   const groups = useMemo(() => groupEvents(events), [events]);
 
@@ -63,7 +66,12 @@ export function IterationEventTimeline({
       </div>
 
       {/* 扁平转录流 */}
-      <TranscriptView events={events} live={live} openingPrompt={openingPrompt} />
+      <TranscriptView
+        events={events}
+        live={live}
+        openingPrompt={openingPrompt}
+        workingElapsedStartMs={live ? workingElapsedStartMs : undefined}
+      />
     </div>
   );
 }

--- a/apps/negentropy-ui/app/interface/routine/_components/transcript/TranscriptView.tsx
+++ b/apps/negentropy-ui/app/interface/routine/_components/transcript/TranscriptView.tsx
@@ -13,18 +13,21 @@ import { normalizeTranscript } from "./normalize-transcript";
  *
  * 把扁平 ``RoutineIterationEventDTO[]`` 经 ``normalizeTranscript`` 折叠为
  * ``TranscriptItem[]``，前置合成的 ``task_dispatch`` 开场回合，再交共享渲染器
- * ``TranscriptItemsView`` + ``ROUTINE_POLICY`` 渲染。公共签名与外部引用路径不变，
- * 行为与历史逐像素等价（``ROUTINE_POLICY.roleHeaderFor`` 恒 null、对齐规则保留）。
+ * ``TranscriptItemsView`` + ``ROUTINE_POLICY`` 渲染。公共签名与外部引用路径不变；
+ * 机侧（Claude Code）在回合切换处显 ``claude_code`` 徽章，人↔CC 对话结构显化。
  */
 export function TranscriptView({
   events,
   live,
   openingPrompt,
+  workingElapsedStartMs,
 }: {
   events: RoutineIterationEventDTO[];
   live?: boolean;
   /** 迭代任务 prompt（人下发给 CC 的任务）——非空时合成为开场「人→机」task_dispatch 回合。 */
   openingPrompt?: string | null;
+  /** 在途态计时起点（epoch ms）——透传给 WorkingIndicator（对齐 Conductor 耗时）。 */
+  workingElapsedStartMs?: number;
 }) {
   const normalized = useMemo(() => normalizeTranscript(events, { live: !!live }), [events, live]);
   const items = useMemo<TranscriptItem[]>(
@@ -35,5 +38,12 @@ export function TranscriptView({
     [normalized, openingPrompt],
   );
 
-  return <TranscriptItemsView items={items} live={live} policy={ROUTINE_POLICY} />;
+  return (
+    <TranscriptItemsView
+      items={items}
+      live={live}
+      policy={ROUTINE_POLICY}
+      workingElapsedStartMs={live ? workingElapsedStartMs : undefined}
+    />
+  );
 }

--- a/apps/negentropy-ui/components/transcript/AssistantText.tsx
+++ b/apps/negentropy-ui/components/transcript/AssistantText.tsx
@@ -7,6 +7,11 @@ import { cn } from "@/lib/utils";
 import { MarkdownContent } from "@/components/ui/MessageBubble";
 
 import { MarkdownText } from "@/components/markdown/MarkdownText";
+import {
+  ASSISTANT_BUBBLE_CLASS,
+  LONG_MESSAGE_COLLAPSED_MAX_HEIGHT,
+  LONG_MESSAGE_THRESHOLD_CHARS,
+} from "./style";
 import type { TranscriptItem } from "./types";
 
 /** CC 自报交互异常的模式（如 AskUserQuestion 在 headless 下被 CLI 报错）——命中则红显，让断链可见。 */
@@ -43,8 +48,8 @@ export function AssistantText({ item }: { item: Extract<TranscriptItem, { kind: 
       />
     );
   }
-  // 正文提亮至 foreground，贴合 paseo 中栏对比度
-  return <MarkdownText content={item.text} className="[&_li]:text-foreground [&_p]:text-foreground" />;
+  // 正文：机侧气泡（左上拉直，对齐 Conductor）+ 长消息折叠降噪
+  return <AssistantBody item={item} />;
 }
 
 /** 可折叠的 thinking 推理片段——默认收起为单行，点击展开全文。 */
@@ -63,6 +68,41 @@ function ThinkingText({ text }: { text: string }) {
         <ChevronRight className={cn("h-3 w-3 transition-transform", open && "rotate-90")} aria-hidden />
       </button>
       {open ? <MarkdownText content={text} className="mt-0.5 italic [&_p]:text-text-secondary" /> : null}
+    </div>
+  );
+}
+
+/**
+ * 机侧 assistant 正文气泡（左上拉直 = 机侧，对齐 Conductor agent 气泡容器）。
+ *
+ * 长消息（超 ``LONG_MESSAGE_THRESHOLD_CHARS``）默认折叠为限高 + 底部渐隐 + 「展开全文」，
+ * 降低长转录视觉噪音（对齐 Conductor "Show full message"）；短消息不折叠。
+ */
+function AssistantBody({ item }: { item: Extract<TranscriptItem, { kind: "assistant" }> }) {
+  const long = item.text.length > LONG_MESSAGE_THRESHOLD_CHARS;
+  const [open, setOpen] = useState(false);
+  return (
+    <div className={cn("relative", ASSISTANT_BUBBLE_CLASS)}>
+      <div className="relative">
+        <div className={cn(long && !open && LONG_MESSAGE_COLLAPSED_MAX_HEIGHT, long && !open && "overflow-hidden")}>
+          <MarkdownText content={item.text} className="[&_li]:text-foreground [&_p]:text-foreground" />
+        </div>
+        {long && !open ? (
+          <div
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-16 bg-gradient-to-t from-muted/30 to-transparent"
+            aria-hidden
+          />
+        ) : null}
+      </div>
+      {long ? (
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          className="mt-2 text-caption font-medium text-text-secondary hover:text-foreground"
+        >
+          {open ? "收起" : "展开全文"}
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/apps/negentropy-ui/components/transcript/TranscriptItemsView.tsx
+++ b/apps/negentropy-ui/components/transcript/TranscriptItemsView.tsx
@@ -38,12 +38,12 @@ function gapClass(item: TranscriptItem, prev: TranscriptItem | null, policy: Tra
 }
 
 /** 按 kind 分发渲染单项（key 与对齐/间距由外层 wrapper 统一处理）。 */
-function renderItem(item: TranscriptItem) {
+function renderItem(item: TranscriptItem, userAvatar?: ReactNode) {
   switch (item.kind) {
     case "task_dispatch":
       return <TaskDispatchBubble prompt={item.prompt} />;
     case "user":
-      return <UserBubble item={item} />;
+      return <UserBubble item={item} avatar={userAvatar} />;
     case "assistant":
       return <AssistantText item={item} />;
     case "tool":
@@ -83,6 +83,8 @@ export function TranscriptItemsView({
   live,
   policy,
   itemWrapper,
+  userAvatar,
+  workingElapsedStartMs,
 }: {
   items: TranscriptItem[];
   live?: boolean;
@@ -92,6 +94,16 @@ export function TranscriptItemsView({
    * Routine 不传 → 直接渲染内容（行为不变）。包裹器位于对齐/间距容器之内、内容之外。
    */
   itemWrapper?: (item: TranscriptItem, children: ReactNode) => ReactNode;
+  /**
+   * 可选的用户头像（Studio 经 ``useAuth`` + ``UserAvatar`` 注入到 ``user`` 气泡右侧，对齐 Conductor
+   * 用户侧头像）。Routine 不传 → ``UserBubble`` 不渲染头像（行为不变）。
+   */
+  userAvatar?: ReactNode;
+  /**
+   * 可选的在途态计时起点（epoch ms）。提供时 ``WorkingIndicator`` 追加等宽耗时（"1m 23s"，对齐
+   * Conductor typing）；不传则仅显脉冲 + 文案（行为不变）。
+   */
+  workingElapsedStartMs?: number;
 }) {
   const last = items[items.length - 1];
   const workingLabel =
@@ -104,7 +116,7 @@ export function TranscriptItemsView({
         const prev = i > 0 ? items[i - 1] : null;
         const side = policy.align(item);
         const headerRole = policy.roleHeaderFor(item, prev);
-        const content = renderItem(item);
+        const content = renderItem(item, userAvatar);
         return (
           <div
             key={itemKey(item)}
@@ -117,7 +129,7 @@ export function TranscriptItemsView({
       })}
       {live ? (
         <div className={items.length > 0 ? "mt-2" : ""}>
-          <WorkingIndicator label={workingLabel} />
+          <WorkingIndicator label={workingLabel} startedAtMs={workingElapsedStartMs} />
         </div>
       ) : null}
     </div>

--- a/apps/negentropy-ui/components/transcript/UserBubble.tsx
+++ b/apps/negentropy-ui/components/transcript/UserBubble.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { ReactNode } from "react";
+
 import { MarkdownText } from "@/components/markdown/MarkdownText";
 
 import type { TranscriptItem } from "./types";
@@ -7,13 +9,24 @@ import type { TranscriptItem } from "./types";
 /**
  * Studio 用户消息气泡（人 = 真实用户，居右）。
  *
- * 对齐 Routine ``TaskDispatchBubble`` 的背景/圆角语言（primary 浅底 + 右上角拉直），
- * 但不挂 RoleHeader——用户身份由对齐方向自明。右对齐由 ``TranscriptItemsView`` 外层包裹实现。
+ * 对齐 Routine ``TaskDispatchBubble`` 的背景/圆角语言（primary 浅底 + 右上角拉直）。
+ * 可选 ``avatar``（由 ``StudioTranscript`` 经 ``useAuth`` + ``UserAvatar`` 注入）渲染在气泡右侧，
+ * 让「人」的一方有一眼可辨的身份锚点（对齐 Conductor 用户侧头像）。右对齐由
+ * ``TranscriptItemsView`` 外层包裹实现；此处 ``flex justify-end`` 让 [气泡][头像] 右贴边。
  */
-export function UserBubble({ item }: { item: Extract<TranscriptItem, { kind: "user" }> }) {
+export function UserBubble({
+  item,
+  avatar,
+}: {
+  item: Extract<TranscriptItem, { kind: "user" }>;
+  avatar?: ReactNode;
+}) {
   return (
-    <div className="min-w-0 max-w-[85%] rounded-2xl rounded-tr-sm border border-primary/20 bg-primary/[0.06] px-4 py-3">
-      <MarkdownText content={item.text} className="[&_p]:text-foreground" />
+    <div className="flex items-start justify-end gap-2">
+      <div className="min-w-0 max-w-[85%] rounded-2xl rounded-tr-sm border border-primary/20 bg-primary/[0.06] px-4 py-3">
+        <MarkdownText content={item.text} className="[&_p]:text-foreground" />
+      </div>
+      {avatar ? <div className="mt-0.5 shrink-0">{avatar}</div> : null}
     </div>
   );
 }

--- a/apps/negentropy-ui/components/transcript/WorkingIndicator.tsx
+++ b/apps/negentropy-ui/components/transcript/WorkingIndicator.tsx
@@ -1,14 +1,46 @@
 "use client";
 
+import { useEffect, useState } from "react";
+
 import { cn } from "@/lib/utils";
+
+/** 把 epoch 毫秒差格式化为 "45s" / "1m 23s"（对齐 Conductor typing 计时）。 */
+export function formatElapsed(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  return `${m}m ${s % 60}s`;
+}
 
 /**
  * 运行态指示器 —— Conductor「Working… / Planning…」态的纯 CSS 等价物（规避 dotlottie-web WASM）。
  *
  * 三个点经 ``animate-working-pulse`` + 错相位 ``animationDelay`` 形成波动脉冲，尾随一行状态文案。
- * 仅在 ``live`` 在途态渲染于转录流末尾，示意「机器仍在工作」。已尊重 prefers-reduced-motion（全局降级）。
+ * 仅在 ``live`` 在途态渲染于转录流末尾，示意「机器仍在工作」。``startedAtMs`` 提供时追加等宽耗时
+ * 计时（"1m 23s"，每秒自更新），让长耗时回合有进度感知（对齐 Conductor）。已尊重 prefers-reduced-motion。
  */
-export function WorkingIndicator({ label = "Working…", className }: { label?: string; className?: string }) {
+export function WorkingIndicator({
+  label = "Working…",
+  startedAtMs,
+  className,
+}: {
+  label?: string;
+  startedAtMs?: number;
+  className?: string;
+}) {
+  // 复用 ``ClockProvider`` 同范式：state 持 ``now``，effect 内经 ``tick()`` 间接刷新——规避
+  // render 内调 ``Date.now``（purity）与 effect 内同步 setState（set-state-in-effect）。
+  // 仅在需要计时时起 1Hz interval；``now`` 为纯 state，render 内 ``now - startedAtMs`` 安全。
+  const [now, setNow] = useState<number>(() => Date.now());
+  useEffect(() => {
+    if (startedAtMs === undefined) return;
+    const tick = () => setNow(Date.now());
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [startedAtMs]);
+  const elapsed = startedAtMs !== undefined ? formatElapsed(now - startedAtMs) : null;
+
   return (
     <div
       className={cn("flex items-center gap-2 py-1 text-caption text-text-secondary", className)}
@@ -27,6 +59,11 @@ export function WorkingIndicator({ label = "Working…", className }: { label?: 
         ))}
       </span>
       <span className="font-medium">{label}</span>
+      {elapsed ? (
+        <span className="font-mono tabular-nums text-text-muted" aria-hidden>
+          {elapsed}
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/apps/negentropy-ui/components/transcript/policy.ts
+++ b/apps/negentropy-ui/components/transcript/policy.ts
@@ -6,9 +6,10 @@
  *
  * 1. ``align``：物理左右对齐——Routine 把 ``human_reply``/``task_dispatch``/``engine`` 居右、
  *    其余居左；Studio 把 ``user`` 居右、其余（一核五翼 + Claude Code）全居左。
- * 2. ``roleHeaderFor``：是否在机侧 item 上方渲染 per-agent ``RoleHeader`` 徽章——Routine 恒
- *    不渲染（徽章仍内嵌在 Engine/Human/TaskDispatch 块中，观感不变）；Studio 在 role 相对
- *    上一条机侧 item 变化时渲染（分组，避免同 agent 连续刷屏）。
+ * 2. ``roleHeaderFor``：是否在 item 上方渲染 ``RoleHeader`` 徽章——Routine 在机侧（Claude Code）
+ *    「回合切换处」（上一条非机侧或无 prev）渲染 ``claude_code`` 徽章（连续机侧不重复刷；人侧
+ *    engine/human_reply/task_dispatch 自带内嵌徽章，此处不重复）；Studio 在机侧 role 相对
+ *    上一条变化时渲染（分组，避免同 agent 连续刷屏）。
  */
 
 import type { AgentRole } from "@/features/agent-identity";
@@ -34,7 +35,13 @@ export interface TranscriptPolicy {
   workingLabel?(lastItem: TranscriptItem | undefined): string;
 }
 
-/** Routine 策略：与历史 ``TranscriptView`` 行为逐像素等价。 */
+/**
+ * Routine 策略：人 = 一核五翼 6 Agent + Engine（居右）；机 = Claude Code（居左）。
+ *
+ * ``roleHeaderFor`` 在机侧「回合切换处」显 ``claude_code`` 徽章，让人↔CC 对话结构显化（对齐
+ * Conductor 机侧身份标注）；连续机侧不重复刷，人侧块（engine/human_reply/task_dispatch）自带
+ * 内嵌徽章，此处返回 null 不重复。
+ */
 export const ROUTINE_POLICY: TranscriptPolicy = {
   align: (item) =>
     item.kind === "human_reply" || item.kind === "task_dispatch" || item.kind === "engine"
@@ -45,7 +52,10 @@ export const ROUTINE_POLICY: TranscriptPolicy = {
     if (item.kind === "engine") return "engine";
     return "cc";
   },
-  roleHeaderFor: () => null,
+  roleHeaderFor: (item, prev) => {
+    if (!isMachineItem(item)) return null;
+    return prev && isMachineItem(prev) ? null : "claude_code";
+  },
   workingLabel: (last) => (last?.kind === "cc_request" && last.pending ? "Planning…" : "Working…"),
 };
 
@@ -66,15 +76,26 @@ export const STUDIO_POLICY: TranscriptPolicy = {
   workingLabel: (last) => (last?.kind === "cc_request" && last.pending ? "Planning…" : "Working…"),
 };
 
-/** 取机侧 item 的 role（仅 assistant/tool/tool_summary/cc_request 携带；其余返回 null）。 */
+/** 机侧 kind 集合（assistant/tool/tool_summary/cc_request）——Routine 与 Studio 共用判定。 */
+const MACHINE_KINDS: ReadonlySet<TranscriptItem["kind"]> = new Set([
+  "assistant",
+  "tool",
+  "tool_summary",
+  "cc_request",
+]);
+
+/** 机侧 TranscriptItem（四个 kind 均携带可选 ``role``，供 ``machineRoleOf`` 收窄访问）。 */
+type MachineTranscriptItem = Extract<
+  TranscriptItem,
+  { kind: "assistant" | "tool" | "tool_summary" | "cc_request" }
+>;
+
+/** item 是否为机侧 kind（类型守卫：收窄为 ``MachineTranscriptItem``）。 */
+function isMachineItem(item: TranscriptItem): item is MachineTranscriptItem {
+  return MACHINE_KINDS.has(item.kind);
+}
+
+/** 取机侧 item 的 role（仅机侧 kind 携带；其余返回 null）。 */
 function machineRoleOf(item: TranscriptItem): AgentRole | null {
-  if (
-    item.kind === "assistant" ||
-    item.kind === "tool" ||
-    item.kind === "tool_summary" ||
-    item.kind === "cc_request"
-  ) {
-    return item.role ?? null;
-  }
-  return null;
+  return isMachineItem(item) ? (item.role ?? null) : null;
 }

--- a/apps/negentropy-ui/components/transcript/style.ts
+++ b/apps/negentropy-ui/components/transcript/style.ts
@@ -6,3 +6,12 @@ export const BADGE_BASE =
 
 /** 展开区代码块基类：等宽、可选中、纵向滚动封顶。 */
 export const CODE_BLOCK = "max-h-[400px] overflow-auto px-2.5 py-2 font-mono text-[12.5px] leading-relaxed select-text";
+
+/** 机侧 assistant 气泡基类（左上拉直 = 机侧，镜像用户气泡右上拉直 ``rounded-tr-sm``）。 */
+export const ASSISTANT_BUBBLE_CLASS = "rounded-2xl rounded-tl-sm bg-muted/30 px-4 py-3";
+
+/** 长消息折叠阈值（字符数）——超过则折叠为限高 + 渐隐 + 「展开全文」（对齐 Conductor Show full message）。 */
+export const LONG_MESSAGE_THRESHOLD_CHARS = 1500;
+
+/** 长消息折叠态限高（≈12 行）——与 ``LONG_MESSAGE_THRESHOLD_CHARS`` 配合决定折叠。 */
+export const LONG_MESSAGE_COLLAPSED_MAX_HEIGHT = "max-h-[18rem]";

--- a/apps/negentropy-ui/components/ui/StudioTranscript.tsx
+++ b/apps/negentropy-ui/components/ui/StudioTranscript.tsx
@@ -8,9 +8,11 @@ import { CHAT_CONTENT_RAIL_CLASS } from "./chat-layout";
 import { buildStudioTranscript } from "./studio-transcript/build-studio-transcript";
 import { STUDIO_POLICY, TranscriptItemsView, type TranscriptItem } from "@/components/transcript";
 import { buildChatDisplayBlocks } from "@/utils/chat-display";
+import { useAuth } from "@/features/auth";
 import { cn } from "@/lib/utils";
 import type { ConversationNode } from "@/types/a2ui";
 import type { ToolProgressMap } from "@/types/common";
+import { UserAvatar } from "./UserAvatar";
 
 type StudioTranscriptProps = {
   nodes: ConversationNode[];
@@ -30,6 +32,8 @@ type StudioTranscriptProps = {
   suggestions?: ChatSuggestion[];
   onSuggestionPick?: (prompt: string) => void;
   welcomeUserName?: string | null;
+  /** 在途态计时起点（epoch ms）——run 开始时刻，透传给 WorkingIndicator（对齐 Conductor 耗时）。 */
+  workingElapsedStartMs?: number;
 };
 
 /**
@@ -53,7 +57,20 @@ export function StudioTranscript({
   suggestions,
   onSuggestionPick,
   welcomeUserName,
+  workingElapsedStartMs,
 }: StudioTranscriptProps) {
+  // 「人」的一方（真实用户）头像：OAuth 照片优先，回退首字母——锚定用户身份（对齐 Conductor）。
+  const { user } = useAuth();
+  const userAvatar = user ? (
+    <UserAvatar
+      picture={user.picture}
+      name={user.name}
+      email={user.email}
+      className="h-7 w-7"
+      fallbackClassName="bg-muted text-foreground text-xs"
+    />
+  ) : undefined;
+
   const scrollRef = useRef<HTMLDivElement>(null);
   const isUserAtBottomRef = useRef(true);
   const [showJumpToBottom, setShowJumpToBottom] = useState(false);
@@ -187,6 +204,8 @@ export function StudioTranscript({
               policy={STUDIO_POLICY}
               live={live}
               itemWrapper={itemWrapper}
+              userAvatar={userAvatar}
+              workingElapsedStartMs={live ? workingElapsedStartMs : undefined}
             />
           )}
         </div>

--- a/apps/negentropy-ui/tests/unit/components/transcript/UserBubble.test.tsx
+++ b/apps/negentropy-ui/tests/unit/components/transcript/UserBubble.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+
+import { describe, expect, it } from "vitest";
+
+import { UserBubble } from "@/components/transcript/UserBubble";
+import { formatElapsed } from "@/components/transcript/WorkingIndicator";
+import type { TranscriptItem } from "@/components/transcript/types";
+
+type UserItem = Extract<TranscriptItem, { kind: "user" }>;
+const userItem: UserItem = { kind: "user", seq: 1, id: "u1", text: "你好，世界。" };
+
+describe("UserBubble（A：Studio 用户头像注入）", () => {
+  it("提供 avatar 时渲染在气泡侧（锚定「人」的一方）", () => {
+    render(
+      <UserBubble
+        item={userItem}
+        avatar={<span data-testid="user-avatar">A</span>}
+      />,
+    );
+    expect(screen.getByTestId("user-avatar")).toBeInTheDocument();
+    expect(screen.getByText("你好，世界。")).toBeInTheDocument();
+  });
+
+  it("不提供 avatar 时不渲染头像位（气泡仍正常）", () => {
+    const { container } = render(<UserBubble item={userItem} />);
+    expect(screen.getByText("你好，世界。")).toBeInTheDocument();
+    expect(container.querySelector('[data-testid="user-avatar"]')).toBeNull();
+  });
+});
+
+describe("formatElapsed（C：在途态耗时格式化）", () => {
+  it("<60s → \"Ns\"", () => {
+    expect(formatElapsed(0)).toBe("0s");
+    expect(formatElapsed(45_000)).toBe("45s");
+  });
+
+  it("≥60s → \"Nm Ns\"", () => {
+    expect(formatElapsed(60_000)).toBe("1m 0s");
+    expect(formatElapsed(83_000)).toBe("1m 23s");
+  });
+
+  it("负值兜底为 0s（防时钟回退）", () => {
+    expect(formatElapsed(-500)).toBe("0s");
+  });
+});

--- a/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
+++ b/apps/negentropy-ui/tests/unit/ui/IterationEventTimeline.test.tsx
@@ -172,6 +172,19 @@ describe("IterationEventTimeline assistant 文本", () => {
     const flow = container.querySelector(".flex.flex-col");
     expect(flow?.children.length ?? 0).toBe(0);
   });
+
+  it("长 assistant 文本（超阈值）默认折叠显「展开全文」，点击后「收起」", () => {
+    // > LONG_MESSAGE_THRESHOLD_CHARS(1500)
+    const longText = "这是一段用于测试折叠阈值的长内容。".repeat(100);
+    render(
+      <IterationEventTimeline
+        events={[makeEvent({ event_type: "assistant", tool_name: null, payload: { text: longText } })]}
+      />,
+    );
+    expect(screen.getByText("展开全文")).toBeInTheDocument();
+    fireEvent.click(screen.getByText("展开全文"));
+    expect(screen.getByText("收起")).toBeInTheDocument();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -498,6 +511,45 @@ describe("IterationEventTimeline 人机回合（human_reply）", () => {
     expect(screen.queryByText(/次工具调用/)).not.toBeInTheDocument();
     expect(screen.getByText("Read")).toBeInTheDocument();
     expect(screen.getByText("Edit")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 机侧（Claude Code）回合徽章：对齐 Conductor 机侧身份标注
+// ---------------------------------------------------------------------------
+
+describe("IterationEventTimeline 机侧回合徽章", () => {
+  it("机侧首项（assistant）在回合切换处显 Claude Code 徽章", () => {
+    render(
+      <IterationEventTimeline
+        events={[makeEvent({ event_type: "assistant", tool_name: null, payload: { text: "我开始执行。" } })]}
+      />,
+    );
+    // 机侧（Claude Code）身份徽章显化，让人↔CC 对话结构一眼可辨
+    expect(screen.getByText("Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("我开始执行。")).toBeInTheDocument();
+  });
+
+  it("连续机侧（多个 tool）不重复刷徽章——仅回合首项 1 个 Claude Code", () => {
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, tool_name: "Read", payload: { tool_id: "t1", input: { file_path: "a.ts" } } }),
+      makeEvent({ seq: 1, id: "e2", tool_name: "Bash", payload: { tool_id: "t2", input: { command: "ls" } } }),
+    ];
+    render(<IterationEventTimeline events={events} />);
+    // 两个连续机侧 tool，仅在回合切换处（首项）渲染 1 个徽章
+    expect(screen.getAllByText("Claude Code")).toHaveLength(1);
+  });
+
+  it("人侧 human_reply 不挂机侧徽章；其后机侧 assistant 触发回合切换徽章", () => {
+    const events: RoutineIterationEventDTO[] = [
+      makeEvent({ seq: 0, event_type: "plan_review", title: "Plan Review", tool_name: null, payload: { verdict: "approve", score: 85, module_reviews: [], feedback: "", reflection: "" } }),
+      makeEvent({ seq: 1, id: "e2", event_type: "assistant", tool_name: null, payload: { text: "按审阅意见继续。" } }),
+    ];
+    render(<IterationEventTimeline events={events} />);
+    // 人侧 human_reply 自带内嵌「元神」徽章，不挂外层机侧徽章
+    expect(screen.getByText("元神")).toBeInTheDocument();
+    // 其后机侧 assistant 在回合切换处显 Claude Code
+    expect(screen.getAllByText("Claude Code")).toHaveLength(1);
   });
 });
 

--- a/docs/concepts/subsystems/041-human-machine-interaction-transcript.md
+++ b/docs/concepts/subsystems/041-human-machine-interaction-transcript.md
@@ -84,7 +84,7 @@ interface TranscriptPolicy {
 }
 ```
 
-- **`ROUTINE_POLICY`**：`human_reply`/`task_dispatch`/`engine` 居右、其余居左；`turnGroup` 三分（cc / human / engine）；`roleHeaderFor` 恒 `null`（徽章内嵌在 Engine/Human/TaskDispatch 块中）。
+- **`ROUTINE_POLICY`**：`human_reply`/`task_dispatch`/`engine` 居右、其余居左；`turnGroup` 三分（cc / human / engine）；`roleHeaderFor` 在机侧（cc）回合切换处显 `claude_code` 徽章（连续机侧不重复刷；人侧 engine/human_reply/task_dispatch 自带内嵌徽章不重复），让 Routine 人↔CC 对话结构显化（对齐 Conductor 机侧身份标注）。
 - **`STUDIO_POLICY`**：仅 `user` 居右、其余全居左；`roleHeaderFor` 在机侧 `role` 相邻变化时渲染徽章（分组降噪）；不设 `turnGroup`（回落 align）。
 
 薄壳 `TranscriptView`（Routine）与 `StudioTranscript`（Studio）各自归一化后委派给同一渲染器，**外部签名稳定、行为各表**。
@@ -107,7 +107,7 @@ interface TranscriptPolicy {
 | `system_note` | Studio 纯文本系统/状态/摘要行 | — | ✓ | 左 |
 | `truncated` | 动作数超限截断哨兵 | ✓ | — | 左 |
 
-可选字段（全 additive）：`role: AgentRole`（机侧 + human_reply）、`nodeId: string`（Studio 选中/搜索）、`citations: Citation[]`（assistant，Studio 引用尾注）、`progress: ToolProgressSnapshot`（tool，Studio 流式进度）、`streaming` / `thinking`（assistant）。所有可选字段对 Routine 归一化输出恒空 → Routine 渲染逐像素等价。
+可选字段（全 additive）：`role: AgentRole`（机侧 + human_reply）、`nodeId: string`（Studio 选中/搜索）、`citations: Citation[]`（assistant，Studio 引用尾注）、`progress: ToolProgressSnapshot`（tool，Studio 流式进度）、`streaming` / `thinking`（assistant）。Routine 归一化不填这些可选字段——机侧 identity 不依赖 `role`，而由 `ROUTINE_POLICY.roleHeaderFor` 按 `kind` 在回合切换处统一投射为 `claude_code`（故 Routine 不再逐像素等价于历史裸文观感，属主动语义升级）。
 
 ## 6. Agent 身份映射
 
@@ -145,6 +145,10 @@ interface TranscriptPolicy {
 | 节点选中 / 搜索 | `itemWrapper` 挂 `data-node-id` + 点击 ring + 搜索高亮 ring + `scrollIntoView` | `StudioTranscript` |
 | 在途指示器 | `pending && !lastIsStreamingAssistant` 时尾随 `WorkingIndicator`；label 由 `policy.workingLabel` 解析（cc_request+pending → Planning…，否则 Working…） | `TranscriptItemsView` |
 | CC 交互错误红显 | `AssistantText` 用 `CC_ERROR_RE` 检测「returned an error」等模式，红框 + ⚠ | `AssistantText.tsx` |
+| 机侧回合徽章 | `ROUTINE_POLICY.roleHeaderFor` 按 `kind` 在机侧回合切换处显 `claude_code`；连续机侧不重复刷；人侧块不挂外层徽章（自带内嵌） | `policy.ts`（`isMachineItem` 类型守卫）+ `IterationEventTimeline.test.tsx` 3 条回归守卫 |
+| Studio 用户头像 | `StudioTranscript` 经 `useAuth` + `UserAvatar` 注入 `userAvatar` 到 `UserBubble` 右侧（OAuth 图/首字母） | `StudioTranscript.tsx` / `UserBubble.tsx` |
+| 在途态耗时计时 | `WorkingIndicator` 接 `workingElapsedStartMs`（Routine=`iteration.started_at`，Studio=`runStartedAtMs` state），复用 `ClockProvider` 同范式 tick；格式 `1m 23s` | `WorkingIndicator.tsx`（`formatElapsed`）/ `home-body.tsx` / `IterationAuditDrawer.tsx` |
+| 长消息折叠 | `AssistantText` 正文超 `LONG_MESSAGE_THRESHOLD_CHARS`(1500) 折叠为限高 + 渐隐 + 「展开全文」（对齐 Conductor Show full message） | `AssistantText.tsx`（`AssistantBody`）/ `style.ts` |
 | thinking 折叠 | 默认收起为「思考…」单行 + Brain 图标，点击展开 | `AssistantText` |
 | 空 assistant 丢弃 | 仅 `{raw}` 无 text 的 assistant 事件归一化时丢弃，防空气泡 | `normalize-transcript.ts` |
 | 持久化 + live 合并 | `mergeEvents` 按 `seq` 去重（持久化优先）+ 升序重排 | `IterationAuditDrawer.tsx` |
@@ -174,7 +178,7 @@ interface TranscriptPolicy {
 
 | 编号 | 风险 | 影响 | 概率 | 对策 |
 |---|---|---|---|---|
-| R1 | Routine 渲染回归（迁移共享模块） | 高 | 低 | 44 项转录契约测试零改动全绿；`ROUTINE_POLICY.roleHeaderFor` 恒 null 保逐像素等价 |
+| R1 | Routine 渲染回归（迁移共享模块 / 机侧徽章化 / 气泡化） | 高 | 低 | 转录契约测试全绿（机侧徽章新增 3 条回归守卫）；`ROUTINE_POLICY.roleHeaderFor` 改为机侧回合显 `claude_code`、`AssistantText` 正文套机侧气泡，「逐像素等价」承诺已主动解除（任务明确的语义升级，注释/文档同步） |
 | R2 | 流式 key 抖动致重挂载 | 中 | 中 | item key `${kind}-${seq}-${id}`，`id` 源自稳定 nodeId；fingerprint memo 含子内容长度 |
 | R3 | per-agent 归因失真（author 字段不规范） | 中 | 低 | 子串匹配 + 中文学名兜底 + 未知回退 engine；Phase 2 切后端字段后消除 |
 | R4 | Studio 选择器破坏旧 E2E | 中 | 中 | `itemWrapper` 挂 `data-testid="message-bubble"` + `data-message-role`，双气泡守卫零改动保留 |

--- a/docs/concepts/user-guide/transcript-view.md
+++ b/docs/concepts/user-guide/transcript-view.md
@@ -50,8 +50,8 @@ flowchart LR
 **能做什么**：发送一条指令，看清谁的产出在哪。
 
 **怎么做**：
-1. 底部输入框打字 → Enter（或点 Send 上箭头）。你的消息**居右**显示（primary 浅底气泡）。
-2. 机的回复**居左**，每段产出上方挂一个**角色徽章**（图标 + 中文标签）。
+1. 底部输入框打字 → Enter（或点 Send 上箭头）。你的消息**居右**显示（primary 浅底气泡 + 右侧你的头像：OAuth 照片或首字母，锚定「人」的一方）。
+2. 机的回复**居左**（机侧 muted 气泡），每段产出上方挂一个**角色徽章**（图标 + 中文标签）。
 
 **徽章速查**：
 
@@ -112,7 +112,7 @@ Routine 详情页 → Iteration 时间线卡片 → 点「Full View」→ 右侧
 抽屉顶部 metadata bar（phase / status / verdict / score / turns / cost / agent 角色 count）→ 下方是按 seq 时序交织的人机回合：
 
 - **开场任务下发**（右）：`Negentropy → Claude Code` 的 `task_dispatch` 气泡，含目标 / 验收 / 反思 / 记忆注入（由 `iteration.prompt` 合成）。
-- **Claude Code 推理 / 工具**（左）：裸文 + 紧凑工具行（同 Studio 的工具卡范式）。
+- **Claude Code 推理 / 工具**（左）：机侧 muted 气泡 + 回合起始显 **Claude Code 徽章**（让人↔CC 结构一眼可辨，连续机侧不重复刷）+ 紧凑工具行（同 Studio 的工具卡范式）。长回复默认折叠为「展开全文」。
 - **待决卡片** `cc_request`（左，高亮）：CC 通过 `ExitPlanMode` / `AskUserQuestion` 向「人」提交 Plan / 问题，等待裁决；标题显 `Review plan` / `Answer question` / `Exit plan mode`，在途态显脉冲「等待裁决」。
 - **「人」侧应答** `human_reply`（右）：一核五翼 6 Agent 的裁决气泡，徽章按动作语义显化：
   - **元神 Contemplation**：审 Plan（approve ✔ / refine 🔄）/ 批准退出 / 迭代评估。


### PR DESCRIPTION
## 背景

negentropy 的两处「人机交互」回合制转录视图（Routine Iterations Full View 与 Home/Studio 中栏）已统一为同一套渲染器（`TranscriptItemsView` + `TranscriptPolicy`）。拿到 Conductor.app 的真实前端反编译产物后比对，发现人/机身份的视觉锚定仍有差距，导致人机交互内容不够直观、聚焦。

本次在不改变已落地的**角色语义**与**左右方向（人=右 / 机=左，主流惯例）**前提下，做 4 项针对性精修，让两处视图向 Conductor 人机交互视图再次对齐。

## 角色语义（保持不变）

| 视图 | 人（居右） | 机（居左） |
|---|---|---|
| **Routine Full View** | 一核五翼 6 Agent | Claude Code |
| **Studio 中栏** | 真实用户 | 一核五翼 + Claude Code |

## 改动（A/B/C/D）

### B — Routine 机侧回合徽章【核心】
- `ROUTINE_POLICY.roleHeaderFor` 由恒 `null` 改为：机侧（Claude Code）在**回合切换处**（上一条非机侧或无 prev）显 `claude_code` 徽章，连续机侧不重复刷（镜像 `STUDIO_POLICY` 分组降噪）。
- 关键正确性：Routine 的 `normalize-transcript` 不给机侧 item 挂 `role`，故**不能复用** `machineRoleOf`，改为按 `kind` 判定（抽 `MACHINE_KINDS` + `isMachineItem` 类型守卫，`machineRoleOf` 同步复用）。
- 解除 Routine「逐像素等价」承诺（任务明确的语义升级），新增 3 条回归守卫。

### A — Studio 用户头像【核心】
- `UserBubble` 经 `useAuth()` + `UserAvatar` 注入用户头像（OAuth 照片 → 首字母回退），渲染在气泡右侧，锚定「人」的一方（对齐 Conductor）。
- 经 `TranscriptItemsView` 新增的可选 `userAvatar` prop 注入，Routine 不传 → 零影响。复用既有 `UserAvatar`，不新建组件。

### C — 在途态耗时计时
- `WorkingIndicator` 接 `workingElapsedStartMs`，追加等宽耗时「1m 23s」（`formatElapsed`），复用 `ClockProvider` 同范式 `tick()` 间接 setState 规避 React 19 严格规则（purity / set-state-in-effect）。
- 两路来源：Routine = `iteration.started_at`（`IterationAuditDrawer` in-flight 时）；Studio = `home-body` 的 `runStartedAtMs` state（doSend 写入、run 终止/取消清空）。

### D — 长消息折叠 + 机侧气泡化
- **D1**：`AssistantText` 正文超 1500 字符折叠为限高 + 渐隐 + 「展开全文」（对齐 Conductor Show full message）；阈值常量化到 `style.ts`。
- **D2**：机侧 assistant 正文套 `muted` 气泡（左上拉直 = 机侧，镜像用户气泡右上拉直），对齐 Conductor agent 气泡容器；用户气泡保持 `primary/[0.06]`（比 Conductor 的 muted 更显「属于用户」且避免与 system 行撞色）。

## 机制层零侵入（正交）

- A/C 经 `TranscriptItemsView` / `TranscriptPolicy` 的**可选** prop 注入，不传则行为不变；
- B 仅改 `ROUTINE_POLICY`，`STUDIO_POLICY` 不动；D 落 `AssistantText`/`style.ts`；
- `TranscriptItemsView` 机制层、`RoleHeader`、`normalize-transcript` 均不改。

## 验证

- **单测**：`IterationEventTimeline`（48，含 B 的 3 条机侧徽章守卫 + D1 折叠用例）、`build-studio-transcript`（12）、新增 `UserBubble`+`formatElapsed`（5）—— **65 全绿**。
- **类型**：`tsc --noEmit` 改动文件零新增错误（仓库既有 `@negentropy/agents-chat-core` 解析错误为离线环境未构建该 workspace 包，预存在、非本次引入）。
- **Lint**：`eslint` 改动文件零错误（已规避 react-hooks 的 purity / set-state-in-effect / refs 三条严格规则）。
- ⚠️ **浏览器实机回归（建议后续）**：`/dev-transcript`（Routine 侧 B/D）与 `/`（Studio 侧 A/C）的深浅模式 + 在途态目视，需借用户已认证 Chrome（遵循浏览器验证协议），建议合并前由用户或后续 PR 实机确认。

## 文档

- 同步 `docs/concepts/subsystems/041-...transcript.md`（§4 ROUTINE_POLICY / §5 视图模型 / §8 回归守卫 / §11 风险）。
- 同步 `docs/concepts/user-guide/transcript-view.md`（§2.1 用户头像 / §3.2 CC 徽章 + 气泡）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
