### PR TITLE
fix(perceives): 重组 docling PDF 拆字(drop-cap/连字/名跨行)修复文本保真

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -410,16 +410,24 @@ def _rejoin_heading_dropcap(line: str) -> str:
     )
     if not (is_heading or is_label):
         return line
-    matches = _DROPCAP_TOKEN_RE.findall(line)
+    # 仅处理「标题区」前缀（前 80 字符）。真实章节标题远短于此；当标题与正文被
+    # assembly 粘成超长一行时，前缀之外是正文，不能对其中的 ``A loop`` / ``I am``
+    # 等合法独立大写词施 drop-cap 重组（否则 ``Aloop`` / ``Iam`` 误并）。
+    HEAD_PREFIX = 80
+    if len(line) <= HEAD_PREFIX:
+        target, tail = line, ""
+    else:
+        target, tail = line[:HEAD_PREFIX], line[HEAD_PREFIX:]
+    matches = _DROPCAP_TOKEN_RE.findall(target)
     n = len(matches)
     if n >= 3:
-        return _DROPCAP_TOKEN_RE.sub(r"\1\2", line)
+        return _DROPCAP_TOKEN_RE.sub(r"\1\2", target) + tail
     if n == 2 and not {c for c, _ in matches} & {"I", "A"}:
-        return _DROPCAP_TOKEN_RE.sub(r"\1\2", line)
+        return _DROPCAP_TOKEN_RE.sub(r"\1\2", target) + tail
     if n == 1:
         cap, rest = matches[0]
         if (cap + rest).lower() in _SECTION_TITLE_WORDS:
-            return _DROPCAP_TOKEN_RE.sub(r"\1\2", line, count=1)
+            return _DROPCAP_TOKEN_RE.sub(r"\1\2", target, count=1) + tail
     return line
 
 
@@ -446,20 +454,18 @@ def _rejoin_attested_inline_hyphens(text: str) -> str:
 
 
 def _rejoin_dropcap_and_ligatures(text: str) -> str:
-    """重组 PDF 提取拆解的 drop-cap 首字母与连字（ﬀ/ﬃ/ﬄ）碎片。
+    """重组 PDF 提取拆解的 drop-cap 首字母与缩写撇号碎片（局部安全规则）。
 
-    覆盖三类 docling 常见拆字：
+    覆盖两类**局部即可判定、无需同文佐证**的 docling 拆字：
 
-    1. drop-cap 首字母：``I ntroduction`` → ``Introduction``（仅标题/标签行，
-       详见 :func:`_rejoin_heading_dropcap`）。
-    2. 连字 ﬀ/ﬃ/ﬄ：``di ff erent`` → ``different``、``o ffi cial`` →
-       ``official``、``hando ff,`` → ``handoff,``。**仅处理 ``ff/ffi/ffl``**，
-       不处理 ``fi/fl``——后者会误并 ``staff if`` / ``half fl`` 等合法两词。
-    3. 缩写撇号：``don ' t`` → ``don't``，仅限常见后缀（t/s/re/ve/ll/m/d），
+    1. drop-cap 首字母：``I ntroduction`` → ``Introduction``（仅标题/标签行的
+       前 80 字符标题区，详见 :func:`_rejoin_heading_dropcap`）。
+    2. 缩写撇号：``don ' t`` → ``don't``，仅限常见后缀（t/s/re/ve/ll/m/d），
        不动 ``'no'`` / ``'runs'`` 这类独立引号。
 
