### PR TITLE
skill(pdf-fidelity-restore): 沉淀 inner-loop staging 图片 serving carve-out 洞察

### DIFF
--- a/.agent/skills/pdf-fidelity-restore/SKILL.md
+++ b/.agent/skills/pdf-fidelity-restore/SKILL.md
@@ -67,12 +67,14 @@ Markdown，并通过浏览器逐页对比将差异修复至完全一致。
 - **三套渲染栈系统性差异**：旧 `_fidelity_render`（Python-Markdown 近似）/ wiki（react-markdown + remark/rehype）/ ui（另一套 react-markdown + sanitize）三栈不同——公式/Mermaid/figure/figcaption/图片尺寸/代码高亮会假阳性/假阴性。对照须用**真实 wiki 渲染栈**（巡检经 `patrol_wiki_env` 起 `next dev` 真页截图，非模拟渲染）。
 - **全绿率评分口径**：`score = round(pass_pages/total_pages×100)`（逐页校验清单全绿率），替代主观「100-Σ扣分」——CC 自评与 Judge 复核锁同一份程序化预筛 + defects，根治 ±20 振荡（ISSUE-128）。
 - **双源验证防误归因**：渲染层缺陷（候选 MD 正确、渲染器渲染错）会被误归到 perceives；归因前必走「候选 MD 源码层 vs 渲染层」双源决策树（见步骤 7）。
+- **inner-loop staging wiki 不 bake/serve 图片（V1 工具链限制，process 层 carve-out）**：`patrol_wiki_env publish-candidate` 仅写 entry Markdown、不烘焙资产；staging dev server（主仓 `negentropy-wiki`，`public/assets/` 无文档资产）对候选 MD 的 `./images/...` 相对引用返回 500/断图，`patrol_page_check` 报 `dom_broken_images=N`（且 Next SPA 对未匹配路由回退 200 HTML，curl 状态码会骗人，须看 content-type/PNG 头）。此为 **staging 工具链 V1 限制，非文档/渲染缺陷**——图资产本身忠实（全分辨率 PNG 落盘 `/.../images/`），生产经 `WikiExportService.export_single_entry(bake=True)` 烘焙到 `public/assets/{doc}/` 后由 ZoomableImage 正常渲染。**inner loop 见全图断 → 记 process carve-out（不扣分、不逐图排查）；图片保真改由 (a) 直接核对落盘 PNG 资产尺寸/完整性 或 (b) Real-Render Gate bake 后截图二选一坐实。**
 
 ## 反模式（严禁）
 
 - 跳过逐页核对即声明完成；
 - 只比文字而忽略图 / 表 / 公式 / 代码 / 注释；
-- 图片不还原原始显示尺寸（宽高）。
+- 图片不还原原始显示尺寸（宽高）；
+- 在 inner loop 对「全图断」（staging serving V1 限制）逐图排查或误归到 pipeline/render——context 耗尽根因；先认 staging carve-out，图片保真走资产直查或 Gate。
 
 ## 完成判据
 

--- a/apps/negentropy/src/negentropy/agents/skill_templates/pdf_fidelity_restore.yaml
+++ b/apps/negentropy/src/negentropy/agents/skill_templates/pdf_fidelity_restore.yaml
@@ -81,11 +81,13 @@ prompt_template: |
   - **三套渲染栈系统性差异**：旧 `_fidelity_render`（Python-Markdown 近似）/ wiki（react-markdown + remark/rehype）/ ui（另一套 react-markdown + sanitize）三栈不同——公式/Mermaid/figure/figcaption/图片尺寸/代码高亮会假阳性/假阴性。对照须用**真实 wiki 渲染栈**（巡检经 `patrol_wiki_env` 起 `next dev` 真页截图，非模拟渲染）。
   - **全绿率评分口径**：`score = round(pass_pages/total_pages×100)`（逐页校验清单全绿率），替代主观「100-Σ扣分」——CC 自评与 Judge 复核锁同一份程序化预筛 + defects，根治 ±20 振荡（ISSUE-128）。
   - **双源验证防误归因**：渲染层缺陷（候选 MD 正确、渲染器渲染错）会被误归到 perceives；归因前必走「候选 MD 源码层 vs 渲染层」双源决策树（见步骤 7）。
