### PR TITLE
fix(perceives/patrol): 预筛适配连续滚动 wiki + 注册客观验证命令

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
@@ -32,6 +32,7 @@ import argparse
 import asyncio
 import contextlib
 import json
+import re
 from pathlib import Path
 from typing import Any
 
@@ -65,6 +66,7 @@ _DOM_PROBE_JS = """
   const imgs = Array.from(root.querySelectorAll('img')).map(img => ({
     natural_width: img.naturalWidth,
     rendered_width: Math.round(img.getBoundingClientRect().width),
+    alt: img.getAttribute('alt') || '',
   }));
   const codeBlocks = root.querySelectorAll('pre code').length;
   const headings = Array.from(root.querySelectorAll('h1, h2, h3, h4')).map(h => norm(h.textContent));
@@ -73,6 +75,45 @@ _DOM_PROBE_JS = """
   return { blocks, tables, tableCells, imgs, codeBlocks, headings, katexErrors };
 }
 """
+
+
+def _resolve_chromium_executable() -> str | None:
+    """定位可用的 chromium 可执行文件；默认 headless-shell 缺失时回退完整 chromium。
+
+    patrol 运行环境（本地/CI）的 Playwright 缓存布局可能只装了完整 chromium 而无
+    chrome-headless-shell（headless 默认路径）；两者皆可 headless 运行。返回 None
+    则交由 Playwright 默认解析。
+    """
+    import os
+
+    candidates: list[Path] = []
+    for env in (
+        os.environ.get("PLAYWRIGHT_BROWSERS_PATH"),
+        os.path.expanduser("~/Library/Caches/ms-playwright"),
+        os.path.expanduser("~/.cache/ms-playwright"),
+    ):
+        if env:
+            candidates.append(Path(env))
+    for base in candidates:
+        if not base.is_dir():
+            continue
+        # 1) chrome-headless-shell-* （版本号最大优先）
+        for sub in sorted(base.glob("chromium_headless_shell-*"), reverse=True):
+            for rel in ("chrome-headless-shell-mac-arm64/chrome-headless-shell",):
+                c = sub / rel
+                if c.exists():
+                    return str(c)
+        # 2) 完整 chromium-* （mac/linux 布局）
+        for sub in sorted(base.glob("chromium-*"), reverse=True):
+            for rel in (
+                "chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+                "chrome-mac-x64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing",
+                "chrome-linux/chrome",
+            ):
+                c = sub / rel
+                if c.exists():
+                    return str(c)
+    return None
 
 
 async def _probe_wiki_dom(
@@ -85,7 +126,9 @@ async def _probe_wiki_dom(
     from playwright.async_api import async_playwright  # noqa: PLC0415
 
     async with async_playwright() as p:
-        browser = await p.chromium.launch()
+        browser = await p.chromium.launch(
+            executable_path=_resolve_chromium_executable()
+        )
         try:
             page = await browser.new_page(
                 viewport={"width": int(width), "height": 1100}
@@ -95,6 +138,15 @@ async def _probe_wiki_dom(
             # 用 contextlib.suppress 代替 try/except: pass，规避 bandit B110（CWE-703）。
             with contextlib.suppress(Exception):
                 await page.wait_for_load_state("networkidle", timeout=8000)
+            # 滚屏触发懒载图（ZoomableImage loading=lazy）——否则屏外图 naturalWidth=0
+            # 被误判断图。逐段滚动一遍再回顶，让所有 <img> 有机会加载。
+            with contextlib.suppress(Exception):
+                scroll_h = await page.evaluate("document.body.scrollHeight")
+                for y in range(0, int(scroll_h), 900):
+                    await page.evaluate(f"window.scrollTo(0,{y})")
+                    await page.wait_for_timeout(80)
+                await page.evaluate("window.scrollTo(0,0)")
+                await page.wait_for_timeout(500)
             dom = await page.evaluate(_DOM_PROBE_JS)
             return dom
         finally:
@@ -104,6 +156,42 @@ async def _probe_wiki_dom(
 # ---------------------------------------------------------------------------
 # 锚点对齐：PDF 页 head/tail 指纹 → wiki DOM blocks 序列位置
 # ---------------------------------------------------------------------------
+
+
+def _norm_text(s: str) -> str:
+    """归一化文本：小写 + 非字母数字(保留 CJK)转空格 + 折叠空白。
+
+    抹平 PDF↔wiki 间的标点/空白差异，使子串包含判定抗 reflow（连续滚动渲染下，
+    PDF 页首文本会并入 wiki 前一块、页尾并入后一块，逐块 head/tail 指纹必然失配）。
+    """
+    s = (s or "").lower()
+    s = re.sub(r"[^a-z0-9一-鿿]+", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _contains_distinctive(
+    corpus_tokens: set[str],
+    fingerprint: str,
+    *,
+    min_tokens: int = 3,
+    threshold: float = 0.7,
+) -> bool:
+    """指纹的**区分性 token**在 wiki 语料 token 集中的覆盖率是否达标。
+
+    比 head/tail 子串匹配更抗 reflow 与截断：指纹是 PDF 页首/页尾文本块的前 80 字符，
+    连续滚动渲染下页首文本会并入 wiki 前一块、且 DOM 块也被探针截断到 80 字符，子串
+    边界难对齐。改取指纹的区分性 token（len>3，滤除页码/短虚词），只要足够比例出现在
+    wiki 全文档语料（含 img alt 图注）即判内容存在——reflow/截断不再误报，真缺失（区分
+    性技术词不在 wiki）仍能检出。短指纹（3-4 token，如小节标题 "provider model cache"）
+    要求全匹配以避免巧合命中。
+    """
+    fp_tokens = [t for t in _norm_text(fingerprint).split() if len(t) > 3]
+    if len(fp_tokens) < min_tokens:
+        return False  # 指纹过短（如页码 "6"/裸文件名）不具备区分性，交视觉兜底
+    hits = sum(1 for t in fp_tokens if t in corpus_tokens)
+    cov = hits / len(fp_tokens)
+    thr = 1.0 if len(fp_tokens) < 5 else threshold  # 短标题要求全匹配
+    return cov >= thr
 
 
 def _find_fingerprint_index(blocks: list[str], fingerprint: str) -> int:
@@ -161,6 +249,14 @@ def _grade_pages(
     dom_katex_err = dom.get("katexErrors", 0)
     dom_headings = dom.get("headings", [])
 
+    # text 维度抗-reflow 包含判定：归一化全 DOM 语料（blocks + img alt 图注）+ PDF 页指纹查表。
+    # 连续滚动 wiki 下 PDF 页首/页尾文本会跨块并入，逐块 head/tail 指纹（align_index）必然
+    # 失配；改在归一化全语料上做子串包含，reflow 不再误报，真缺失仍能检出。
+    img_alts = [str(im.get("alt", "")) for im in dom_imgs]
+    corpus_norm = _norm_text(" ".join(dom_blocks) + " " + " ".join(img_alts))
+    corpus_tokens = set(corpus_norm.split())
+    pdf_fp_by_page = {p["page"]: p for p in pdf_index.get("pages", [])}
+
     # 整文档级信号（不依赖页对齐）：formula（KaTeX 错误）、image（断图）。
     broken_imgs = sum(1 for im in dom_imgs if not im.get("natural_width"))
     pdf_total_imgs = sum(p.get("image_count", 0) for p in pdf_index["pages"])
@@ -171,12 +267,19 @@ def _grade_pages(
     for ai in align_index:
         n = ai["pdf_page"]
         checks: dict[str, Any] = {}
-        # text：对齐即 green
+        # text：归一化 head/tail 在全 DOM 语料（含 img alt 图注）中包含即 green（抗 reflow）。
+        # align_index 的逐块指纹仍作兜底（同序命中肯定 green）。
+        pf = pdf_fp_by_page.get(n, {})
+        text_ok = (
+            _contains_distinctive(corpus_tokens, pf.get("head_fingerprint", ""))
+            or _contains_distinctive(corpus_tokens, pf.get("tail_fingerprint", ""))
+            or ai["align"] == "ok"
+        )
         checks["text"] = {
-            "status": "green" if ai["align"] == "ok" else "red",
+            "status": "green" if text_ok else "red",
             "reason": ""
-            if ai["align"] == "ok"
-            else "head/tail 指纹未在 wiki DOM 命中（内容流/顺序不一致）",
+            if text_ok
+            else "head/tail 归一化指纹未在 wiki DOM 语料中命中（内容可能缺失/乱序）",
         }
         # formula：整文档 KaTeX 错误>0 则全部页标 warn（无法定位到页）
         checks["formula"] = {

--- a/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_verify_fidelity.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_verify_fidelity.py
@@ -1,0 +1,111 @@
+"""patrol_verify_fidelity — PDF Fidelity Patrol 客观验证命令（Routine.verification_command）。
+
+被 RoutineEvaluator 的门控（``_run_gate``）在 worktree 内执行，退出码锚定 Judge 评分：
+退出码 0 = 文档经客观验证全绿（每页文本 distinctive-token 覆盖达标 + 每图资产可达 200），
+非 0 = 存在客观缺陷或环境异常。
+
+客观口径（无视觉主观）：
+1. 取生产 markdown_content（= wiki 渲染源）+ img alt 图注 → 归一化语料 token 集。
+2. 每页 PDF distinctive token（len>4）覆盖率 ≥ ``--text-thr``（默认 0.85）。
+3. 每个 figure 资产经后端 ``/knowledge/wiki/documents/{doc}/assets/{file}`` HTTP 200。
+
+CLI::
+
+    python -m negentropy.perceives.tools.patrol_verify_fidelity \\
+        --doc-id <uuid> --pdf /tmp/.../source.pdf [--backend http://127.0.0.1:3292]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+
+_TEXT_THR_DEFAULT = 0.85
+
+
+def _norm(s: str) -> str:
+    s = (s or "").lower()
+    s = re.sub(r"<img[^>]*>", " ", s)
+    s = re.sub(r"[^a-z0-9一-鿿]+", " ", s)
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _http_code(url: str, timeout: int = 5) -> int:
+    try:
+        return urllib.request.urlopen(url, timeout=timeout).getcode()
+    except Exception as e:  # noqa: BLE001 - 任意异常都转退出码
+        return getattr(e, "code", 0) or 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(prog="patrol_verify_fidelity")
+    ap.add_argument("--doc-id", required=True)
+    ap.add_argument("--pdf", required=True)
+    ap.add_argument("--backend", default="http://127.0.0.1:3292")
+    ap.add_argument("--text-thr", type=float, default=_TEXT_THR_DEFAULT)
+    args = ap.parse_args()
+
+    fails: list[str] = []
+
+    # 1) 取生产 markdown_content（wiki 忠实渲染它）
+    try:
+        with urllib.request.urlopen(
+            f"{args.backend}/knowledge/documents/{args.doc_id}", timeout=10
+        ) as r:
+            doc = json.load(r)
+        md = doc.get("markdown_content") or ""
+    except Exception as e:  # noqa: BLE001
+        print(f"FAIL: backend markdown fetch error: {e!r}")
+        return 1
+    if not md.strip():
+        print("FAIL: empty markdown_content")
+        return 1
+
+    alts = re.findall(r'<img\b[^>]*?alt=["\']([^"\']+)["\']', md, re.I)
+    cset = set(_norm(md + " " + " ".join(alts)).split())
+
+    # 2) 每页文本 distinctive-token 覆盖
+    import fitz  # PyMuPDF  # noqa: PLC0415
+
+    low: list[tuple[int, float]] = []
+    with fitz.open(args.pdf) as d:
+        n_pages = d.page_count
+        for i, pg in enumerate(d, start=1):
+            toks = {t for t in _norm(pg.get_text("text")).split() if len(t) > 4}
+            if not toks:  # 纯图页（由 image 维度覆盖）
+                continue
+            cov = len(toks & cset) / len(toks)
+            if cov < args.text_thr:
+                low.append((i, round(cov, 3)))
+    if low:
+        fails.append(f"text_cov_below_{args.text_thr}: {low}")
+
+    # 3) 每个 figure 资产后端可达 200
+    fns = sorted(
+        {
+            re.sub(r".*/", "", m)
+            for m in re.findall(r'src=["\']([^"\']*fig_p\d+_\d+\.png)["\']', md)
+        }
+    )
+    bad_imgs = [
+        fn
+        for fn in fns
+        if _http_code(
+            f"{args.backend}/knowledge/wiki/documents/{args.doc_id}/assets/{fn}"
+        )
+        != 200
+    ]
+    if bad_imgs:
+        fails.append(f"asset_not_200: {bad_imgs}")
+
+    print(f"pages={n_pages} text_thr={args.text_thr} low_cov={low}")
+    print(f"images={len(fns)} asset_not_200={bad_imgs}")
+    print(f"FAILS={fails}")
+    return 0 if not fails else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
+++ b/apps/negentropy/src/negentropy/engine/schedulers/handlers/pdf_fidelity_patrol.py
@@ -867,7 +867,13 @@ def _build_patrol_routine(
         cwd=None,  # 由 repository_id 派生 worktree cwd（单一事实源指针）
         baseline_branch=baseline_branch,
         repository_id=repo_id,
-        verification_command=None,
+        verification_command=(
+            # 客观门控（RoutineEvaluator._run_gate 在 worktree 内执行，退出码锚定 Judge 评分）：
+            # 退出码 0 = 每页文本 distinctive-token 覆盖≥阈值 + 每个 figure 资产后端可达 200。
+            f"uv run --project apps/negentropy-perceives python -m"
+            f" negentropy.perceives.tools.patrol_verify_fidelity"
+            f" --doc-id {doc_id} --pdf {source_pdf_path}"
+        ),
         status="running",
         max_iterations=settings.routine.patrol_max_iterations_per_doc,
         max_cost_usd=settings.routine.patrol_max_cost_usd_per_doc,


### PR DESCRIPTION
## 变更

pdf-fidelity-patrol 巡检程序化预筛（patrol_page_check）在 wiki 单页连续滚动渲染下两类系统性误报，且 routine 未配 verification_command 致 Judge 客观门控栏恒空。

### 0aa3020c — 预筛适配连续滚动 wiki（消除 text/image 伪缺陷）
- **text 维度**：head/tail 单块子串匹配 → 区分性 token 覆盖率（归一化 head/tail 在全 DOM 语料含 img alt 的 token 集中；短标题 3-4 token 全匹配 / 长指纹 ≥70%）。抗 reflow 与 DOM 块截断。
- **image 维度**：探针前逐段滚屏触发 `ZoomableImage loading=lazy`，屏外图加载后再判 `naturalWidth`；`_DOM_PROBE_JS` 收集 img alt 纳入语料（图注页不再失配）。
- chromium 启动自动定位（headless-shell 缺失回退完整 chromium），跨环境健壮。

### bedb0e94 — 注册客观验证命令（填补 Judge 门控空栏）
- 新增 `patrol_verify_fidelity.py`：客观口径验证文档保真——逐页 PDF distinctive-token 覆盖 ≥0.85 + 每个 figure 资产后端 HTTP 200，全过 exit 0（无视觉主观，可独立复现）。
- `_build_patrol_routine` 设 `verification_command` 为该工具（doc_id/source_pdf 注入），worktree 内执行。

## 复现（doc 4a43aba4，81 页）
- checker：text red 59→4（残 4 为稀疏 head 指纹页，全文 token 覆盖 99-100% 已证），image warn 81→green 81，formula/table/code/toc green 81。
- 验证命令：worktree 内 `uv run --project apps/negentropy-perceives python -m negentropy.perceives.tools.patrol_verify_fidelity ...` exit 0（模拟剥 VIRTUAL_ENV 的 gate 环境复验）。

## 非回归
- ruff format/lint/mypy 全过；perceives `test_fidelity_render` 3 测过；`_build_patrol_routine` 直接调用构造正确（verification_command 设且 doc_id 注入，status/success_score_threshold 不变）。
- 后端 pytest 被既有 alembic/测试库 infra（test-db-alembic-version-drift）阻断 session fixture，非本次改动（未触迁移）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)