-    三类规则的共同特征是「拆字产物在合法英文中几乎不出现」，故可全局施加而
-    误伤极低。
+    ﬀ/ﬃ/ﬄ 连字拆字（``di ff erent`` / ``hando ff skipped``）须区分词内/词尾，
+    需同文佐证判定，由 :func:`_rejoin_attested_ligatures` 在 assembly 全文落定
+    后处理，不在此函数。
     """
     if not text:
         return text
@@ -467,21 +473,108 @@ def _rejoin_dropcap_and_ligatures(text: str) -> str:
     # 1) drop-cap：逐行只改标题/章节标签行
     text = "\n".join(_rejoin_heading_dropcap(ln) for ln in text.split("\n"))
 
-    # 1b) 同文佐证回并行内硬连字符（专有名跨行断字）：Ra-jasekaran → Rajasekaran
-    text = _rejoin_attested_inline_hyphens(text)
-
-    # 2) 连字 ﬃ/ﬄ（先于 ﬀ，避免 ``o ffi c`` 中 ``ff`` 被先部分吞掉）
-    text = re.sub(r"(?<=[a-z])[ \t](ffi|ffl)[ \t](?=[a-z])", r"\1", text)
-    # 3) 连字 ﬀ：词内 ``i ff e`` → ``iffe``
-    text = re.sub(r"(?<=[a-z])[ \t](ff)[ \t](?=[a-z])", r"\1", text)
-    # 4) 连字 ﬀ：词尾 ``o ff,`` / ``o ff)`` → ``off,`` / ``off)``
-    text = re.sub(r"(?<=[a-z])[ \t](ff)(?=[ \t.,;:!?)\]”’]|$)", r"\1", text)
-    # 5) 缩写撇号：``don ' t`` → ``don't``（curly 与 straight 引号皆收）
+    # 2) 缩写撇号：don ' t → don't（curly 与 straight 引号皆收；不动独立引号）
     text = re.sub(
         r"(?<=[a-z])[ \t][’'][ \t](?=(?:t|s|re|ve|ll|m|d)\b)",
         "’",
         text,
     )
+    return text
+
+
+# 常见含 ﬀ/ﬃ/ﬄ 的英文词：拆字后若该词在文档别处无干净形式可佐证，以此白名单兜底。
+_FF_LIGATURE_WORDS = frozenset(
+    (
+        "off",
+        "handoff",
+        "handoffs",
+        "different",
+        "difference",
+        "differences",
+        "differently",
+        "differ",
+        "differs",
+        "official",
+        "officially",
+        "office",
+        "offices",
+        "officer",
+        "officers",
+        "offer",
+        "offers",
+        "offered",
+        "offering",
+        "offerings",
+        "effort",
+        "efforts",
+        "afford",
+        "affordable",
+        "affordability",
+        "scaffold",
+        "scaffolding",
+        "difficulty",
+        "difficulties",
+        "staff",
+        "stiff",
+        "stuff",
+        "stuffs",
+        "scoff",
+        "skiff",
+        "sniff",
+        "snuff",
+        "fluff",
+        "bluff",
+        "raffle",
+        "shuffle",
+        "baffle",
+        "scuffle",
+        "snaffle",
+        "quaff",
+        "gaffe",
+    )
+)
+
+# 词内连字拆分：prefix + space + (ff|ffi|ffl) + space + post（如 di ff erent）
+_LIGATURE_SPLIT_RE = re.compile(r"\b([a-z]+)[ \t](ff|ffi|ffl)[ \t]([a-z]{2,})\b")
+# 词尾连字拆分：prefix + space + (ff|ffi|ffl) + 标点/行尾（如 hando ff,）
+_LIGATURE_FINAL_RE = re.compile(r"\b([a-z]+)[ \t](ff|ffi|ffl)(?=[ \t.,;:!?)\]”’\"]|$)")
+
+
+def _rejoin_attested_ligatures(text: str) -> str:
+    """同文佐证 + 白名单重组 ﬀ/ﬃ/ﬄ 连字拆字（须在全文落定后执行）。
+
+    docling 把 ``different`` 拆成 ``di ff erent``（词内，``ff`` 属两侧）、把
+    ``handoff`` 拆成 ``hando ff``（词尾，``ff`` 属前词），二者须区别对待：
+
+    - 词内（``di ff erent``）：去两侧空格 → ``different``。
+    - 词尾（``hando ff skipped``）：仅去前侧空格 → ``handoff skipped``，
+      **保留**与后词的空格——否则误并 ``handoffskipped``。
+
+    安全闸：仅当「全并」(different) 或「前词并」(handoff/off) 的结果落在同文
+    佐证集或 ``_FF_LIGATURE_WORDS`` 白名单时才动手；未知形态原样保留，绝不
+    误并。须在 assembly 全文落定后调用以取得同文佐证。
+    """
+    if not text:
+        return text
+    attested = {w.lower() for w in re.findall(r"\b[A-Za-z]{3,}\b", text)}
+    known = attested | _FF_LIGATURE_WORDS
+
+    def _internal(m: re.Match) -> str:
+        pre, lig, post = m.group(1), m.group(2), m.group(3)
+        if (pre + lig + post) in known:
+            return pre + lig + post  # 词内：different / official / effort
+        if (pre + lig) in known:
+            return pre + lig + " " + post  # 词尾：handoff skipped / off was
+        return m.group(0)
+
+    def _final(m: re.Match) -> str:
+        pre, lig = m.group(1), m.group(2)
+        if (pre + lig) in known:
+            return pre + lig  # handoff, / off.
+        return m.group(0)
+
+    text = _LIGATURE_SPLIT_RE.sub(_internal, text)
+    text = _LIGATURE_FINAL_RE.sub(_final, text)
     return text
 
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -354,6 +354,137 @@ def _rejoin_split_diacritics(text: str) -> str:
     return text
 
 
+# 常见学术章节标题词——用于安全地重组 ``#### R eferences`` 这类「单 drop-cap
+# 词标题」（并回后落在该白名单才重组，避免误并正文 ``A brief`` / ``I think``）。
+_SECTION_TITLE_WORDS = frozenset(
+    {
+        "references",
+        "introduction",
+        "abstract",
+        "conclusion",
+        "conclusions",
+        "acknowledgment",
+        "acknowledgments",
+        "acknowledgement",
+        "acknowledgements",
+        "appendix",
+        "appendices",
+        "background",
+        "methodology",
+        "methodologies",
+        "results",
+        "discussion",
+        "bibliography",
+        "preface",
+        "foreword",
+        "synthesis",
+        "evaluation",
+    }
+)
+
+# drop-cap 碎片：``I ntroduction`` / ``W hat``（大号首字母与正文被分作两个 span，
+# ``" ".join`` 后插入空格）。rest 允许单字母（``I s`` → ``Is``）。
+_DROPCAP_TOKEN_RE = re.compile(r"([A-Z])[ \t]([a-z]+)")
+
+
+def _rejoin_heading_dropcap(line: str) -> str:
+    """重组标题/章节标签行内的 drop-cap 首字母碎片。
+
+    docling 等引擎把大号首字母（drop-cap）与剩余小写正文抽成独立 span，
+    拼接成 ``I ntroduction`` / ``W hat L oop E ngineering``（应为
+    ``Introduction`` / ``What Loop Engineering``）。仅作用于标题（``#`` 开头）
+    或章节标签（``I.`` / ``II.`` / ``A.`` 行首）行，避免误并正文里 ``I think``
+    / ``A few`` 这类合法独立大写词。
+
+    安全闸（逐级放宽、层层防误并）：
+    - ≥3 个 ``X yyy`` 碎片 → 整行重组（合法标题鲜少有 3+ 个 ``Capital 小写词``
+      密集形态；系统的 drop-cap 拆字才如此密集）。
+    - 恰好 2 个 → 仅当两个首字母都**不是**独立代词/冠词 ``I``/``A`` 时重组
+      （误并高危形态 ``I think…`` / ``A brief…`` 恰以 I/A 起头）。
+    - 恰好 1 个 → 仅当并回结果落在常见章节标题白名单（如 ``References``）才重组。
+    """
+    stripped = line.lstrip()
+    is_heading = stripped.startswith("#")
+    is_label = bool(
+        re.match(r"^[IVX]+\.\s", stripped) or re.match(r"^[A-Z]\.\s", stripped)
+    )
+    if not (is_heading or is_label):
+        return line
+    matches = _DROPCAP_TOKEN_RE.findall(line)
+    n = len(matches)
+    if n >= 3:
+        return _DROPCAP_TOKEN_RE.sub(r"\1\2", line)
+    if n == 2 and not {c for c, _ in matches} & {"I", "A"}:
+        return _DROPCAP_TOKEN_RE.sub(r"\1\2", line)
+    if n == 1:
+        cap, rest = matches[0]
+        if (cap + rest).lower() in _SECTION_TITLE_WORDS:
+            return _DROPCAP_TOKEN_RE.sub(r"\1\2", line, count=1)
+    return line
+
+
+def _rejoin_attested_inline_hyphens(text: str) -> str:
+    """同文佐证回并行内硬连字符：``Ra-jasekaran`` → ``Rajasekaran``。
+
+    docling 偶把跨行专有名词的软换行连字符保留为行内硬连字符。仅当去连字符后
+    的形式在**同一文档别处**作为完整词（``\\b[A-Za-z]{4,}\\b``）出现过才回并——
+    这是安全闸：``Sub-agents`` / ``state-of-the-art`` 这类「从未以无连字符形式
+    出现」的合法复合词不会被误并。模式进一步收窄到「大写短前缀 + 长小写尾」
+    （专有名词断行形态），把爆炸半径压到最小。
+    """
+    if not text:
+        return text
+    attested = {w.lower() for w in re.findall(r"\b[A-Za-z]{4,}\b", text)}
+
+    def _maybe(m: re.Match) -> str:
+        joined = (m.group(1) + m.group(2)).lower()
+        if joined in attested:
+            return m.group(1) + m.group(2)
+        return m.group(0)
+
+    return re.sub(r"\b([A-Z][a-z]{1,2})-([a-z]{3,})\b", _maybe, text)
+
+
+def _rejoin_dropcap_and_ligatures(text: str) -> str:
+    """重组 PDF 提取拆解的 drop-cap 首字母与连字（ﬀ/ﬃ/ﬄ）碎片。
+
+    覆盖三类 docling 常见拆字：
+
+    1. drop-cap 首字母：``I ntroduction`` → ``Introduction``（仅标题/标签行，
+       详见 :func:`_rejoin_heading_dropcap`）。
+    2. 连字 ﬀ/ﬃ/ﬄ：``di ff erent`` → ``different``、``o ffi cial`` →
+       ``official``、``hando ff,`` → ``handoff,``。**仅处理 ``ff/ffi/ffl``**，
+       不处理 ``fi/fl``——后者会误并 ``staff if`` / ``half fl`` 等合法两词。
+    3. 缩写撇号：``don ' t`` → ``don't``，仅限常见后缀（t/s/re/ve/ll/m/d），
+       不动 ``'no'`` / ``'runs'`` 这类独立引号。
+
+    三类规则的共同特征是「拆字产物在合法英文中几乎不出现」，故可全局施加而
+    误伤极低。
+    """
+    if not text:
+        return text
+
+    # 1) drop-cap：逐行只改标题/章节标签行
+    text = "\n".join(_rejoin_heading_dropcap(ln) for ln in text.split("\n"))
+
+    # 1b) 同文佐证回并行内硬连字符（专有名跨行断字）：Ra-jasekaran → Rajasekaran
+    text = _rejoin_attested_inline_hyphens(text)
+
+    # 2) 连字 ﬃ/ﬄ（先于 ﬀ，避免 ``o ffi c`` 中 ``ff`` 被先部分吞掉）
+    text = re.sub(r"(?<=[a-z])[ \t](ffi|ffl)[ \t](?=[a-z])", r"\1", text)
+    # 3) 连字 ﬀ：词内 ``i ff e`` → ``iffe``
+    text = re.sub(r"(?<=[a-z])[ \t](ff)[ \t](?=[a-z])", r"\1", text)
+    # 4) 连字 ﬀ：词尾 ``o ff,`` / ``o ff)`` → ``off,`` / ``off)``
+    text = re.sub(r"(?<=[a-z])[ \t](ff)(?=[ \t.,;:!?)\]”’]|$)", r"\1", text)
+    # 5) 缩写撇号：``don ' t`` → ``don't``（curly 与 straight 引号皆收）
+    text = re.sub(
+        r"(?<=[a-z])[ \t][’'][ \t](?=(?:t|s|re|ve|ll|m|d)\b)",
+        "’",
+        text,
+    )
+    return text
+
+
 def _is_list_continuation(line: str) -> bool:
     """判断行是否为列表项的缩进续行（非新列表标记的缩进文本）。"""
     if not line or not line[0].isspace():
@@ -1591,6 +1722,10 @@ class MarkdownFormatter:
                 # \u7528\u5bf9\u5e94\u7684\u7ec4\u5408\u53d8\u97f3\u7b26\u53f7\uff08U+0300 \u7cfb\u5217\uff09\u62fc\u5408\uff0c\u5e76\u901a\u8fc7
                 # ``unicodedata.normalize("NFC", ...)`` \u6536\u655b\u4e3a\u9884\u7ec4\u5408 codepoint\u3002
                 text = _rejoin_split_diacritics(text)
+
+                # 重组 drop-cap 首字母与连字碎片（docling 拆字）：
+                # ``I ntroduction`` → ``Introduction``、``di ff erent`` → ``different``。
+                text = _rejoin_dropcap_and_ligatures(text)
 
                 # \u8de8\u884c\u65ad\u5b57\u5408\u5e76\uff1aPyMuPDF \u6587\u672c\u63d0\u53d6\u5e38\u6b8b\u7559 `word-\nword`\uff0cassembly \u9636\u6bb5
                 # \u628a `\n` \u6298\u53e0\u4e3a\u7a7a\u683c\u540e\u53d8\u6210 `word- word`\u3002\u4ec5\u5339\u914d\u4e24\u4fa7\u5747\u4e3a ASCII \u5c0f\u5199

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -68,7 +68,10 @@ class BuiltinAssembler(PDFToolBase):
     async def _run(self, input_data: AssemblyInput) -> StageResult[AssemblyOutput]:
         """组装 Markdown 文档。"""
         try:
-            from ....markdown.formatter import MarkdownFormatter
+            from ....markdown.formatter import (
+                MarkdownFormatter,
+                _rejoin_attested_inline_hyphens,
+            )
             from ....markdown.image_ref_normalizer import (
                 normalize_image_references,
             )
@@ -1960,6 +1963,12 @@ class BuiltinAssembler(PDFToolBase):
 
             # 6. 参考文献节条目分段（多条目连段 → 每条独占段落）
             markdown = _segment_references_section(markdown)
+
+            # 7. 同文佐证回并行内硬连字符（专有名跨行断字）：须在全文落定后做，
+            #    以便「去连字符形式」能从文档别处（如参考文献）取得佐证。
+            #    Ra-jasekaran → Rajasekaran（仅当 Rajasekaran 别处出现）；从不误并
+            #    Sub-agents / state-of-the-art 等未佐证复合词。
+            markdown = _rejoin_attested_inline_hyphens(markdown)
 
             word_count = len(markdown.split())
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/assembly.py
@@ -71,6 +71,7 @@ class BuiltinAssembler(PDFToolBase):
             from ....markdown.formatter import (
                 MarkdownFormatter,
                 _rejoin_attested_inline_hyphens,
+                _rejoin_attested_ligatures,
             )
             from ....markdown.image_ref_normalizer import (
                 normalize_image_references,
@@ -1969,6 +1970,10 @@ class BuiltinAssembler(PDFToolBase):
             #    Ra-jasekaran → Rajasekaran（仅当 Rajasekaran 别处出现）；从不误并
             #    Sub-agents / state-of-the-art 等未佐证复合词。
             markdown = _rejoin_attested_inline_hyphens(markdown)
+            # 8. 同文佐证 + 白名单重组 ﬀ/ﬃ/ﬄ 连字拆字：须在全文落定后做以取得
+            #    佐证；区分词内（di ff erent→different）与词尾（hando ff skipped→
+            #    handoff skipped），避免误并 handoffskipped。
+            markdown = _rejoin_attested_ligatures(markdown)
 
             word_count = len(markdown.split())
 

--- a/apps/negentropy-perceives/tests/unit/test_formatter_dropcap_ligature_rejoin.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_dropcap_ligature_rejoin.py
@@ -1,0 +1,136 @@
+"""drop-cap 首字母 / 连字 / 同文佐证硬连字符 重组规则的单测。
+
+锁定 ``_rejoin_dropcap_and_ligatures`` 的修复行为与防误并护栏：
+- docling 把大号首字母（drop-cap）与正文分作两 span，``" ".join`` 后产生
+  ``I ntroduction`` / ``W hat L oop E ngineering`` 碎片；
+- ﬀ/ﬃ 连字被拆为 ``di ff erent`` / ``o ffi cial``；
+- 专有名跨行软换行连字符残留为行内硬连字符 ``Ra-jasekaran``。
+"""
+
+from negentropy.perceives.markdown.formatter import (
+    _rejoin_attested_inline_hyphens,
+    _rejoin_dropcap_and_ligatures,
+)
+
+
+def _f(text: str) -> str:
+    return _rejoin_dropcap_and_ligatures(text)
+
+
+# ---------------- drop-cap 首字母重组（修复项） ----------------
+
+
+def test_dropcap_multidword_heading_rejoined():
+    assert _f("I. I ntroduction: W hat L oop E ngineering R eally I s") == (
+        "I. Introduction: What Loop Engineering Really Is"
+    )
+    assert _f("II. F rom P rompt to C ontext to L oop") == (
+        "II. From Prompt to Context to Loop"
+    )
+
+
+def test_dropcap_two_word_heading_no_pronoun_rejoined():
+    # 两个碎片且首字母非 I/A（独立代词/冠词）→ 重组
+    assert _f("V. G enerator and E valuator") == "V. Generator and Evaluator"
+    assert _f("XI. O perational D iscipline") == "XI. Operational Discipline"
+
+
+def test_dropcap_single_word_whitelisted_section_title():
+    assert _f("#### R eferences") == "#### References"
+    assert _f("## A bstract") == "## Abstract"
+
+
+# ---------------- drop-cap 防误并护栏 ----------------
+
+
+def test_no_false_merge_standalone_pronoun_in_heading():
+    # 「I think Therefore I am」恰 2 碎片且首字母为 I → 不重组
+    assert _f("## I think Therefore I am") == "## I think Therefore I am"
+
+
+def test_no_false_merge_article_plus_word():
+    assert _f("## A brief history of time") == "## A brief history of time"
+
+
+def test_no_touch_body_text():
+    body = "I think A few engineers will agree on this."
+    assert _f(body) == body
+
+
+def test_intact_title_case_heading_unchanged():
+    assert _f("# Loop Engineering: The Anthropic Playbook") == (
+        "# Loop Engineering: The Anthropic Playbook"
+    )
+    assert _f("A. A One-Line Definition") == "A. A One-Line Definition"
+
+
+# ---------------- 连字 ﬀ/ﬃ 重组（修复项） ----------------
+
+
+def test_ligature_ff_internal_rejoined():
+    assert _f("the di ff erence is structural") == "the difference is structural"
+
+
+def test_ligature_ffi_rejoined():
+    assert _f("refer to each tool’s o ffi cial documentation") == (
+        "refer to each tool’s official documentation"
+    )
+
+
+def test_ligature_ff_word_final_rejoined():
+    assert _f("hando ff, and tune it") == "handoff, and tune it"
+    assert _f("turn it o ff)") == "turn it off)"
+
+
+def test_ligature_fi_fl_NOT_merged_to_avoid_staff_if():
+    # ﬁ/ﬂ 单独不重组，避免误并 ``staff if`` / ``half fl``
+    assert _f("the staff if present should leave") == (
+        "the staff if present should leave"
+    )
+
+
+# ---------------- 缩写撇号（修复项 + 引号护栏） ----------------
+
+
+def test_contraction_apostrophe_rejoined():
+    assert _f("don ' t and won ' t") == "don’t and won’t"
+    assert _f("don ’ t") == "don’t"
+
+
+def test_quoted_words_not_touched():
+    assert _f("say 'no' between 'runs' and 'right.'") == (
+        "say 'no' between 'runs' and 'right.'"
+    )
+
+
+# ---------------- 同文佐证硬连字符（修复项 + 护栏） ----------------
+
+
+def test_attested_inline_hyphen_merged_when_clean_form_exists():
+    doc = "Prithvi Rajasekaran wrote it. The Ra-jasekaran finding stands."
+    out = _rejoin_attested_inline_hyphens(doc)
+    assert "Ra-jasekaran" not in out
+    assert "Rajasekaran finding" in out
+
+
+def test_unattested_compound_preserved():
+    doc = "Sub-agents are useful. state-of-the-art too."
+    out = _rejoin_attested_inline_hyphens(doc)
+    assert "Sub-agents" in out
+    assert "state-of-the-art" in out
+
+
+def test_attested_hyphen_full_pipeline_helper():
+    # 端到端：整段经 _rejoin_dropcap_and_ligatures（含佐证回并）
+    doc = (
+        "X. T he E conomics of J udgment\n"
+        "Rajasekaran found the di ff erence. Addy Osmani wrote it; by Os-mani.\n"
+        "Sub-agents remain. 'no' is quoted."
+    )
+    out = _f(doc)
+    assert "The Economics of Judgment" in out
+    assert "difference" in out
+    assert "Os-mani" not in out  # Osmani 在别处出现 → 同文佐证回并
+    assert "Osmani wrote it" in out
+    assert "Sub-agents" in out
+    assert "'no'" in out

--- a/apps/negentropy-perceives/tests/unit/test_formatter_dropcap_ligature_rejoin.py
+++ b/apps/negentropy-perceives/tests/unit/test_formatter_dropcap_ligature_rejoin.py
@@ -9,12 +9,21 @@
 
 from negentropy.perceives.markdown.formatter import (
     _rejoin_attested_inline_hyphens,
+    _rejoin_attested_ligatures,
     _rejoin_dropcap_and_ligatures,
 )
 
 
 def _f(text: str) -> str:
     return _rejoin_dropcap_and_ligatures(text)
+
+
+def _full(text: str) -> str:
+    """模拟 assembly 末道：局部规则 + 两条同文佐证规则。"""
+    text = _rejoin_dropcap_and_ligatures(text)
+    text = _rejoin_attested_inline_hyphens(text)
+    text = _rejoin_attested_ligatures(text)
+    return text
 
 
 # ---------------- drop-cap 首字母重组（修复项） ----------------
@@ -64,29 +73,62 @@ def test_intact_title_case_heading_unchanged():
     assert _f("A. A One-Line Definition") == "A. A One-Line Definition"
 
 
-# ---------------- 连字 ﬀ/ﬃ 重组（修复项） ----------------
+def test_glued_heading_plus_body_no_false_merge():
+    # 标题与正文被粘成超长一行：标题区 drop-cap 重组，正文 ``A loop`` 保留
+    glued = (
+        "XV. S ynthesis: W hat the P laybook C omes D own T o technical in this "
+        "note serves that one posture. A loop is the most powerful tool."
+    )
+    out = _f(glued)
+    assert "XV. Synthesis: What the Playbook Comes Down To" in out
+    assert "Aloop" not in out
+    assert "A loop is the most powerful" in out
+
+
+# ---------------- 连字 ﬀ/ﬃ 重组（修复项，经同文佐证/白名单） ----------------
 
 
 def test_ligature_ff_internal_rejoined():
-    assert _f("the di ff erence is structural") == "the difference is structural"
+    # "difference" 在白名单 → 词内两侧空格去除
+    assert _full("the di ff erence is structural") == ("the difference is structural")
 
 
 def test_ligature_ffi_rejoined():
-    assert _f("refer to each tool’s o ffi cial documentation") == (
+    assert _full("refer to each tool’s o ffi cial documentation") == (
         "refer to each tool’s official documentation"
     )
 
 
 def test_ligature_ff_word_final_rejoined():
-    assert _f("hando ff, and tune it") == "handoff, and tune it"
-    assert _f("turn it o ff)") == "turn it off)"
+    assert _full("hando ff, and tune it") == "handoff, and tune it"
+    assert _full("turn it o ff)") == "turn it off)"
+
+
+def test_ligature_word_final_keeps_space_before_next_word():
+    # 回归 handoffskipped：词尾 ff 后接另一词 → 仅去前侧空格，保留词间空格
+    out = _full("hando ff skipped the work")
+    assert "handoff skipped the work" == out
+    assert "handoffskipped" not in out
+
+
+def test_ligature_word_final_off_keeps_space():
+    out = _full("turn it o ff was fine")
+    assert "turn it off was fine" == out
+    assert "offwas" not in out
 
 
 def test_ligature_fi_fl_NOT_merged_to_avoid_staff_if():
-    # ﬁ/ﬂ 单独不重组，避免误并 ``staff if`` / ``half fl``
-    assert _f("the staff if present should leave") == (
+    # ﬁ/ﬂ 单独不重组；"staff if" 无独立 ff token，不触发
+    assert _full("the staff if present should leave") == (
         "the staff if present should leave"
     )
+
+
+def test_ligature_unknown_split_left_unchanged():
+    # 未知 ff 拆词（非白名单、非同文佐证）原样保留，绝不误并
+    out = _full("the xylo ff nium played")
+    assert "xylo ff nium" in out
+    assert "xyloffnium" not in out
 
 
 # ---------------- 缩写撇号（修复项 + 引号护栏） ----------------
@@ -121,15 +163,17 @@ def test_unattested_compound_preserved():
 
 
 def test_attested_hyphen_full_pipeline_helper():
-    # 端到端：整段经 _rejoin_dropcap_and_ligatures（含佐证回并）
+    # 端到端：drop-cap + 佐证连字 + 佐证硬连字符 三道工序
     doc = (
         "X. T he E conomics of J udgment\n"
         "Rajasekaran found the di ff erence. Addy Osmani wrote it; by Os-mani.\n"
-        "Sub-agents remain. 'no' is quoted."
+        "hando ff skipped a beat. Sub-agents remain. 'no' is quoted."
     )
-    out = _f(doc)
+    out = _full(doc)
     assert "The Economics of Judgment" in out
-    assert "difference" in out
+    assert "the difference" in out
+    assert "handoff skipped a beat" in out
+    assert "handoffskipped" not in out
     assert "Os-mani" not in out  # Osmani 在别处出现 → 同文佐证回并
     assert "Osmani wrote it" in out
     assert "Sub-agents" in out


### PR DESCRIPTION
## 背景
PDF→Markdown 巡检《Loop Engineering IEEE》(doc_id 6c2b64bf) 发现 docling 引擎对大号首字母（drop-cap）与正文分作独立 span、ﬀ/ﬃ 连字被拆解、专有名跨行软换行连字符残留为行内硬连字符，拼接后产生 `I ntroduction` / `W hat L oop` / `di ff erent` / `o ffi cial` / `Ra-jasekaran` 等拆字碎片，覆盖全部 11 页标题与正文。

## 改动（2 commits，单逻辑根因＝PDF 拆字重组，①pipeline 杠杆）
- **formatter.py** `_rejoin_dropcap_and_ligatures`（局部安全规则，接入 fix_spacing 块）：
  - drop-cap 首字母：仅标题/章节标签行的「前 80 字符标题区」重组；≥3 碎片、或 ≥2 且首字母非 I/A（独立代词/冠词）、或单词标题落白名单才并回 —— 防误并 `I think` / `A brief`，并防「标题粘正文」超长行误并 `A loop`→`Aloop`。
  - 缩写撇号：`don ' t`→`don't`，仅限 t/s/re/ve/ll/m/d 后缀，不动 `'no'` 独立引号。
- **assembly.py** 末道（全文落定后执行，取得同文佐证）：
  - `_rejoin_attested_inline_hyphens`：`Ra-jasekaran`→`Rajasekaran`，仅当去连字符形式文档别处出现才并回，永不误并 `Sub-agents` / `state-of-the-art`。
  - `_rejoin_attested_ligatures`：区分词内（`di ff erent`→`different`，去两侧空格）/ 词尾（`hando ff skipped`→`handoff skipped`，仅去前侧保留词间空格），安全闸为「全并或前词并结果须落在同文佐证集或 _FF_LIGATURE_WORDS 白名单」，未知形态原样保留 —— 修自引入的 `handoffskipped` 误并，且不误并 `staff if`。

## 非回归
- formatter+assembly 单测 **567 passed / 2 skipped(asset-missing) / 0 failed**；ruff check / ruff format / mypy 全绿（pre-commit）。
- 新增 20 用例锁定：dropcap 标题/连字/撇号/名跨行修复 + `Aloop`/`handoffskipped`/`offwas`/`xyloffnium`/`staff if`/`state-of-the-art` 防误并护栏。

## 巡检验证（候选侧，真实 wiki 渲染栈 :62321）
- 候选 MD grep：`I ntroduction`=0、`di ff erent`=0、`handoffskipped`=0、`Aloop`=0；`Introduction: What...`/`different`/`official`/`#### References` 干净。
- wiki curl 渲染 HTML：10 类拆字碎片 0 残留；playwright 截图 + 视觉模型核验 V/VI 标题·References·different 干净。
- 8 维度（text/paragraph_order/image/image_size/toc/table/formula/code/footnote）候选侧 11/11 全绿，score=100。

## 说明
- refresh_markdown Gate 反映 deployed perceives 态（主仓 :2992，非本 worktree），未含本修复故生产 MD 仍拆字；合并+重部署后须重跑 Gate 复核（预期 `I ntroduction`=0）。
- 双栏 IEEE→单栏 wiki 重排致 patrol_page_check head/tail 指纹 text 伪报红（11 页），已以 curl+截图覆盖判定，非真实缺陷。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>