+  - **inner-loop staging wiki 不 bake/serve 图片（V1 工具链限制，process 层 carve-out）**：``patrol_wiki_env publish-candidate`` 仅写 entry Markdown、不烘焙资产；staging dev server（主仓 ``negentropy-wiki``，``public/assets/`` 无文档资产）对候选 MD 的 ``./images/...`` 相对引用返回 500/断图，``patrol_page_check`` 报 ``dom_broken_images=N``（且 Next SPA 对未匹配路由回退 200 HTML，curl 状态码会骗人，须看 content-type/PNG 头）。此为 **staging 工具链 V1 限制，非文档/渲染缺陷**——图资产本身忠实（全分辨率 PNG 落盘 ``/.../images/``），生产经 ``WikiExportService.export_single_entry(bake=True)`` 烘焙到 ``public/assets/{doc}/`` 后由 ZoomableImage 正常渲染。**inner loop 见全图断 → 记 process carve-out（不扣分、不逐图排查）；图片保真改由 (a) 直接核对落盘 PNG 资产尺寸/完整性 或 (b) Real-Render Gate bake 后截图二选一坐实。**
 
   ## 反模式（严禁）
   - 跳过逐页核对即声明完成；
   - 只比文字而忽略图 / 表 / 公式 / 代码 / 注释；
-  - 图片不还原原始显示尺寸（宽高）。
+  - 图片不还原原始显示尺寸（宽高）；
+  - 在 inner loop 对「全图断」（staging serving V1 限制）逐图排查或误归到 pipeline/render——context 耗尽根因；先认 staging carve-out，图片保真走资产直查或 Gate。
 
   ## 完成判据
   逐页校验清单全绿 + 关键页对比截图留证 + 整本 PDF 在 Documents 页可读性与一致性达最佳。


### PR DESCRIPTION
## 变更
对 pdf-fidelity-restore Skill 做 SSOT 双写（`SKILL.md` + `skill_templates/pdf_fidelity_restore.yaml`），各补 1 条关键洞察 + 1 条反模式（共 +6/-2，仅 yaml/md）：

- **洞察**：inner-loop staging wiki（`patrol_wiki_env publish-candidate`）按 V1 设计不 bake/serve 图片资产——候选 MD 的 `./images/...` 相对引用在 staging dev server（主仓 `negentropy-wiki`，`public/assets/` 无文档资产）下返回 500/断图，`patrol_page_check` 报 `dom_broken_images=N`（Next SPA 对未匹配路由回退 200 HTML，curl 状态码会骗人）。此为 staging 工具链 V1 限制（process 层 carve-out），非文档/渲染缺陷——图资产忠实，生产经 `WikiExportService.export_single_entry(bake=True)` 烘焙后由 ZoomableImage 正常渲染。inner loop 见全图断应记 process carve-out（不扣分、不逐图排查），图片保真走落盘 PNG 资产直查或 Real-Render Gate。
- **反模式**：在 inner loop 对「全图断」（staging serving V1 限制）逐图排查或误归到 pipeline/render——context 耗尽根因。

## 动机
routine `pdf-fidelity-patrol`（doc=666ea2ee *Self-Harness*，19 页单栏论文）巡检中，inner-loop staging 全图断（dom_broken_images=12）一度被深度调查，消耗大量 context。该洞察缺失是 context 耗尽的根因；SSOT 双写以防后续迭代/其他文档重蹈。文档本身经评估全绿率 100%（公式碎片化缺陷已于候选层定点修复并经真实 wiki SSR katex 验证；p1-3 text-red 为 checker 页码/页脚 fingerprint artifact，已 carve-out）。

## 验证
- 改动仅 yaml/md（4 行），ruff（Python-only）0 新增；903+ lint errors 为 baseline 既存项目债（非本 PR 引入）。
- pre-commit 提交时通过（`check yaml...Passed`、`ruff...Skipped`）；`yaml.safe_load` OK，SSOT 双写骨架一致（grep 校验）。
- pytest：`test_skill_templates.py` 失败于 alembic `No 'script_location' key`（测试 DB 基建，在加载本 yaml 前崩），属 pre-existing 基建问题（参见 issue 记忆 test-db-alembic-version-drift-blocks-tests），与本 yaml 改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)