### PR TITLE
fix(patrol): 抢救 #1084 的 dev 静态资源路由与标题检测两处独立修复

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -693,9 +693,24 @@ class FitzTextExtractor(PDFToolBase):
             # 11. 不定式列表起首（``To identify, classify, and ...``）
             if re.match(r"^To\s+[a-z]+,\s+\w+,", section_title):
                 return None
-            # 12. 多逗号子句（≥ 2 个 ``, ``）且长度 > 60 —— 句子型正文
+            # 12. 多逗号子句（≥ 2 个 ``, ``）且长度 > 60 —— 句子型正文；
+            #     豁免「标题: 枚举副标题」型合法 heading（综述论文常见，如
+            #     "Harness Interface: Code for Reasoning, Acting, and Environment
+            #     Modeling"）。冒号后 ≥2 个 Title Case 起首的逗号项是 heading 强
+            #     信号；句子型副标题（"the model improves, reduces, ..."）小写起首，
+            #     不满足该指纹，仍按正文丢弃，避免回归。
             if section_title.count(", ") >= 2 and len(section_title) > 60:
-                return None
+                after_colon = (
+                    section_title.split(":", 1)[1].strip()
+                    if ":" in section_title
+                    else ""
+                )
+                items = [it.strip() for it in after_colon.split(",") if it.strip()]
+                is_enum_subtitle = ":" in section_title and (
+                    sum(1 for it in items if re.match(r"[A-Z]", it)) >= 2
+                )
+                if not is_enum_subtitle:
+                    return None
 
             # R10-D25：list-item label + 句子型 body 折叠到同一文本块的剩余信号。
             # 典型产物 ``Paradigm specialization by domain High-stakes, regulated``

--- a/apps/negentropy-wiki/next.config.ts
+++ b/apps/negentropy-wiki/next.config.ts
@@ -50,8 +50,15 @@ function stableBuildId(): string {
   }
 }
 
+// `output: "export"` 仅生产构建（next build / 静态导出）需要；dev（next dev）下保留
+// 它会强制 SSG 路由严格化（generateStaticParams 须枚举所有 param），致 dev server 把
+// public/ 静态文件请求（如 /assets/{doc}/{file}）误派给 catch-all 路由并 500（PDF
+// Fidelity Patrol inner-loop 图片渲染即受此害）。dev 下不设 output，public/ 走 next 原生
+// 静态服务即可靠；生产构建 NODE_ENV=production 不变，静态导出行为零变化。
+const isStaticExport = process.env.NODE_ENV === "production";
+
 const nextConfig: NextConfig = {
-  output: "export",
+  ...(isStaticExport ? { output: "export" as const } : {}),
   trailingSlash: true,
   // 不设 outputFileTracingRoot：曾尝试收敛到 wiki 包根（process.cwd()），但 CI 的 pnpm
   // hoisting 把 next 提升至 monorepo 根 node_modules，收缩 Turbopack 边界后从 src/app

--- a/apps/negentropy-wiki/tests/unit/config/next-config.test.ts
+++ b/apps/negentropy-wiki/tests/unit/config/next-config.test.ts
@@ -1,10 +1,33 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import nextConfig from "../../../next.config";
 
-describe("next.config（纯静态导出）", () => {
-  it("使用 export 输出以支撑独立静态部署（无 Node 运行时）", () => {
-    expect(nextConfig.output).toBe("export");
+// next.config 在模块加载时读取 process.env.NODE_ENV 决定是否静态导出：
+// 仅生产（production）设 `output: "export"`；dev/test 不设，以免 SSG 路由严格化把
+// public/ 静态资源（如 /assets/{doc}/{file}）误派给 catch-all 路由并 500。
+// 故用「重置模块缓存 + 覆写 NODE_ENV + 动态导入」分别验证生产与非生产两条分支。
+async function loadConfigWithEnv(nodeEnv: string) {
+  const env = process.env as Record<string, string | undefined>;
+  const prev = env.NODE_ENV;
+  vi.resetModules();
+  env.NODE_ENV = nodeEnv;
+  try {
+    return (await import("../../../next.config")).default;
+  } finally {
+    if (prev === undefined) delete env.NODE_ENV;
+    else env.NODE_ENV = prev;
+  }
+}
+
+describe("next.config（生产静态导出 / dev 非导出）", () => {
+  it("生产构建启用 export 输出以支撑独立静态部署（无 Node 运行时）", async () => {
+    const cfg = await loadConfigWithEnv("production");
+    expect(cfg.output).toBe("export");
+  });
+
+  it("dev（非生产）不设 output:export，避免 SSG 路由严格化把 public 静态资源误派 catch-all 路由并 500", async () => {
+    const cfg = await loadConfigWithEnv("development");
+    expect(cfg.output).toBeUndefined();
   });
 
   it("启用 trailingSlash，为 catch-all 路由产出目录式 HTML，对静态托管友好", () => {


### PR DESCRIPTION
## 背景

PR #1084 的核心机制（`_bake_patrol_assets` **hard-bake**：把候选图片拷贝到 `public/assets/{doc}/`）已被基线取代：

- **#1086** 重写了同一套 patrol checker 逻辑；
- **#1085** 将「图片 serving V1 carve-out」决策沉淀为 SKILL，确立 `bake_relative_images` **soft-bake**（http URL / base64 重写）为既定方向。

因此 #1084 已关闭为「已被取代」。本 PR 从中**抢救两处与 hard-bake 正交、干净且仍有价值**的修复。

## 变更

1. **`apps/negentropy-wiki/next.config.ts`** — `output: "export"` 改为仅 `NODE_ENV=production` 时设置。
   dev（`next dev`）下保留它会强制 SSG 路由严格化，致 dev server 把 `public/` 静态文件请求（如 `/assets/{doc}/{file}`）误派给 catch-all 路由并 500。**生产静态导出行为零变化。**

2. **`apps/negentropy-perceives/.../pdf/text_extraction.py`** — `FitzTextExtractor._detect_heading` 滤子 #12 新增「冒号 + ≥2 Title Case 枚举副标题」豁免。
   放行综述论文编号枚举型 h2 标题（如 `"...Interface: Code for Reasoning, Acting, and Environment Modeling"`），原被误判为句子型正文丢弃；句子型副标题（小写起首）仍按正文丢弃，无回归。

## 验证

- perceives `ruff check` / `ruff format --check` / `mypy`：全过。
- `pytest tests/unit -k "head or detect_heading or heading"`：**106 passed, 1 skipped**（含多逗号 / 复合标题分类用例，无回归）。
- next lint（wiki）：Passed。

## 说明

本 PR 触及 `apps/negentropy-perceives/**`，会触发 Perceives CI；在 CI 修复 PR #1087（soupsieve 2.8.4）合入基线前，其 *pip-audit* 安全审计会短暂标红（继承基线现存问题，非本 PR 引入）。合入 #1087 后点「Update branch」即转绿。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)