### PR TITLE
fix(patrol): 巡检 harness 补全图片 bake 与文本保真判定,消除四类检测假缺陷

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/tools/_fidelity_render.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/tools/_fidelity_render.py
@@ -95,8 +95,13 @@ def render_pdf_page_index(
     - 用于 ``patrol_page_check`` 程序化预筛（零 context 成本），不替代视觉判定。
     """
     import fitz  # PyMuPDF  # noqa: PLC0415
+    from collections import Counter  # noqa: PLC0415
 
-    pages: list[dict[str, Any]] = []
+    page_blocks: list[list[str]] = []  # 每页文本块指纹序列
+    page_full_texts: list[str] = []  # 每页完整正文（token 覆盖率判定用）
+    page_meta: list[
+        tuple[int, int, int]
+    ] = []  # (image_count, table_count, text_block_count)
     with fitz.open(str(pdf_path)) as doc:
         page_count = doc.page_count
         toc = doc.get_toc(simple=True)  # [[level, title, page], ...]
@@ -107,16 +112,11 @@ def render_pdf_page_index(
             text_blocks = [
                 b for b in raw_blocks if len(b) > 6 and b[6] == 0 and str(b[4]).strip()
             ]
-            head = (
-                _fingerprint(str(text_blocks[0][4]), n=fingerprint_chars)
-                if text_blocks
-                else ""
+            page_blocks.append(
+                [_fingerprint(str(b[4]), n=fingerprint_chars) for b in text_blocks]
             )
-            tail = (
-                _fingerprint(str(text_blocks[-1][4]), n=fingerprint_chars)
-                if text_blocks
-                else ""
-            )
+            # 每页完整正文（未截断）：供 patrol_page_check 做 token 覆盖率判定。
+            page_full_texts.append(" ".join(str(b[4]) for b in text_blocks))
             image_count = len(page.get_images(full=True))
             table_count = 0
             try:
@@ -124,16 +124,39 @@ def render_pdf_page_index(
                 table_count = len(tabs.tables) if tabs is not None else 0
             except Exception:  # noqa: BLE001 - 老版本 PyMuPDF 无 find_tables，降级 0
                 table_count = 0
-            pages.append(
-                {
-                    "page": i,
-                    "head_fingerprint": head,
-                    "tail_fingerprint": tail,
-                    "image_count": image_count,
-                    "table_count": table_count,
-                    "text_block_count": len(text_blocks),
-                }
-            )
+            page_meta.append((image_count, table_count, len(text_blocks)))
+
+    # 检测 running header / footer：在 >40% 页重复出现的首/末文本块（页眉页脚家具）。
+    # 这类块在 wiki DOM 中不重复（管线正确剥离），须从内容对齐中剔除，避免系统性失配。
+    def _repeated(seq: list[str], threshold: float = 0.4) -> str:
+        if not seq:
+            return ""
+        value, count = Counter(seq).most_common(1)[0]
+        return value if count / len(seq) > threshold else ""
+
+    header = _repeated([b[0] for b in page_blocks if b])
+    footer = _repeated([b[-1] for b in page_blocks if b])
+
+    pages: list[dict[str, Any]] = []
+    for i, blocks in enumerate(page_blocks, start=1):
+        # 剔除页眉页脚家具后的内容块指纹列表（供 patrol_page_check 做「内容覆盖率」判定，
+        # 而非依赖块顺序对齐——双栏 PDF 的视觉块序 ≠ 单栏化 DOM 线性序，顺序对齐必假阳性）。
+        content = [x for x in blocks if x and x not in (header, footer)]
+        head = content[0] if content else ""
+        tail = content[-1] if content else ""
+        image_count, table_count, tbc = page_meta[i - 1]
+        pages.append(
+            {
+                "page": i,
+                "head_fingerprint": head,
+                "tail_fingerprint": tail,
+                "block_fingerprints": content,
+                "full_text": page_full_texts[i - 1],
+                "image_count": image_count,
+                "table_count": table_count,
+                "text_block_count": tbc,
+            }
+        )
     return {"page_count": page_count, "toc": toc, "pages": pages}
 
 

--- a/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
@@ -189,12 +189,19 @@ def _grade_pages(
     import re as _re  # noqa: PLC0415
 
     def _tokens(text: str) -> list[str]:
-        # 提取字母数字词（含 CJK），小写；过滤 1 字符噪声与纯页码点线。
-        return [
-            t
-            for t in _re.findall(r"[0-9a-zA-Z一-鿿]+", (text or "").lower())
-            if len(t) >= 2
-        ]
+        # 提取字母数字词（含 CJK），小写；过滤 1 字符噪声。在字母↔数字边界切分
+        # （PDF 把上标引用/编号粘连成 "Fu¹"→"fu1"，DOM 分词为 "fu"+"1"），避免把
+        # 「作者名+上标」等表示差异误判为内容缺失——纯分词正确性,非针对性放宽。
+        raw = _re.findall(r"[0-9a-zA-Z一-鿿]+", (text or "").lower())
+        out: list[str] = []
+        for w in raw:
+            parts = (
+                _re.findall(r"[a-z一-鿿]+|[0-9]+", w)
+                if _re.search(r"[a-z一-鿿][0-9]|[0-9][a-z一-鿿]", w)
+                else [w]
+            )
+            out.extend(p for p in parts if len(p) >= 2)
+        return out
 
     # DOM 全文 token 集合：优先用 innerText（含行内 code/公式/链接、按视觉顺序），
     # 回退分块拼接。另备去分隔符长串，兜底 PDF 跨行连字符断词（如 execu-tion → executiON）。

--- a/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_page_check.py
@@ -70,7 +70,10 @@ _DOM_PROBE_JS = """
   const headings = Array.from(root.querySelectorAll('h1, h2, h3, h4')).map(h => norm(h.textContent));
   // KaTeX 渲染错误标记（rehype-katex 失败时残留 class）
   const katexErrors = root.querySelectorAll('.katex-error, .katex-invalid, .katex-parse-error').length;
-  return { blocks, tables, tableCells, imgs, codeBlocks, headings, katexErrors };
+  // 整页可见文本（innerText 含行内 code/公式/链接，且按视觉顺序拼接）——供 token 覆盖率判定，
+  // 比分块 textContent 拼接更完整（不漏行内元素、不割裂）。
+  const pageText = root.innerText || '';
+  return { blocks, tables, tableCells, imgs, codeBlocks, headings, katexErrors, pageText };
 }
 """
 
@@ -95,6 +98,18 @@ async def _probe_wiki_dom(
             # 用 contextlib.suppress 代替 try/except: pass，规避 bandit B110（CWE-703）。
             with contextlib.suppress(Exception):
                 await page.wait_for_load_state("networkidle", timeout=8000)
+            # 触发懒加载图片（loading="lazy"）：逐张滚入视口后等其解码完成，避免把
+            # 「视口外未加载的懒加载图」误判为断图（naturalWidth=0 假阳性）。超时不阻断
+            # ——真断图 naturalWidth 恒 0，仍会被下方探针正确识别为 broken。
+            with contextlib.suppress(Exception):
+                await page.evaluate(
+                    "() => { for (const i of document.querySelectorAll('img')) i.scrollIntoView(); }"
+                )
+                await page.wait_for_function(
+                    "() => Array.from(document.querySelectorAll('img'))"
+                    ".every(i => i.complete && i.naturalWidth > 0)",
+                    timeout=8000,
+                )
             dom = await page.evaluate(_DOM_PROBE_JS)
             return dom
         finally:
@@ -167,17 +182,56 @@ def _grade_pages(
     dom_total_imgs = len(dom_imgs)
     pdf_total_tables = sum(p.get("table_count", 0) for p in pdf_index["pages"])
 
+    # text 维度：改用「token 覆盖率」而非「块顺序对齐」。双栏学术 PDF 的视觉块顺序 ≠
+    # 单栏化 DOM 线性顺序，且 PDF get_text("blocks") 块粒度 ≠ DOM 段落粒度、块内含软换行/
+    # 连字符/目录点线，精确子串对齐必假阳性。正确口径是「该页的实词是否都出现在 DOM 中」
+    # ——对语序、分块、换行不敏感，直接度量「内容是否缺失」。
+    import re as _re  # noqa: PLC0415
+
+    def _tokens(text: str) -> list[str]:
+        # 提取字母数字词（含 CJK），小写；过滤 1 字符噪声与纯页码点线。
+        return [
+            t
+            for t in _re.findall(r"[0-9a-zA-Z一-鿿]+", (text or "").lower())
+            if len(t) >= 2
+        ]
+
+    # DOM 全文 token 集合：优先用 innerText（含行内 code/公式/链接、按视觉顺序），
+    # 回退分块拼接。另备去分隔符长串，兜底 PDF 跨行连字符断词（如 execu-tion → executiON）。
+    dom_page_text = dom.get("pageText") or " ".join(dom_blocks)
+    dom_token_set = set(_tokens(dom_page_text))
+    dom_collapsed = "".join(_tokens(dom_page_text))  # 无分隔连续串，兜底断词
+    pdf_pages = {p["page"]: p for p in pdf_index["pages"]}
+
+    def _text_coverage(page_meta: dict[str, Any]) -> tuple[str, str]:
+        """该页实词在 DOM 的覆盖率 ≥0.9 green，≥0.75 warn，否则 red（含断词兜底）。"""
+        page_text = page_meta.get("full_text") or " ".join(
+            page_meta.get("block_fingerprints", [])
+        )
+        uniq = set(_tokens(page_text))
+        if len(uniq) < 5:
+            return "green", "本页文本极少（纯图表/分隔页）"
+
+        # 命中：token 在 DOM token 集合，或（长度≥4 的词）作为子串出现在去分隔连续串中
+        # ——后者吸收连字符断词与 PDF/DOM 分词差异，避免把表示差异误判为内容缺失。
+        def _hit(t: str) -> bool:
+            return t in dom_token_set or (len(t) >= 4 and t in dom_collapsed)
+
+        hit = sum(1 for t in uniq if _hit(t))
+        cov = hit / len(uniq)
+        if cov >= 0.9:
+            return "green", ""
+        if cov >= 0.75:
+            return "warn", f"词覆盖率 {cov:.0%}（{hit}/{len(uniq)}）"
+        return "red", f"词覆盖率仅 {cov:.0%}（{hit}/{len(uniq)}），疑内容缺失"
+
     page_checks: list[dict[str, Any]] = []
     for ai in align_index:
         n = ai["pdf_page"]
         checks: dict[str, Any] = {}
-        # text：对齐即 green
-        checks["text"] = {
-            "status": "green" if ai["align"] == "ok" else "red",
-            "reason": ""
-            if ai["align"] == "ok"
-            else "head/tail 指纹未在 wiki DOM 命中（内容流/顺序不一致）",
-        }
+        # text：内容覆盖率判定（不依赖块顺序对齐）。
+        t_status, t_reason = _text_coverage(pdf_pages.get(n, {}))
+        checks["text"] = {"status": t_status, "reason": t_reason}
         # formula：整文档 KaTeX 错误>0 则全部页标 warn（无法定位到页）
         checks["formula"] = {
             "status": "warn" if dom_katex_err > 0 else "green",

--- a/apps/negentropy/src/negentropy/engine/routine/patrol_wiki_env.py
+++ b/apps/negentropy/src/negentropy/engine/routine/patrol_wiki_env.py
@@ -29,8 +29,11 @@ negentropy.engine.routine.patrol_wiki_env <cmd>`` 调用）：
 
 from __future__ import annotations
 
+import base64
 import json
+import mimetypes
 import os
+import re
 import socket
 import subprocess
 import sys
@@ -190,6 +193,56 @@ def write_entry_content(
     target = entries_dir / f"{PATROL_ENTRY_ID}.json"
     _atomic_write_json(target, payload)
     return target
+
+
+# ---------------------------------------------------------------------------
+# 图片资产 bake（staging 专属：相对路径 → 可解析 URL）
+# ---------------------------------------------------------------------------
+#
+# V1 限制拟合补全：候选 Markdown 内 ``<img src="./images/...">`` 相对引用在 wiki dev
+# 源下 404（content_root 不含候选兄弟 images/ 目录，且无后端 ``/api/.../assets``）。
+# publish 时把相对图引用重写为 wiki 渲染栈可解析的形式，保留 width/height/style。
+#
+# 两种 bake 模式（按是否提供 ``url_base`` 选择）：
+# - **http 模式**（``url_base`` 给定，推荐）：重写为 ``{url_base}/<相对路径>``，由巡检
+#   harness 起的本地静态服务（serve 候选兄弟 images/）供出。兼容 wiki 默认 sanitize
+#   （放行 http/https），无需改渲染层。
+# - **data 模式**（``url_base`` 缺省）：就地编码为 ``data:image/*;base64,...``，自包含、
+#   无需静态服务，但需渲染层 sanitize 放行 ``data:`` 协议。
+# 绝对 URL / 已有 data URI / 缺文件者原样保留（缺文件者仅仍 404，不致崩渲染）。
+
+_IMG_SRC_RE = re.compile(r'(<img\b[^>]*?\bsrc=")([^"]+)(")', re.IGNORECASE)
+_MD_IMG_RE = re.compile(r"(!\[[^\]]*\]\()([^)]+)(\))")
+
+
+def bake_relative_images(markdown: str, base_dir: Path, url_base: str | None = None) -> str:
+    """把 Markdown 中相对路径图片引用重写为 wiki 渲染栈可解析的 URL。
+
+    覆盖 ``<img src="...">`` 与 ``![alt](...)`` 两种语法。``url_base`` 给定走 http 模式
+    （重写为 ``{url_base}/<相对路径>``）；否则走 data 模式（base64 编码）。
+    """
+    abs_root = base_dir.resolve()
+    base = url_base.rstrip("/") if url_base else None
+
+    def _bake(src: str) -> str:
+        if src.startswith(("http://", "https://", "data:", "//", "mailto:", "#")):
+            return src
+        if base is not None:
+            # http 模式：拼接到 harness 静态服务 base（去掉前导 ./）。
+            return f"{base}/{src.removeprefix('./')}"
+        # data 模式：就地 base64 编码。
+        img_path = (abs_root / src).resolve()
+        try:
+            data = img_path.read_bytes()
+        except OSError:
+            return src
+        mime = mimetypes.guess_type(str(img_path))[0] or "image/png"
+        return f"data:{mime};base64,{base64.b64encode(data).decode('ascii')}"
+
+    def _repl(m: re.Match) -> str:
+        return f"{m.group(1)}{_bake(m.group(2))}{m.group(3)}"
+
+    return _MD_IMG_RE.sub(_repl, _IMG_SRC_RE.sub(_repl, markdown))
 
 
 # ---------------------------------------------------------------------------
@@ -361,6 +414,12 @@ def _cli() -> int:
     p_pub.add_argument("--doc-id", required=True)
     p_pub.add_argument("--title", default="")
     p_pub.add_argument("--filename", default="")
+    p_pub.add_argument(
+        "--asset-url-base",
+        default="",
+        help="图片 bake 的 http 静态服务 base（如 http://127.0.0.1:64300）；"
+        "给定则相对图引用重写为 http URL，否则走 base64 data URI",
+    )
 
     p_wait = sub.add_parser("wait-ready", help="阻塞至 wiki dev server 可服务（截图前调）")
     p_wait.add_argument("--port", type=int, required=True)
@@ -370,7 +429,10 @@ def _cli() -> int:
 
     if args.cmd == "publish-candidate":
         content_root = Path(args.content_root)
-        markdown = Path(args.markdown_file).read_text(encoding="utf-8")
+        md_path = Path(args.markdown_file)
+        markdown = md_path.read_text(encoding="utf-8")
+        # staging 图片 bake：相对路径 → 可解析 URL（见 bake_relative_images 注释）。
+        markdown = bake_relative_images(markdown, md_path.parent, url_base=args.asset_url_base or None)
         target = write_entry_content(
             content_root,
             markdown=markdown,


### PR DESCRIPTION
## 背景

PDF 保真巡检对生产文档《Self-Improving Agents in the Era of Experience: A Survey of Self-to Meta-Evolution》（88 页双栏学术综述）执行时，staging 巡检 harness 暴露**检测精度缺口**，致文档被系统性误判（program 预筛 green=0，但视觉截图证实文档本身保真）。本 PR 补全四处 harness 检测逻辑（均为 **process 杠杆 / 巡检工具本体**，不触 pipeline/render 生产链），使程序化预筛与真实视觉保真一致。

## 变更（4 类修复，2 commit）

**① 图片资产 bake**（`patrol_wiki_env.py`）
候选 MD 相对图引用 `./images/...` 在 wiki dev 源下无路由 → 11 张图全 404。`publish-candidate` 新增 `bake_relative_images`：http 模式（`--asset-url-base` 重写为本地静态服务 URL，兼容 wiki 默认 sanitize）+ data 模式（base64 回退），保留 width/height/style。`dom_broken_images 11→0`。

**② 懒加载误判**（`patrol_page_check.py`）
图片 `loading="lazy"`，探针探 `naturalWidth` 时视口外图未加载被误记断图。`_probe_wiki_dom` 探测前先 `scrollIntoView` 触发懒加载并 `wait_for_function` 等解码（超时不阻断——真断图仍 `naturalWidth=0` 被检出）。消除 8 张懒加载假阳性。

**③ 文本指纹假阳性**（`_fidelity_render.py` + `patrol_page_check.py`）
head/tail 块顺序对齐对双栏 PDF 系统性失配（视觉块序 ≠ 单栏化 DOM 线性序）。改用 **token 覆盖率**：`render_pdf_page_index` 剥离 running header/footer 家具 + 输出 `full_text`，`patrol_page_check` 用 DOM `innerText` 全文 token 集合 + 连字符断词兜底判定覆盖率。`text red 53→0`。

**④ 上标粘连分词**（`patrol_page_check._tokens`）
PDF 作者姓+上标引用数字粘连（`Fu¹`→`fu1`），DOM 分词为 `fu`+`1`，致 p1 标题页覆盖率停在 90%。tokenizer 在字母↔数字边界切分（学术 PDF 上标/编号普遍），p1 warn→green。负向测试确认纯词不变、真缺失仍判 red。

## 验证

- **地面真值**：wiki 真实渲染栈（`next dev` :64242）逐页程序化预筛 → **88/88 全维度 green（text/image/formula/table/toc）**，`vision_required` 为空，`score=100`。
- **视觉证据**：5 个原 red 页（p1/p13/p32/p39/p64）截图对照，内容完整。
- **Real-Render Gate**：刷新 http-bake 重发 + :64242 复跑确认地面真值稳定。
- **非回归**：`test_fidelity_render` 3/3 通过；`render_pdf_page_index` 向后兼容（旧字段保留）；bake 三模式（http/data/绝对URL）自测通过；tokenizer 负向测试（真缺失仍判 red，未掩盖缺陷）；pre-commit（ruff/mypy）全绿。

## 影响面

四处均 **process 杠杆**（巡检工具本体：`patrol_page_check.py` / `_fidelity_render.py` / `patrol_wiki_env.py`），跨 doc 通用（所有 PDF 巡检受益），**不改动 pipeline 提取 / render 渲染 / ingest 摄取 / export 导出生产链**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)