### PR TITLE
feat(agents): 六翼单例收敛——tools 运行时回源 + 后台 LLM 经 Faculty 产出;

### DIFF
--- a/apps/negentropy/src/negentropy/agents/_dynamic_tools.py
+++ b/apps/negentropy/src/negentropy/agents/_dynamic_tools.py
@@ -1,0 +1,141 @@
+"""
+动态工具集 — 运行时按 ``agents.tools`` 解析六翼工具集（WS1 tools 单一事实源）。
+
+与 ``_dynamic_instruction`` / ``_dynamic_model`` 同构（三者共用 ``subagent:<name>`` 60s TTL
+缓存行，Agent PATCH 触发 ``invalidate_cache(prefix="subagent:")`` 一并失效）：
+
+- ADK ``LlmAgent.tools`` 接受 ``BaseToolset``；``flows/llm_flows/base_llm_flow`` 每个
+  invocation 用 ``ReadonlyContext`` 调 ``agent.canonical_tools`` → ``NegentropyToolset.get_tools``
+  （``canonical_tools_cache`` 仅在单次 invocation 内缓存），故 UI 编辑 ``agents.tools`` 后经缓存
+  失效、**下一轮请求即生效**，无需重建单例 faculty 实例。
+- DB 不可达 / 未启用 / 为空 / 异常 → 回退构造期 ``default_names``（= 代码硬编码可摘工具集），
+  保持「永不阻塞请求」语义（与 instruction fallback 同构）。
+- ``allowed_names`` 白名单：仅该翼被许可的工具名可经 DB 挂载，越权 / 未知名丢弃 + warn，防止
+  UI 把高危工具（如 ``invoke_claude_code``）跨翼挂到只读翼（慧眼）。ADK 层无翼隔离，此白名单
+  是 WS1 的关键安全增量。
+- ``mandatory_names``：恒常挂载工具（如 ``log_activity`` / ``load_memory``）已在工厂 ``tools=[]``
+  常量位以裸 callable 挂载，本 toolset 从产出中剔除，避免重复声明（即便 DB 误列亦然）。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from google.adk.tools import FunctionTool
+from google.adk.tools.base_tool import BaseTool
+from google.adk.tools.base_toolset import BaseToolset
+
+from negentropy.logging import get_logger
+
+from .tools.registry import canonicalize_tool_name, resolve_tool_names
+
+if TYPE_CHECKING:
+    from google.adk.agents.readonly_context import ReadonlyContext
+
+_logger = get_logger("negentropy.agents.dynamic_tools")
+
+
+class NegentropyToolset(BaseToolset):
+    """按 ``agents.tools`` 运行时解析某个 faculty 的「可摘」工具集。
+
+    Args:
+        agent_name: ``agents.name``，用于 DB 查询；与 ADK ``Agent.name`` 一致。
+        default_names: DB 未命中 / 为空 / 异常时回退的可摘工具名列表（= 代码硬编码集）。
+        mandatory_names: 恒常挂载工具名（已在工厂常量位挂载）；本 toolset 从产出中剔除。
+        allowed_names: 该翼被许可经 DB 挂载的工具名上界；越界名丢弃 + warn。
+            ``None``（默认）→ 取 ``mandatory + default``（= 当前硬编码集）：UI 只能「摘除」
+            既有工具、不能跨翼新增高危工具（保守安全默认）。未来若要放开某翼可挂的工具面，
+            显式传入更宽的 ``allowed_names`` 即可。
+    """
+
+    def __init__(
+        self,
+        *,
+        agent_name: str,
+        default_names: list[str],
+        mandatory_names: list[str],
+        allowed_names: list[str] | None = None,
+    ) -> None:
+        super().__init__()
+        self._agent_name = agent_name
+        self._default_names = list(default_names)
+        self._mandatory_names = list(mandatory_names)
+        self._mandatory_set = set(mandatory_names)
+        self._allowed_set = set(allowed_names) if allowed_names is not None else {*mandatory_names, *default_names}
+
+    def configured_tool_names(self) -> list[str]:
+        """序列化用：该翼「恒常 + 默认可摘」工具名（保序去重）。
+
+        供 ``interface/agent_presets.serialize_adk_config`` 把 toolset 展开为稳定的工具名数组，
+        作为 sync 落库 ``agents.tools`` 的初值，避免 ``NegentropyToolset`` 类名污染。
+        """
+        seen: set[str] = set()
+        ordered: list[str] = []
+        for name in [*self._mandatory_names, *self._default_names]:
+            if name not in seen:
+                seen.add(name)
+                ordered.append(name)
+        return ordered
+
+    async def _resolve_names(self) -> list[str]:
+        """解析工具名列表。
+
+        总开关 ``settings.agents.tools_from_db_enabled`` 关（默认）→ 恒用 ``default_names``
+        （与改造前硬编码逐字节等价，零回归）；开 → 读 DB ``agents.tools``（60s TTL 缓存），
+        None / 空 → 回退 ``default_names``（与 instruction / model fallback 同构）。
+        """
+        from negentropy.config import settings
+
+        if not settings.agents.tools_from_db_enabled:
+            return self._default_names
+
+        from negentropy.config.model_resolver import resolve_subagent_tool_names
+
+        names = await resolve_subagent_tool_names(self._agent_name)
+        if not names:
+            return self._default_names
+        return names
+
+    async def get_tools(
+        self,
+        readonly_context: ReadonlyContext | None = None,
+    ) -> list[BaseTool]:
+        try:
+            names = await self._resolve_names()
+        except Exception:
+            _logger.warning(
+                "dynamic_tools_resolve_failed",
+                agent_name=self._agent_name,
+                exc_info=True,
+            )
+            names = self._default_names
+
+        # 过滤：先归一别名（claude_code → invoke_claude_code）再比对，避免误删已许可工具；
+        # 剔除 mandatory（已在常量位）、剔除白名单外（越权防御）、去重保序。
+        effective: list[str] = []
+        seen: set[str] = set()
+        for raw in names:
+            name = canonicalize_tool_name(raw)
+            if name in self._mandatory_set:
+                continue
+            if name not in self._allowed_set:
+                _logger.warning(
+                    "dynamic_tools_disallowed",
+                    agent_name=self._agent_name,
+                    name=raw,
+                )
+                continue
+            if name in seen:
+                continue
+            seen.add(name)
+            effective.append(name)
+
+        tools: list[BaseTool] = []
+        for union in resolve_tool_names(effective):
+            if isinstance(union, BaseTool):
+                tools.append(union)
+            elif callable(union):
+                # 与 ADK ``_convert_tool_union_to_tools`` 一致：裸 callable → FunctionTool。
+                tools.append(FunctionTool(func=union))
+            # 其它类型（不应发生）静默跳过，绝不抛。
+        return tools

--- a/apps/negentropy/src/negentropy/agents/faculties/action.py
+++ b/apps/negentropy/src/negentropy/agents/faculties/action.py
@@ -2,10 +2,14 @@ from google.adk.agents import LlmAgent
 
 from .._citation_protocol import CITATION_PROTOCOL
 from .._dynamic_instruction import make_instruction_provider
+from .._dynamic_tools import NegentropyToolset
 from .._model import create_subagent_model
-from ..tools.action import execute_code, read_file, write_file
-from ..tools.claude_code import invoke_claude_code
 from ..tools.common import log_activity
+
+# WS1：可摘工具集经 ``NegentropyToolset`` 按 ``agents.tools`` 运行时解析（单源来自
+# Interface/Agents 页）；恒常工具（log_activity）仍以裸 callable 挂常量位。
+_DEFAULT_TOOL_NAMES = ["execute_code", "read_file", "write_file", "invoke_claude_code"]
+_MANDATORY_TOOL_NAMES = ["log_activity"]
 
 _DESCRIPTION = (
     "Handles: code execution, file operations, implementation, system changes, tool invocation. "
@@ -71,7 +75,14 @@ def create_action_agent(*, output_key: str | None = None, mode: str | None = Non
         model=create_subagent_model(agent_name="ActionFaculty"),
         description=_DESCRIPTION,
         instruction=make_instruction_provider("ActionFaculty", _INSTRUCTION),
-        tools=[log_activity, execute_code, read_file, write_file, invoke_claude_code],
+        tools=[
+            log_activity,
+            NegentropyToolset(
+                agent_name="ActionFaculty",
+                default_names=_DEFAULT_TOOL_NAMES,
+                mandatory_names=_MANDATORY_TOOL_NAMES,
+            ),
+        ],
         output_key=output_key,
         mode=mode,
         # Pipeline 边界管控：在流水线内使用时，禁止 LLM 路由逃逸

--- a/apps/negentropy/src/negentropy/agents/faculties/contemplation.py
+++ b/apps/negentropy/src/negentropy/agents/faculties/contemplation.py
@@ -3,9 +3,14 @@ from google.adk.tools import load_memory
 
 from .._citation_protocol import CITATION_PROTOCOL
 from .._dynamic_instruction import make_instruction_provider
+from .._dynamic_tools import NegentropyToolset
 from .._model import create_subagent_model
 from ..tools.common import log_activity
-from ..tools.contemplation import analyze_context, create_plan
+
+# WS1：可摘工具集经 ``NegentropyToolset`` 按 ``agents.tools`` 运行时解析（单源来自
+# Interface/Agents 页）；恒常工具（log_activity / load_memory）仍以裸 callable 挂常量位。
+_DEFAULT_TOOL_NAMES = ["analyze_context", "create_plan"]
+_MANDATORY_TOOL_NAMES = ["log_activity", "load_memory"]
 
 _DESCRIPTION = (
     "Handles: deep analysis, strategic planning, root cause analysis, second-order thinking, risk assessment. "
@@ -77,7 +82,15 @@ def create_contemplation_agent(*, output_key: str | None = None, mode: str | Non
         model=create_subagent_model(agent_name="ContemplationFaculty"),
         description=_DESCRIPTION,
         instruction=make_instruction_provider("ContemplationFaculty", _INSTRUCTION),
-        tools=[log_activity, analyze_context, create_plan, load_memory],
+        tools=[
+            log_activity,
+            load_memory,
+            NegentropyToolset(
+                agent_name="ContemplationFaculty",
+                default_names=_DEFAULT_TOOL_NAMES,
+                mandatory_names=_MANDATORY_TOOL_NAMES,
+            ),
+        ],
         output_key=output_key,
         mode=mode,
         # Pipeline 边界管控：在流水线内使用时，禁止 LLM 路由逃逸

--- a/apps/negentropy/src/negentropy/agents/faculties/influence.py
+++ b/apps/negentropy/src/negentropy/agents/faculties/influence.py
@@ -2,10 +2,16 @@ from google.adk.agents import LlmAgent
 
 from .._citation_protocol import CITATION_PROTOCOL
 from .._dynamic_instruction import make_instruction_provider
+from .._dynamic_tools import NegentropyToolset
 from .._model import create_subagent_model
-from ..tools.claude_code import invoke_claude_code
 from ..tools.common import log_activity
-from ..tools.influence import publish_content, send_notification
+
+# WS1：可摘工具集经 ``NegentropyToolset`` 按 ``agents.tools`` 运行时解析（单源来自
+# Interface/Agents 页）；恒常工具（log_activity）仍以裸 callable 挂常量位。
+# 注：``document-translate`` 技能依赖 ``invoke_claude_code``（默认挂载）；经 UI 摘除会导致
+# 分块翻译不可用，属预期的可配置行为。
+_DEFAULT_TOOL_NAMES = ["publish_content", "send_notification", "invoke_claude_code"]
+_MANDATORY_TOOL_NAMES = ["log_activity"]
 
 _DESCRIPTION = (
     "Handles: content publishing, report generation, documentation, user communication, value delivery. "
@@ -78,7 +84,14 @@ def create_influence_agent(*, output_key: str | None = None, mode: str | None = 
         model=create_subagent_model(agent_name="InfluenceFaculty"),
         description=_DESCRIPTION,
         instruction=make_instruction_provider("InfluenceFaculty", _INSTRUCTION),
-        tools=[log_activity, publish_content, send_notification, invoke_claude_code],
+        tools=[
+            log_activity,
+            NegentropyToolset(
+                agent_name="InfluenceFaculty",
+                default_names=_DEFAULT_TOOL_NAMES,
+                mandatory_names=_MANDATORY_TOOL_NAMES,
+            ),
+        ],
         output_key=output_key,
         mode=mode,
         # Pipeline 边界管控：在流水线内使用时，禁止 LLM 路由逃逸

--- a/apps/negentropy/src/negentropy/agents/faculties/internalization.py
+++ b/apps/negentropy/src/negentropy/agents/faculties/internalization.py
@@ -3,11 +3,19 @@ from google.adk.tools import load_memory
 
 from .._citation_protocol import CITATION_PROTOCOL
 from .._dynamic_instruction import make_instruction_provider
+from .._dynamic_tools import NegentropyToolset
 from .._model import create_subagent_model
 from ..tools.common import log_activity
-from ..tools.ingest import ingest_to_corpus
-from ..tools.internalization import save_to_memory, update_knowledge_graph
-from ..tools.paper import ingest_paper
+
+# WS1：可摘工具集经 ``NegentropyToolset`` 按 ``agents.tools`` 运行时解析（单源来自
+# Interface/Agents 页）；恒常工具（log_activity / load_memory）仍以裸 callable 挂常量位。
+_DEFAULT_TOOL_NAMES = [
+    "save_to_memory",
+    "update_knowledge_graph",
+    "ingest_paper",
+    "ingest_to_corpus",
+]
+_MANDATORY_TOOL_NAMES = ["log_activity", "load_memory"]
 
 _DESCRIPTION = (
     "Handles: memory storage, knowledge structuring, knowledge graph updates, long-term retention. "
@@ -105,7 +113,15 @@ def create_internalization_agent(*, output_key: str | None = None, mode: str | N
         model=create_subagent_model(agent_name="InternalizationFaculty"),
         description=_DESCRIPTION,
         instruction=make_instruction_provider("InternalizationFaculty", _INSTRUCTION),
-        tools=[log_activity, save_to_memory, update_knowledge_graph, ingest_paper, ingest_to_corpus, load_memory],
+        tools=[
+            log_activity,
+            load_memory,
+            NegentropyToolset(
+                agent_name="InternalizationFaculty",
+                default_names=_DEFAULT_TOOL_NAMES,
+                mandatory_names=_MANDATORY_TOOL_NAMES,
+            ),
+        ],
         output_key=output_key,
         mode=mode,
         # Pipeline 边界管控：在流水线内使用时，禁止 LLM 路由逃逸

--- a/apps/negentropy/src/negentropy/agents/faculties/perception.py
+++ b/apps/negentropy/src/negentropy/agents/faculties/perception.py
@@ -3,15 +3,20 @@ from google.adk.tools import load_memory
 
 from .._citation_protocol import CITATION_PROTOCOL
 from .._dynamic_instruction import make_instruction_provider
+from .._dynamic_tools import NegentropyToolset
 from .._model import create_subagent_model
 from ..tools.common import log_activity
-from ..tools.paper import search_papers
-from ..tools.perception import (
-    search_knowledge_base,
-    search_knowledge_graph_global,
-    search_knowledge_graph_with_papers,
-    search_web,
-)
+
+# WS1：可摘工具集经 ``NegentropyToolset`` 按 ``agents.tools`` 运行时解析（单源来自
+# Interface/Agents 页）；恒常工具（log_activity / load_memory）仍以裸 callable 挂常量位。
+_DEFAULT_TOOL_NAMES = [
+    "search_knowledge_base",
+    "search_knowledge_graph_global",
+    "search_knowledge_graph_with_papers",
+    "search_web",
+    "search_papers",
+]
+_MANDATORY_TOOL_NAMES = ["log_activity", "load_memory"]
 
 _DESCRIPTION = (
     "Handles: information retrieval, web search, knowledge queries, fact-finding, data collection. "
@@ -122,14 +127,15 @@ def create_perception_agent(*, output_key: str | None = None, mode: str | None =
         description=_DESCRIPTION,
         instruction=make_instruction_provider("PerceptionFaculty", _INSTRUCTION),
         tools=[
+            # 恒常工具（常量位）：审计 + 长期记忆回溯（ADK 原生，经 tool_context 取 app_name/user_id）。
             log_activity,
-            search_knowledge_base,
-            search_knowledge_graph_global,
-            search_knowledge_graph_with_papers,
-            search_web,
-            search_papers,
-            # 长期记忆回溯（ADK 原生：经 tool_context 取 app_name/user_id，无越权风险）
             load_memory,
+            # 可摘工具集：运行时按 agents.tools 解析（单源 = Interface/Agents 页）。
+            NegentropyToolset(
+                agent_name="PerceptionFaculty",
+                default_names=_DEFAULT_TOOL_NAMES,
+                mandatory_names=_MANDATORY_TOOL_NAMES,
+            ),
         ],
         output_key=output_key,
         mode=mode,

--- a/apps/negentropy/src/negentropy/agents/tools/registry.py
+++ b/apps/negentropy/src/negentropy/agents/tools/registry.py
@@ -1,0 +1,134 @@
+"""
+六翼工具注册表 — 「工具名 → callable / BaseTool」单一事实源。
+
+WS1（tools 运行时回源）的名解析基座：``NegentropyToolset.get_tools`` 从 DB 读到的
+``agents.tools``（``list[str]``）经本表映射回真实 ADK 工具对象。
+
+设计约束（遵循 AGENTS.md「单一事实源」「最小干预」）：
+- **命名单源**：``tool_name(tool)`` 是工具名的唯一权威口径；``interface/agent_presets`` 的
+  序列化（sync 落库 ``agents.tools``）与本表的键都由它产生，从根源消除正 / 反向命名漂移。
+- **fail-soft**：``resolve_tool_names`` 对未知名 log warning 后丢弃，绝不抛（缺工具 ≠ 崩请求）。
+- **别名兼容**：``tools/available``（BuiltinTool 表，迁移 0039）的历史命名（如 ``claude_code``）
+  经 ``_ALIASES`` 归一到 callable 的真实符号名（``invoke_claude_code``）。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from negentropy.logging import get_logger
+
+_logger = get_logger("negentropy.agents.tools.registry")
+
+
+def tool_name(tool: Any) -> str:
+    """工具名的唯一权威口径（与 sync 序列化同源）。
+
+    取值优先级：``.name`` 属性（ADK ``BaseTool``）→ ``__name__``（裸函数）→ 类名。
+    ``interface/agent_presets._tool_name`` 委派到本函数，保证 sync 落库的 ``agents.tools``
+    与本注册表键逐字一致。
+    """
+    name = getattr(tool, "name", None)
+    if isinstance(name, str) and name:
+        return name
+    func_name = getattr(tool, "__name__", None)
+    if isinstance(func_name, str) and func_name:
+        return func_name
+    return tool.__class__.__name__
+
+
+def _build_registry() -> dict[str, Any]:
+    """登记六翼可能用到的全部工具符号。
+
+    延迟在函数体内 import，避免模块级 import 顺序耦合（各工具模块彼此、与 faculties 的加载序）。
+    键由 ``tool_name`` 统一生成；命名碰撞（两个不同工具同名）在导入期即抛，绝不静默覆盖。
+    """
+    from google.adk.tools import load_memory
+
+    from .action import execute_code, read_file, write_file
+    from .claude_code import invoke_claude_code
+    from .common import log_activity
+    from .contemplation import analyze_context, create_plan
+    from .influence import publish_content, send_notification
+    from .ingest import ingest_to_corpus
+    from .internalization import save_to_memory, update_knowledge_graph
+    from .memory import preload_memory_tool
+    from .paper import ingest_paper, search_papers
+    from .perception import (
+        search_knowledge_base,
+        search_knowledge_graph_global,
+        search_knowledge_graph_with_papers,
+        search_web,
+    )
+
+    symbols: list[Any] = [
+        # 通用（审计）
+        log_activity,
+        # 感知（慧眼）
+        search_knowledge_base,
+        search_web,
+        search_knowledge_graph_global,
+        search_knowledge_graph_with_papers,
+        search_papers,
+        # 内化（本心）
+        save_to_memory,
+        update_knowledge_graph,
+        ingest_paper,
+        ingest_to_corpus,
+        # 沉思（元神）
+        analyze_context,
+        create_plan,
+        # 行动（妙手）
+        execute_code,
+        read_file,
+        write_file,
+        invoke_claude_code,
+        # 影响（喉舌）
+        publish_content,
+        send_notification,
+        # 记忆（ADK 原生 + 预载）
+        load_memory,
+        preload_memory_tool,
+    ]
+
+    registry: dict[str, Any] = {}
+    for sym in symbols:
+        key = tool_name(sym)
+        existing = registry.get(key)
+        if existing is not None and existing is not sym:
+            # 命名碰撞是设计事故：必须在导入期暴露，而非运行时静默覆盖某个工具。
+            raise RuntimeError(f"tool registry name collision on {key!r}")
+        registry[key] = sym
+    return registry
+
+
+TOOL_REGISTRY: dict[str, Any] = _build_registry()
+
+
+# 历史命名别名 → 注册表主键（callable 的真实符号名）。
+# ``claude_code``：BuiltinTool 种子行名（迁移 0039），callable 实为 ``invoke_claude_code``。
+_ALIASES: dict[str, str] = {
+    "claude_code": "invoke_claude_code",
+}
+
+
+def canonicalize_tool_name(name: str) -> str:
+    """把工具名归一到注册表主键（应用历史别名，如 ``claude_code`` → ``invoke_claude_code``）。
+
+    调用方（如 ``NegentropyToolset`` 的白名单 / mandatory 过滤）必须先归一再比对，否则 DB 里
+    存的别名（``claude_code``）会被误判为「不在白名单」而错误丢弃已许可的工具。
+    """
+    return _ALIASES.get(name, name)
+
+
+def resolve_tool_names(names: list[str] | None) -> list[Any]:
+    """把工具名列表解析为 ADK 工具 / callable 列表；未知名 log warning 后丢弃（fail-soft）。"""
+    resolved: list[Any] = []
+    for raw in names or []:
+        key = canonicalize_tool_name(raw)
+        tool = TOOL_REGISTRY.get(key)
+        if tool is None:
+            _logger.warning("tool_registry_unknown_name", name=raw)
+            continue
+        resolved.append(tool)
+    return resolved

--- a/apps/negentropy/src/negentropy/config/__init__.py
+++ b/apps/negentropy/src/negentropy/config/__init__.py
@@ -27,6 +27,7 @@ from functools import cached_property
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from .agents import AgentsSettings
 from .app import AppSettings
 from .auth import AuthSettings
 from .database import DatabaseSettings
@@ -148,6 +149,11 @@ class Settings(BaseSettings):
         """自进化子系统配置（GEPA 提案器 + 记忆检索参数自进化）。"""
         return EvolutionSettings()
 
+    @cached_property
+    def agents(self) -> AgentsSettings:
+        """一核五翼 Agent 运行时配置解析开关（如 tools 从 DB 回源）。"""
+        return AgentsSettings()
+
     # =========================================================================
     # Legacy Compatibility Layer
     # =========================================================================
@@ -265,6 +271,7 @@ __all__ = [
     "MemorySettings",
     "RoutineSettings",
     "EvolutionSettings",
+    "AgentsSettings",
     "ObservabilitySettings",
     "DatabaseSettings",
     "ServicesSettings",

--- a/apps/negentropy/src/negentropy/config/agents.py
+++ b/apps/negentropy/src/negentropy/config/agents.py
@@ -1,0 +1,34 @@
+"""一核五翼 Agent 子系统配置。
+
+env 前缀 ``NE_AGENTS_``；YAML 节点 ``agents:``。
+
+本段配置治理「6 个内置 Agent 如何从 DB 单源解析运行时配置」的开关。指令（system_prompt）
+与模型（model）历来即经 ``_dynamic_instruction`` / ``_dynamic_model`` 按 ``agents.name`` 每轮
+读 DB；``tools`` 的运行时回源（WS1）为新增能力，故以总开关灰度：默认关 → 六翼工具集仍取代码
+硬编码 default（与改造前逐字节等价），运维在**重新 Sync 使 ``agents.tools`` 对齐当前代码**后
+再翻 True，避免陈旧 / 脏 DB 行导致运行时工具集回归。
+"""
+
+from __future__ import annotations
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class AgentsSettings(BaseSettings):
+    """一核五翼 Agent 运行时配置解析开关。"""
+
+    model_config = SettingsConfigDict(
+        env_prefix="NE_AGENTS_",
+        env_nested_delimiter="__",
+        extra="ignore",
+        frozen=True,
+    )
+
+    tools_from_db_enabled: bool = Field(
+        default=False,
+        description="启用六翼 tools 运行时从 DB(``agents.tools``)回源(WS1)。默认关 → "
+        "``NegentropyToolset`` 恒用代码硬编码 default_names(零回归)。开启前须先调 "
+        "``POST /interface/agents/sync/negentropy`` 使 DB tools 对齐当前代码，否则陈旧 DB "
+        "会丢失代码新增工具。作为 kill-switch:出现异常关回即恢复硬编码基线。",
+    )

--- a/apps/negentropy/src/negentropy/config/model_resolver.py
+++ b/apps/negentropy/src/negentropy/config/model_resolver.py
@@ -15,6 +15,7 @@ Model Resolver — 默认模型 + vendor_configs 凭证的模型配置解析器�
 - resolve_embedding_config_for_task()   — 按 task_key (+ 可选 corpus_id) 解析 Embedding
 - resolve_subagent_model_name()         — 按 agent_name 读取 agents.model
 - resolve_subagent_instruction()        — 按 agent_name 读取 agents.system_prompt
+- resolve_subagent_tool_names()         — 按 agent_name 读取 agents.tools（工具名列表）
 - get_cached_llm_config()               — 同步缓存读取 (无法 await 的上下文)
 - get_cached_llm_config_for_task()      — 同步缓存读取 task 槽位 (无法 await 的上下文)
 - get_fallback_llm_config()             — 同步获取硬编码 LLM 默认值
@@ -232,11 +233,29 @@ async def resolve_subagent_instruction(agent_name: str | None) -> str | None:
     return row[1] or None
 
 
-async def _resolve_subagent_row(agent_name: str | None) -> tuple[str | None, str | None] | None:
-    """共用 Agent 行加载：返回 ``(model, system_prompt)``，未启用 / 不存在返回 ``None``。
+async def resolve_subagent_tool_names(agent_name: str | None) -> list[str] | None:
+    """按 ``agent_name`` 读取 ``agents.tools`` 字段（工具名列表）。
 
-    缓存键 ``subagent:<agent_name>`` 复用三元组：``(model_or_empty, kwargs={"i": instruction}, ts)``。
-    单次 DB 查询同时取 model + instruction，避免 model_resolver 与 instruction provider 双查。
+    - 行不存在、未启用或 ``tools`` 为空 → ``None``（调用方 ``NegentropyToolset`` 回退硬编码默认集）；
+    - 与 ``resolve_subagent_model_name`` / ``resolve_subagent_instruction`` 共用同一行查询与
+      ``subagent:<agent_name>`` 60s TTL 缓存；Agent PATCH/DELETE/Sync 调用
+      ``invalidate_cache(prefix="subagent:")`` 一并失效。
+    """
+    row = await _resolve_subagent_row(agent_name)
+    if row is None:
+        return None
+    tools = row[2]
+    return list(tools) if tools else None
+
+
+async def _resolve_subagent_row(
+    agent_name: str | None,
+) -> tuple[str | None, str | None, list[str] | None] | None:
+    """共用 Agent 行加载：返回 ``(model, system_prompt, tools)``，未启用 / 不存在返回 ``None``。
+
+    缓存键 ``subagent:<agent_name>`` 复用三元组：``(model_or_empty, extras={"i": instruction,
+    "t": tools}, ts)``。单次 DB 查询同时取 model + instruction + tools，避免 model_resolver、
+    instruction provider 与 tools toolset 三查。
     """
     if not agent_name:
         return None
@@ -247,8 +266,10 @@ async def _resolve_subagent_row(agent_name: str | None) -> tuple[str | None, str
     if entry is not None:
         cached_model, cached_extras, ts = entry
         if now - ts < _CACHE_TTL:
-            cached_instruction = cached_extras.get("i") if isinstance(cached_extras, dict) else None
-            return (cached_model or None, cached_instruction or None)
+            extras = cached_extras if isinstance(cached_extras, dict) else {}
+            cached_instruction = extras.get("i")
+            cached_tools = extras.get("t")
+            return (cached_model or None, cached_instruction or None, cached_tools or None)
 
     try:
         loaded = await _load_subagent_row(agent_name)
@@ -265,13 +286,17 @@ async def _resolve_subagent_row(agent_name: str | None) -> tuple[str | None, str
     if loaded is None:
         # 行不存在 / 未启用 → 同样写入空占位，让 60s TTL 覆盖负命中场景，
         # 避免每次 LLM 请求重复触发 DB 查询。
-        _cache[cache_key] = ("", {"i": ""}, now)
+        _cache[cache_key] = ("", {"i": "", "t": []}, now)
         return None
-    model_value, instruction_value = loaded
+    model_value, instruction_value, tools_value = loaded
 
-    # 空串占位：缓存同样适用于「未配置」场景，避免重复 DB 查询
-    _cache[cache_key] = (model_value or "", {"i": instruction_value or ""}, now)
-    return (model_value or None, instruction_value or None)
+    # 空串 / 空列表占位：缓存同样适用于「未配置」场景，避免重复 DB 查询
+    _cache[cache_key] = (
+        model_value or "",
+        {"i": instruction_value or "", "t": tools_value or []},
+        now,
+    )
+    return (model_value or None, instruction_value or None, tools_value or None)
 
 
 async def _load_model_config_row_by_name(model_type: str, vendor: str, model_name: str):
@@ -301,8 +326,10 @@ async def _load_model_config_row_by_name(model_type: str, vendor: str, model_nam
         return result.scalar_one_or_none()
 
 
-async def _load_subagent_row(agent_name: str) -> tuple[str | None, str | None] | None:
-    """从 ``agents`` 表读取 ``(model, system_prompt)``；行不存在或未启用返回 ``None``。
+async def _load_subagent_row(
+    agent_name: str,
+) -> tuple[str | None, str | None, list[str] | None] | None:
+    """从 ``agents`` 表读取 ``(model, system_prompt, tools)``；行不存在或未启用返回 ``None``。
 
     单次 SQL 同时取 model + instruction（system_prompt），避免双查；调用方负责把 ``""``
     视为「未配置」并兜底，本函数仅做 trim。
@@ -402,7 +429,11 @@ async def _load_subagent_row(agent_name: str) -> tuple[str | None, str | None] |
             )
 
     model_normalized = str(model_value).strip() if model_value else None
-    return (model_normalized or None, instruction_normalized or None)
+    # WS1：回源 tools —— ``tools_list`` 是 ``agents.tools``（JSONB ``list[str]``），供
+    # ``NegentropyToolset`` 运行时解析六翼工具集。此处随 model / instruction 同批返回，
+    # 复用同一行查询，零额外 DB 往返。
+    tool_names = [str(t) for t in tools_list] if tools_list else None
+    return (model_normalized or None, instruction_normalized or None, tool_names)
 
 
 async def resolve_embedding_config_by_id(config_id: UUID | str | None) -> tuple[str, dict[str, Any]]:

--- a/apps/negentropy/src/negentropy/config/routine.py
+++ b/apps/negentropy/src/negentropy/config/routine.py
@@ -321,15 +321,51 @@ class RoutineSettings(BaseSettings):
     # 沿用现有 litellm 直调（PlanReviewer / RoutineEvaluator），事件仍带语义 agent_role。
     faculty_bridge_enabled: bool = Field(
         default=False,
-        description="启用 FacultyBridge：在 Plan 审 / 评估等注入点经 ADK Runner 同步调用真实 Faculty "
-        "Agent（元神 / 本心 / 妙手），失败/超时降级 litellm 直调。默认关闭——开启前需确保 ADK "
-        "Runner 在 Routine 编排上下文中可用且不阻塞单 worker 事件循环。",
+        description="启用 FacultyBridge（总 kill-switch）：在 Plan 审 / 评估等注入点经 ADK Runner "
+        "同步调用真实 Faculty Agent，失败/超时降级 litellm 直调。默认关闭——开启前需确保 ADK "
+        "Runner 在 Routine 编排上下文中可用且不阻塞单 worker 事件循环。其下细分组开关"
+        "（faculty_bridge_review_enabled 等）须与本开关同时为 True 才生效（总 AND 组）。",
     )
     faculty_bridge_timeout_seconds: int = Field(
         default=90,
         ge=10,
         le=600,
         description="FacultyBridge 单次同步调用 Faculty Agent 的超时（秒），超时即降级。",
+    )
+    # --- FacultyBridge 分组开关（WS2 后台 LLM 收编）---
+    # 每组独立可回滚：任一组异常只需翻其组开关 False，不影响其它组。生效条件 = 总开关 AND 组开关。
+    # 详见 ADR docs/concepts/040-routine-multi-agent-faculty.md 与 plan「WS2」节。
+    faculty_bridge_review_enabled: bool = Field(
+        default=True,
+        description="评审 / 裁决组（evaluate / plan_review / auto_answer）——已在生产验证降级安全，"
+        "总开关开启时默认参与。",
+    )
+    faculty_bridge_memory_extract_enabled: bool = Field(
+        default=False,
+        description="routine 记忆提取组（memory_extractor → internalization）——高频逐条，默认关，灰度。",
+    )
+    faculty_bridge_consolidation_enabled: bool = Field(
+        default=False,
+        description="consolidation 组（fact_extract / summarize / reflection / entity_normalization → "
+        "internalization | contemplation）——多条目循环，默认关，须配成本护栏灰度。",
+    )
+    faculty_bridge_evolution_enabled: bool = Field(
+        default=False,
+        description="evolution 提案组（proposer → contemplation）——决策敏感（bounded mutation），默认关。",
+    )
+    faculty_bridge_batch_timeout_seconds: int = Field(
+        default=30,
+        ge=10,
+        le=300,
+        description="批处理类（memory_extract / consolidation）单次 Faculty 调用超时（秒）；"
+        "低于评审类以约束多条目循环延迟。",
+    )
+    faculty_bridge_max_calls_per_task: int = Field(
+        default=3,
+        ge=1,
+        le=50,
+        description="单个高层任务（一次 consolidate / extract_on_termination）内 Faculty 调用上限；"
+        "超限即降级 litellm，防 Runner 开销线性膨胀。经 faculty_bridge_budget 上下文生效。",
     )
 
     # --- pdf-fidelity-patrol（PDF→Markdown 高保真自拟合巡检 · Scheduler Task）---

--- a/apps/negentropy/src/negentropy/config/task_registry.py
+++ b/apps/negentropy/src/negentropy/config/task_registry.py
@@ -63,7 +63,9 @@ ALL_TASKS: tuple[TaskSlot, ...] = (
         scope="global",
         label="事实提取",
         category="Memory Consolidation",
-        description="从对话中提取用户偏好 / 资料 / 规则等结构化事实。",
+        description="从对话中提取用户偏好 / 资料 / 规则等结构化事实。"
+        "（WS2：启用 FacultyBridge consolidation 组后，命中路径经 InternalizationFaculty 产出，"
+        "模型由 ``agents.model`` 决定；本槽位作降级兜底。）",
     ),
     TaskSlot(
         task_key="consolidation.summarize",
@@ -71,7 +73,9 @@ ALL_TASKS: tuple[TaskSlot, ...] = (
         scope="global",
         label="用户画像摘要",
         category="Memory Consolidation",
-        description="基于事实生成用户画像摘要文本。",
+        description="基于事实生成用户画像摘要文本。"
+        "（WS2：启用 FacultyBridge consolidation 组后，命中路径经 InternalizationFaculty 产出，"
+        "模型由 ``agents.model`` 决定；本槽位作降级兜底。）",
     ),
     TaskSlot(
         task_key="consolidation.reflection",
@@ -79,7 +83,9 @@ ALL_TASKS: tuple[TaskSlot, ...] = (
         scope="global",
         label="记忆反思",
         category="Memory Consolidation",
-        description="从历史记忆生成更高阶的反思与归纳。",
+        description="从历史记忆生成更高阶的反思与归纳。"
+        "（WS2：启用 FacultyBridge consolidation 组后，命中路径经 ContemplationFaculty 产出，"
+        "模型由 ``agents.model`` 决定；本槽位作降级兜底。）",
     ),
     TaskSlot(
         task_key="consolidation.entity_normalization",
@@ -87,7 +93,9 @@ ALL_TASKS: tuple[TaskSlot, ...] = (
         scope="global",
         label="实体规范化",
         category="Memory Consolidation",
-        description="将实体的别名、缩写等归一到统一表达。",
+        description="将实体的别名、缩写等归一到统一表达。"
+        "（WS2：启用 FacultyBridge consolidation 组后，命中路径经 InternalizationFaculty 产出，"
+        "模型由 ``agents.model`` 决定；本槽位作降级兜底。）",
     ),
     # 注：dedup_merge / auto_link / topic_cluster 三个 step 目前为规则/嵌入驱动，
     # 不调用 LLM。未来若引入 LLM 评判，再在此处补充对应 task_key 并接入调用点。
@@ -98,7 +106,9 @@ ALL_TASKS: tuple[TaskSlot, ...] = (
         scope="global",
         label="进化提案",
         category="Evolution",
-        description="GEPA 式根据检索效果指标提出 hybrid 权重有界变异提案。",
+        description="GEPA 式根据检索效果指标提出 hybrid 权重有界变异提案。"
+        "（WS2：启用 FacultyBridge evolution 组后，命中路径经 ContemplationFaculty 产出，"
+        "模型由 ``agents.model`` 决定；本槽位作降级兜底。）",
     ),
     # --- Session (global) ---
     TaskSlot(
@@ -116,7 +126,9 @@ ALL_TASKS: tuple[TaskSlot, ...] = (
         scope="global",
         label="Routine 结果评估",
         category="Routine",
-        description="LLM-as-Judge 按验收标准为 Routine 迭代结果评分并生成反思反馈。",
+        description="LLM-as-Judge 按验收标准为 Routine 迭代结果评分并生成反思反馈。"
+        "（WS2：启用 FacultyBridge review 组后，命中路径经 ContemplationFaculty 产出，"
+        "模型由 ``agents.model`` 决定；本槽位作降级兜底。）",
     ),
     TaskSlot(
         task_key="routine.plan_review",
@@ -124,7 +136,9 @@ ALL_TASKS: tuple[TaskSlot, ...] = (
         scope="global",
         label="Routine Plan 审阅",
         category="Routine",
-        description="NegentropyEngine 作为 Agent-as-Judge 审阅 Claude Code 的实现方案，评估完整性、可行性与风险。",
+        description="NegentropyEngine 作为 Agent-as-Judge 审阅 Claude Code 的实现方案，评估完整性、可行性与风险。"
+        "（WS2：启用 FacultyBridge review 组后，命中路径经 ContemplationFaculty 产出，"
+        "模型由 ``agents.model`` 决定；本槽位作降级兜底。）",
     ),
     # --- Knowledge Graph (corpus) ---
     TaskSlot(

--- a/apps/negentropy/src/negentropy/engine/claude_code/service.py
+++ b/apps/negentropy/src/negentropy/engine/claude_code/service.py
@@ -12,6 +12,7 @@ from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from typing import Any
 
+from negentropy.engine.utils.json_extract import loads_lenient
 from negentropy.engine.utils.subprocess_env import inherited_env_without_engine_venv
 from negentropy.logging import get_logger
 
@@ -1203,7 +1204,7 @@ class ClaudeCodeService:
             # 解析异常即降级到下方 litellm 直调，保证答问永不因 Faculty 不可用而中断。
             from negentropy.config import settings as _settings
 
-            if _settings.routine.faculty_bridge_enabled:
+            if _settings.routine.faculty_bridge_enabled and _settings.routine.faculty_bridge_review_enabled:
                 with suppress(Exception):
                     from negentropy.engine.routine.faculty_bridge import run_faculty
 
@@ -1211,10 +1212,11 @@ class ClaudeCodeService:
                         "internalization",
                         judge_prompt,
                         timeout_seconds=min(float(_settings.routine.faculty_bridge_timeout_seconds), timeout),
+                        read_only=True,
                     )
                     if fac_text:
-                        fac_parsed = json.loads(fac_text)
-                        if isinstance(fac_parsed.get("answers"), list):
+                        fac_parsed = loads_lenient(fac_text)
+                        if isinstance(fac_parsed, dict) and isinstance(fac_parsed.get("answers"), list):
                             return "\n".join(str(a) for a in fac_parsed["answers"])
                     logger.info("claude_code_auto_answer_faculty_bridge_fallback_litellm")
 
@@ -1240,8 +1242,8 @@ class ClaudeCodeService:
             )
             content = response.choices[0].message.content or ""
             # 解析 JSON 提取 answers 并返回纯文本
-            parsed = json.loads(content)
-            if "answers" in parsed and isinstance(parsed["answers"], list):
+            parsed = loads_lenient(content)
+            if isinstance(parsed, dict) and isinstance(parsed.get("answers"), list):
                 return "\n".join(str(a) for a in parsed["answers"])
             return content  # 非 answers 格式也返回纯文本
         except Exception as exc:

--- a/apps/negentropy/src/negentropy/engine/consolidation/llm_fact_extractor.py
+++ b/apps/negentropy/src/negentropy/engine/consolidation/llm_fact_extractor.py
@@ -18,11 +18,12 @@ LLMFactExtractor: LLM 驱动的对话事实提取器
 from __future__ import annotations
 
 import asyncio
-import json
 
 import litellm
 
 from negentropy.engine.consolidation.fact_extractor import ExtractedFact, PatternFactExtractor
+from negentropy.engine.routine.faculty_bridge import faculty_bridge_budget, run_faculty_json
+from negentropy.engine.utils.json_extract import loads_lenient
 from negentropy.engine.utils.model_config import resolve_model_config_async
 from negentropy.logging import get_logger
 
@@ -105,17 +106,22 @@ class LLMFactExtractor:
         # 解析当前任务模型（resolver 内含 60s TTL 缓存，避免高频 DB 查询）
         await self._resolve_model()
 
+        from negentropy.config import settings
+
         try:
             all_facts: list[ExtractedFact] = []
             seen_keys: set[str] = set()
 
-            for batch in self._batch_turns(user_turns):
-                batch_facts = await self._extract_batch(batch)
-                for fact in batch_facts:
-                    dedup_key = f"{fact.fact_type}:{fact.key}"
-                    if dedup_key not in seen_keys and len(fact.key) >= _MIN_KEY_LENGTH:
-                        seen_keys.add(dedup_key)
-                        all_facts.append(fact)
+            # 成本护栏：单次 extract（一次对话固结）内 Faculty 调用上限，超限即降级 litellm，
+            # 防多条目循环下 ADK Runner 开销线性膨胀。开关关时 run_faculty_json 不消耗预算。
+            async with faculty_bridge_budget(settings.routine.faculty_bridge_max_calls_per_task):
+                for batch in self._batch_turns(user_turns):
+                    batch_facts = await self._extract_batch(batch)
+                    for fact in batch_facts:
+                        dedup_key = f"{fact.fact_type}:{fact.key}"
+                        if dedup_key not in seen_keys and len(fact.key) >= _MIN_KEY_LENGTH:
+                            seen_keys.add(dedup_key)
+                            all_facts.append(fact)
 
             logger.debug(
                 "llm_facts_extracted",
@@ -169,36 +175,56 @@ class LLMFactExtractor:
         # PatternFactExtractor。演化 proposer 须保留 ``{turns}`` 占位符约定（见 PipelinePromptProposer）。
         prompt = base_prompt.replace("{turns}", turns_text)
 
-        last_error = None
-        for attempt in range(self._max_retries):
-            try:
-                safe_kwargs = {
-                    k: v
-                    for k, v in self._model_kwargs.items()
-                    if k not in ("model", "messages", "temperature", "response_format")
-                }
-                response = await litellm.acompletion(
-                    model=self._model,
-                    messages=[{"role": "user", "content": prompt}],
-                    temperature=self._temperature,
-                    response_format={"type": "json_object"},
-                    **safe_kwargs,
-                )
-                content = response.choices[0].message.content
-                return self._parse_response(content)
-            except Exception as exc:
-                last_error = exc
-                logger.warning("llm_fact_extraction_retry", attempt=attempt + 1, error=str(exc))
-                await asyncio.sleep(2**attempt)
+        from negentropy.config import settings
 
-        raise RuntimeError(f"LLM fact extraction failed after {self._max_retries} retries: {last_error}")
+        enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_consolidation_enabled
+
+        def parse(text: str) -> list[ExtractedFact] | None:
+            # 解析失败（非 dict）→ None 触发降级；有效 dict（含空 facts）→ 接受。
+            if not isinstance(loads_lenient(text), dict):
+                return None
+            return self._parse_response(text)
+
+        async def fallback() -> list[ExtractedFact]:
+            last_error: Exception | None = None
+            for attempt in range(self._max_retries):
+                try:
+                    safe_kwargs = {
+                        k: v
+                        for k, v in self._model_kwargs.items()
+                        if k not in ("model", "messages", "temperature", "response_format")
+                    }
+                    response = await litellm.acompletion(
+                        model=self._model,
+                        messages=[{"role": "user", "content": prompt}],
+                        temperature=self._temperature,
+                        response_format={"type": "json_object"},
+                        **safe_kwargs,
+                    )
+                    content = response.choices[0].message.content
+                    return self._parse_response(content)
+                except Exception as exc:
+                    last_error = exc
+                    logger.warning("llm_fact_extraction_retry", attempt=attempt + 1, error=str(exc))
+                    await asyncio.sleep(2**attempt)
+            raise RuntimeError(f"LLM fact extraction failed after {self._max_retries} retries: {last_error}")
+
+        facts, _used = await run_faculty_json(
+            "internalization",
+            prompt,
+            parse=parse,
+            fallback=fallback,
+            enabled=enabled,
+            timeout_seconds=float(settings.routine.faculty_bridge_batch_timeout_seconds),
+            read_only=True,
+        )
+        return facts
 
     def _parse_response(self, content: str) -> list[ExtractedFact]:
         """解析 LLM JSON 响应为 ExtractedFact 列表"""
-        try:
-            data = json.loads(content)
-        except json.JSONDecodeError:
-            logger.warning("llm_fact_response_not_json", content_preview=content[:200])
+        data = loads_lenient(content)
+        if not isinstance(data, dict):
+            logger.warning("llm_fact_response_not_json", content_preview=(content or "")[:200])
             return []
 
         facts_data = data.get("facts", [])

--- a/apps/negentropy/src/negentropy/engine/consolidation/llm_fact_extractor.py
+++ b/apps/negentropy/src/negentropy/engine/consolidation/llm_fact_extractor.py
@@ -180,8 +180,11 @@ class LLMFactExtractor:
         enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_consolidation_enabled
 
         def parse(text: str) -> list[ExtractedFact] | None:
-            # 解析失败（非 dict）→ None 触发降级；有效 dict（含空 facts）→ 接受。
-            if not isinstance(loads_lenient(text), dict):
+            # 缺 facts 键 / 非 dict → None 触发降级；含空 facts 的合法 dict → 接受。
+            # 注：loads_lenient 解析失败恒返回 {}（见 json_extract），故须靠键存在性而非
+            # isinstance(dict) 辨别脏输出，否则散文脏文本会被误判为「命中」而不降级 litellm。
+            data = loads_lenient(text)
+            if not isinstance(data, dict) or "facts" not in data:
                 return None
             return self._parse_response(text)
 

--- a/apps/negentropy/src/negentropy/engine/consolidation/memory_summarizer.py
+++ b/apps/negentropy/src/negentropy/engine/consolidation/memory_summarizer.py
@@ -186,11 +186,13 @@ class MemorySummarizer:
         enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_consolidation_enabled
 
         def parse(text: str) -> str | None:
-            # 解析失败（非 dict）→ None 触发降级；有效 dict → 取 summary（可为空串）。
+            # 空 / 缺 summary → None 触发降级；非空 summary → 接受。
+            # 注：loads_lenient 解析失败恒返回 {}（见 json_extract），仅 isinstance(dict) 无法辨别
+            # 脏输出；空摘要亦视作失败，交由 litellm 兜底重试，契合「批任务不因 Faculty 破损而空转」。
             data = loads_lenient(text)
             if not isinstance(data, dict):
                 return None
-            return data.get("summary", "")
+            return data.get("summary") or None
 
         async def fallback() -> str | None:
             return await self._call_llm(prompt)
@@ -205,4 +207,3 @@ class MemorySummarizer:
             read_only=True,
         )
         return summary
-        return None

--- a/apps/negentropy/src/negentropy/engine/consolidation/memory_summarizer.py
+++ b/apps/negentropy/src/negentropy/engine/consolidation/memory_summarizer.py
@@ -18,7 +18,6 @@ MemorySummarizer: 用户记忆画像摘要生成器
 from __future__ import annotations
 
 import asyncio
-import json
 from datetime import UTC, datetime, timedelta
 
 import litellm
@@ -27,6 +26,8 @@ import sqlalchemy as sa
 import negentropy.db.session as db_session
 from negentropy.engine.adapters.postgres.summary_service import SummaryService
 from negentropy.engine.factories.memory import get_fact_service
+from negentropy.engine.routine.faculty_bridge import run_faculty_json
+from negentropy.engine.utils.json_extract import loads_lenient
 from negentropy.engine.utils.model_config import resolve_model_config_async
 from negentropy.engine.utils.token_counter import TokenCounter
 from negentropy.logging import get_logger
@@ -114,7 +115,7 @@ class MemorySummarizer:
         facts_text = "\n".join(f"- [{f_type}] {key}: {str(val)[:100]}" for f_type, key, val in facts)
 
         prompt = _SUMMARY_PROMPT.format(memories=memories_text, facts=facts_text)
-        summary_text = await self._call_llm(prompt)
+        summary_text = await self._summarize(prompt)
 
         if not summary_text:
             return None
@@ -164,12 +165,44 @@ class MemorySummarizer:
                     **safe_kwargs,
                 )
                 content = response.choices[0].message.content
-                data = json.loads(content)
-                return data.get("summary", "")
+                data = loads_lenient(content)
+                return data.get("summary", "") if isinstance(data, dict) else ""
             except Exception as exc:
                 last_error = exc
                 logger.warning("summary_llm_retry", attempt=attempt + 1, error=str(exc))
                 await asyncio.sleep(2**attempt)
 
         logger.error("summary_llm_failed", error=str(last_error))
+        return None
+
+    async def _summarize(self, prompt: str) -> str | None:
+        """生成摘要：FacultyBridge(internalization, read_only) 优先 + litellm 兜底（WS2 收编）。
+
+        开关关（默认）→ 直接 litellm，行为与改造前逐字节等价。``read_only=True`` 剥离副作用工具
+        （save_to_memory 等），防自治 Faculty 在 approval=never 下静默写记忆。
+        """
+        from negentropy.config import settings
+
+        enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_consolidation_enabled
+
+        def parse(text: str) -> str | None:
+            # 解析失败（非 dict）→ None 触发降级；有效 dict → 取 summary（可为空串）。
+            data = loads_lenient(text)
+            if not isinstance(data, dict):
+                return None
+            return data.get("summary", "")
+
+        async def fallback() -> str | None:
+            return await self._call_llm(prompt)
+
+        summary, _used = await run_faculty_json(
+            "internalization",
+            prompt,
+            parse=parse,
+            fallback=fallback,
+            enabled=enabled,
+            timeout_seconds=float(settings.routine.faculty_bridge_batch_timeout_seconds),
+            read_only=True,
+        )
+        return summary
         return None

--- a/apps/negentropy/src/negentropy/engine/consolidation/pipeline/steps/entity_normalization_step.py
+++ b/apps/negentropy/src/negentropy/engine/consolidation/pipeline/steps/entity_normalization_step.py
@@ -13,11 +13,12 @@
 
 from __future__ import annotations
 
-import json
 import time
 
 import litellm
 
+from negentropy.engine.routine.faculty_bridge import run_faculty_json
+from negentropy.engine.utils.json_extract import loads_lenient
 from negentropy.engine.utils.model_config import resolve_model_config_async
 from negentropy.logging import get_logger
 
@@ -83,32 +84,62 @@ class EntityNormalizationStep:
             output_count=len(entities),
         )
 
+    @staticmethod
+    def _parse_entities(content: str) -> list[dict]:
+        """解析 LLM JSON 为实体归一化列表（无效 / 空 → ``[]``）。"""
+        data = loads_lenient(content)
+        if not isinstance(data, dict):
+            return []
+        entities = data.get("entities", [])
+        if not isinstance(entities, list):
+            return []
+        return [e for e in entities if isinstance(e, dict) and e.get("canonical")]
+
     async def _llm_normalize(self, facts_block: str) -> list[dict]:
         prompt = _PROMPT.format(facts=facts_block)
-        last_error: Exception | None = None
-        for _ in range(self._max_retries):
-            try:
-                safe_kwargs = {
-                    k: v
-                    for k, v in self._model_kwargs.items()
-                    if k not in ("model", "messages", "temperature", "response_format")
-                }
-                response = await litellm.acompletion(
-                    model=self._model,
-                    messages=[{"role": "user", "content": prompt}],
-                    temperature=0.0,
-                    response_format={"type": "json_object"},
-                    **safe_kwargs,
-                )
-                content = response.choices[0].message.content
-                data = json.loads(content)
-                entities = data.get("entities", [])
-                if isinstance(entities, list):
-                    return [e for e in entities if isinstance(e, dict) and e.get("canonical")]
-                return []
-            except Exception as exc:
-                last_error = exc
-        raise RuntimeError(f"entity_normalization llm failed: {last_error}")
+
+        from negentropy.config import settings
+
+        enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_consolidation_enabled
+
+        def parse(text: str) -> list[dict] | None:
+            # 解析失败（非 dict）→ None 触发降级；有效 dict（含空 entities）→ 接受 []。
+            if not isinstance(loads_lenient(text), dict):
+                return None
+            return self._parse_entities(text)
+
+        async def fallback() -> list[dict]:
+            last_error: Exception | None = None
+            for _ in range(self._max_retries):
+                try:
+                    safe_kwargs = {
+                        k: v
+                        for k, v in self._model_kwargs.items()
+                        if k not in ("model", "messages", "temperature", "response_format")
+                    }
+                    response = await litellm.acompletion(
+                        model=self._model,
+                        messages=[{"role": "user", "content": prompt}],
+                        temperature=0.0,
+                        response_format={"type": "json_object"},
+                        **safe_kwargs,
+                    )
+                    content = response.choices[0].message.content
+                    return self._parse_entities(content)
+                except Exception as exc:
+                    last_error = exc
+            raise RuntimeError(f"entity_normalization llm failed: {last_error}")
+
+        entities, _used = await run_faculty_json(
+            "internalization",
+            prompt,
+            parse=parse,
+            fallback=fallback,
+            enabled=enabled,
+            timeout_seconds=float(settings.routine.faculty_bridge_batch_timeout_seconds),
+            read_only=True,
+        )
+        return entities
 
 
 __all__ = ["EntityNormalizationStep"]

--- a/apps/negentropy/src/negentropy/engine/consolidation/pipeline/steps/entity_normalization_step.py
+++ b/apps/negentropy/src/negentropy/engine/consolidation/pipeline/steps/entity_normalization_step.py
@@ -128,6 +128,12 @@ class EntityNormalizationStep:
                         **safe_kwargs,
                     )
                     content = response.choices[0].message.content
+                    # loads_lenient 对不可解析文本返回 {}（见 json_extract），会把脏输出伪装成
+                    # 「空实体成功」而丢失降级信号；故先校验响应确为含 entities 键的 dict，否则 raise
+                    # 触发重试 / 最终 RuntimeError → run() 捕获记为 degraded（与严格 json.loads 时代等价）。
+                    data = loads_lenient(content)
+                    if not isinstance(data, dict) or "entities" not in data:
+                        raise ValueError("entity_normalization: 响应非预期 JSON（缺 'entities' 键）")
                     return self._parse_entities(content)
                 except Exception as exc:
                     last_error = exc

--- a/apps/negentropy/src/negentropy/engine/consolidation/pipeline/steps/entity_normalization_step.py
+++ b/apps/negentropy/src/negentropy/engine/consolidation/pipeline/steps/entity_normalization_step.py
@@ -103,8 +103,11 @@ class EntityNormalizationStep:
         enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_consolidation_enabled
 
         def parse(text: str) -> list[dict] | None:
-            # 解析失败（非 dict）→ None 触发降级；有效 dict（含空 entities）→ 接受 []。
-            if not isinstance(loads_lenient(text), dict):
+            # 缺 entities 键 / 非 dict → None 触发降级；含空 entities 的合法 dict → 接受 []。
+            # 注：loads_lenient 解析失败恒返回 {}（见 json_extract），故须靠键存在性而非
+            # isinstance(dict) 辨别脏输出，否则散文脏文本会被误判为「命中」而不降级 litellm。
+            data = loads_lenient(text)
+            if not isinstance(data, dict) or "entities" not in data:
                 return None
             return self._parse_entities(text)
 

--- a/apps/negentropy/src/negentropy/engine/consolidation/reflection_generator.py
+++ b/apps/negentropy/src/negentropy/engine/consolidation/reflection_generator.py
@@ -21,11 +21,12 @@
 from __future__ import annotations
 
 import asyncio
-import json
 from dataclasses import dataclass
 
 import litellm
 
+from negentropy.engine.routine.faculty_bridge import run_faculty_json
+from negentropy.engine.utils.json_extract import loads_lenient
 from negentropy.engine.utils.model_config import resolve_model_config_async
 from negentropy.logging import get_logger
 
@@ -126,34 +127,49 @@ class ReflectionGenerator:
     ) -> Reflection | None:
         prompt = _REFLECTION_PROMPT.format(query=query, snippets=snippets, outcome=outcome)
 
-        last_error: Exception | None = None
-        for attempt in range(self._max_retries):
-            try:
-                safe_kwargs = {
-                    k: v
-                    for k, v in self._model_kwargs.items()
-                    if k not in ("model", "messages", "temperature", "response_format")
-                }
-                response = await litellm.acompletion(
-                    model=self._model,
-                    messages=[{"role": "user", "content": prompt}],
-                    temperature=self._temperature,
-                    response_format={"type": "json_object"},
-                    **safe_kwargs,
-                )
-                content = response.choices[0].message.content
-                return self._parse_response(content)
-            except Exception as exc:
-                last_error = exc
-                logger.warning("reflection_llm_retry", attempt=attempt + 1, error=str(exc))
-                await asyncio.sleep(2**attempt)
-        raise RuntimeError(f"Reflection LLM generation failed after {self._max_retries} retries: {last_error}")
+        from negentropy.config import settings
+
+        enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_consolidation_enabled
+
+        async def fallback() -> Reflection | None:
+            last_error: Exception | None = None
+            for attempt in range(self._max_retries):
+                try:
+                    safe_kwargs = {
+                        k: v
+                        for k, v in self._model_kwargs.items()
+                        if k not in ("model", "messages", "temperature", "response_format")
+                    }
+                    response = await litellm.acompletion(
+                        model=self._model,
+                        messages=[{"role": "user", "content": prompt}],
+                        temperature=self._temperature,
+                        response_format={"type": "json_object"},
+                        **safe_kwargs,
+                    )
+                    content = response.choices[0].message.content
+                    return self._parse_response(content)
+                except Exception as exc:
+                    last_error = exc
+                    logger.warning("reflection_llm_retry", attempt=attempt + 1, error=str(exc))
+                    await asyncio.sleep(2**attempt)
+            raise RuntimeError(f"Reflection LLM generation failed after {self._max_retries} retries: {last_error}")
+
+        ref, _used = await run_faculty_json(
+            "contemplation",
+            prompt,
+            parse=self._parse_response,
+            fallback=fallback,
+            enabled=enabled,
+            timeout_seconds=float(settings.routine.faculty_bridge_batch_timeout_seconds),
+            read_only=True,
+        )
+        return ref
 
     def _parse_response(self, content: str) -> Reflection | None:
-        try:
-            data = json.loads(content)
-        except json.JSONDecodeError:
-            logger.warning("reflection_response_not_json", content_preview=content[:200])
+        data = loads_lenient(content)
+        if not isinstance(data, dict):
+            logger.warning("reflection_response_not_json", content_preview=(content or "")[:200])
             return None
 
         lesson = str(data.get("lesson", "")).strip()[:_MAX_LESSON_LEN]

--- a/apps/negentropy/src/negentropy/engine/eval/attack_generator.py
+++ b/apps/negentropy/src/negentropy/engine/eval/attack_generator.py
@@ -9,6 +9,10 @@
 针对当前 skill prompt 弱点定制**的攻击（综述 §9.3 AutoRedTeamer 20% higher attack success rate
 while reducing cost by 46%）。
 
+**Faculty 边界（WS2）**：本模块是红队「元层」，刻意**不接 FacultyBridge**——攻击生成需高温发散
+（``temperature=0.7``），且与被测系统同源会致循环偏置。保持裸 litellm，由
+``tests/unit_tests/engine/eval/test_faculty_boundary.py`` 反向断言固化。
+
 参考文献：
 [1] C. Jiang et al., "Self-Improving Agents in the Era of Experience," 2026. §9.3 + AutoRedTeamer。
 [2] Y. Zhou et al., "AutoRedTeamer," 2025. 多 agent 架构 + 记忆引导攻击选择。

--- a/apps/negentropy/src/negentropy/engine/eval/runner.py
+++ b/apps/negentropy/src/negentropy/engine/eval/runner.py
@@ -10,6 +10,11 @@
 关键不变量（综述 §9.4 防 Goodhart）：proposer 读证据必须经 ``visible_results_query``——
 它显式排除 ``partition = 'holdout'`` 的 run，使冻结 holdout 结果不回流 proposer。
 
+**Faculty 边界（WS2）**：本模块是评测「元层」——用系统自身当 Judge/执行器去评测被测 target。
+刻意**不接 FacultyBridge**：若 Judge 走 ContemplationFaculty，等于「元神评判修改元神自己的提案」，
+形成循环偏置 + 破坏 holdout 独立性 + 多轮 tool-loop 结构与单发 Faculty 范式不兼容。保持裸
+litellm，并由 ``tests/unit_tests/engine/eval/test_faculty_boundary.py`` 反向断言固化。
+
 参考文献：
 [1] C. Jiang et al., "Self-Improving Agents in the Era of Experience," 2026. §8 held-out gain /
     backward retention；§9.4 冻结 holdout 不回流。

--- a/apps/negentropy/src/negentropy/engine/evolution/handlers/memory_pipeline.py
+++ b/apps/negentropy/src/negentropy/engine/evolution/handlers/memory_pipeline.py
@@ -25,6 +25,7 @@ from negentropy.config import settings
 from negentropy.engine.evolution.decision import decide_skill_canary, decide_skill_shadow, is_noop_template
 from negentropy.engine.evolution.handlers._shared import _emit_evolution_event, _enter_canary
 from negentropy.engine.evolution.proposer import _ProposerBase
+from negentropy.engine.routine.faculty_bridge import run_faculty_json
 from negentropy.engine.utils.json_extract import loads_lenient
 from negentropy.logging import get_logger
 from negentropy.models.eval_suite import (
@@ -297,16 +298,39 @@ class PipelinePromptProposer(_ProposerBase):
 
         await self._resolve_model()
         prompt = self._build_prompt(scope_name=scope_name, active_prompt=active_prompt)
-        content = await self._call_llm(prompt)
-        if not content:
-            return None
-        data = loads_lenient(content)
-        if not isinstance(data, dict) or bool(data.get("no_change", False)):
-            return None
-        new_prompt = str(data.get("prompt") or data.get("prompt_template") or "").strip()
-        if not new_prompt or is_noop_template(new_prompt, active_prompt):
-            return None
-        return SkillProposalDraft(prompt_template=new_prompt, rationale=str(data.get("rationale", "")).strip()[:240])
+
+        from negentropy.config import settings
+
+        enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_evolution_enabled
+
+        def parse(text: str) -> SkillProposalDraft | None:
+            data = loads_lenient(text)
+            if not isinstance(data, dict) or bool(data.get("no_change", False)):
+                return None
+            new_prompt = str(data.get("prompt") or data.get("prompt_template") or "").strip()
+            if not new_prompt or is_noop_template(new_prompt, active_prompt):
+                return None
+            return SkillProposalDraft(
+                prompt_template=new_prompt,
+                rationale=str(data.get("rationale", "")).strip()[:240],
+            )
+
+        async def fallback() -> SkillProposalDraft | None:
+            content = await self._call_llm(prompt)
+            if not content:
+                return None
+            return parse(content)
+
+        draft, _used = await run_faculty_json(
+            "contemplation",
+            prompt,
+            parse=parse,
+            fallback=fallback,
+            enabled=enabled,
+            timeout_seconds=float(settings.routine.faculty_bridge_timeout_seconds),
+            read_only=True,
+        )
+        return draft
 
     def _build_prompt(self, *, scope_name: str, active_prompt: str) -> str:
         return _PIPELINE_PROPOSAL_PROMPT.format(scope=scope_name, active=active_prompt[:1200])

--- a/apps/negentropy/src/negentropy/engine/evolution/handlers/skill.py
+++ b/apps/negentropy/src/negentropy/engine/evolution/handlers/skill.py
@@ -47,6 +47,7 @@ from negentropy.engine.evolution.handlers._shared import (
     _parse_dt,
 )
 from negentropy.engine.evolution.proposer import _ProposerBase
+from negentropy.engine.routine.faculty_bridge import run_faculty_json
 from negentropy.engine.utils.json_extract import loads_lenient
 from negentropy.logging import get_logger
 from negentropy.models.eval_suite import (
@@ -129,14 +130,42 @@ class SkillProposer(_ProposerBase):
         )
         if prompt is None:
             return None
-        content = await self._call_llm(prompt)
-        if not content:
-            return None
-        return self._parse(content, active_template=active_template)
+        return await self._propose_skill_with_faculty(prompt, active_template=active_template)
 
     # ------------------------------------------------------------------
     # override
     # ------------------------------------------------------------------
+
+    async def _propose_skill_with_faculty(self, prompt: str, *, active_template: str) -> SkillProposalDraft | None:
+        """FacultyBridge(contemplation, read_only) 优先 + litellm 兜底（WS2 收编）。
+
+        ``_parse`` 带 ``active_template`` 形参（与基类 ``_parse(content)`` 签名不同），故本子类
+        内联 ``run_faculty_json`` 而非复用 ``_ProposerBase._propose_with_faculty``。``parse→None``
+        即降级 litellm；litellm 亦失败 → ``None``（「宁缺毋滥」）。
+        """
+        from negentropy.config import settings
+
+        enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_evolution_enabled
+
+        def parse(text: str) -> SkillProposalDraft | None:
+            return self._parse(text, active_template=active_template)
+
+        async def fallback() -> SkillProposalDraft | None:
+            content = await self._call_llm(prompt)
+            if not content:
+                return None
+            return self._parse(content, active_template=active_template)
+
+        draft, _used = await run_faculty_json(
+            "contemplation",
+            prompt,
+            parse=parse,
+            fallback=fallback,
+            enabled=enabled,
+            timeout_seconds=float(settings.routine.faculty_bridge_timeout_seconds),
+            read_only=True,
+        )
+        return draft
 
     def _build_prompt(
         self,

--- a/apps/negentropy/src/negentropy/engine/evolution/proposer.py
+++ b/apps/negentropy/src/negentropy/engine/evolution/proposer.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import litellm
 
+from negentropy.engine.routine.faculty_bridge import run_faculty_json
 from negentropy.engine.utils.json_extract import loads_lenient
 from negentropy.engine.utils.model_config import resolve_model_config_async
 from negentropy.logging import get_logger
@@ -118,6 +119,34 @@ class _ProposerBase:
     def _parse(self, content: str) -> ProposalDraft | None:  # noqa: ARG002
         raise NotImplementedError
 
+    async def _propose_with_faculty(self, prompt: str) -> ProposalDraft | None:
+        """FacultyBridge(contemplation, read_only) 优先 + litellm 兜底（WS2 收编）。
+
+        ``parse→None``（解析失败 / 超界失控 / ``no_change=true``）即降级 litellm；litellm 亦失败
+        → ``None``（「宁缺毋滥」，不提案）。开关关（默认）→ 直接 litellm，行为与改造前逐字节等价。
+        提案属低频单发，用评审类超时（``faculty_bridge_timeout_seconds``）。
+        """
+        from negentropy.config import settings
+
+        enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_evolution_enabled
+
+        async def fallback() -> ProposalDraft | None:
+            content = await self._call_llm(prompt)
+            if not content:
+                return None
+            return self._parse(content)
+
+        draft, _used = await run_faculty_json(
+            "contemplation",
+            prompt,
+            parse=self._parse,
+            fallback=fallback,
+            enabled=enabled,
+            timeout_seconds=float(settings.routine.faculty_bridge_timeout_seconds),
+            read_only=True,
+        )
+        return draft
+
 
 class RetrievalWeightProposer(_ProposerBase):
     """retrieval_config 面：对 hybrid 检索 semantic/keyword 权重做 GEPA 式有界变异。"""
@@ -151,10 +180,7 @@ class RetrievalWeightProposer(_ProposerBase):
         if prompt is None:
             return None
 
-        content = await self._call_llm(prompt)
-        if not content:
-            return None
-        return self._parse(content)
+        return await self._propose_with_faculty(prompt)
 
     # ------------------------------------------------------------------
     # override

--- a/apps/negentropy/src/negentropy/engine/routine/evaluator.py
+++ b/apps/negentropy/src/negentropy/engine/routine/evaluator.py
@@ -483,7 +483,7 @@ class RoutineEvaluator:
         """
         from negentropy.config import settings
 
-        if settings.routine.faculty_bridge_enabled:
+        if settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_review_enabled:
             with suppress(Exception):
                 from negentropy.engine.routine.faculty_bridge import run_faculty
 

--- a/apps/negentropy/src/negentropy/engine/routine/faculty_bridge.py
+++ b/apps/negentropy/src/negentropy/engine/routine/faculty_bridge.py
@@ -48,16 +48,12 @@ _ROLE_TO_FACULTY_FACTORY: dict[str, str] = {
 # 无人在环下静默真写记忆 / KG → 记忆重复 / KG 污染（ADR 040「副作用工具陷阱」）。
 # 注：read_only 同时整体剔除 ``BaseToolset``（六翼的可摘工具集经 WS1 以 toolset 承载，副作用工具
 # 藏于其内逐请求解析），故 read_only 调用不会触发任何可摘工具——契合「要确定性 JSON、不要工具漫游」。
+# 因 toolset 被整体剔除，唯有「常量位」裸 callable（log_activity / load_memory）才会走到本白名单
+# 比对；search_* / analyze_context / create_plan 等只读工具均在 toolset 内、已随 toolset 一并剥离，
+# 故不列于此（若未来把某只读工具移回常量位并希望 read_only 保留，再在此显式补名）。
 _READONLY_TOOL_ALLOWLIST: set[str] = {
     "log_activity",
     "load_memory",
-    "search_knowledge_base",
-    "search_knowledge_graph_global",
-    "search_knowledge_graph_with_papers",
-    "search_web",
-    "search_papers",
-    "analyze_context",
-    "create_plan",
 }
 
 # 单任务 Faculty 调用预算（contextvar）：consolidation 等多条目循环收编时，防止「条目越多、ADK
@@ -196,6 +192,11 @@ async def run_faculty_json(
     """
     budget = _faculty_budget.get()
     if enabled and (budget is None or budget > 0):
+        # 预算按「Runner 调用」计费：run_faculty 一旦驱动 ADK Runner，开销即已产生，与解析成败无关。
+        # 故进入本分支即自减一次（而非仅解析成功后），确保 Faculty 持续吐脏文本 / 空响应时预算仍如实
+        # 耗尽、多条目循环不会无上限重驱 Runner（与 contextvar / docstring「每次调用消耗 1」一致）。
+        if budget is not None:
+            _faculty_budget.set(budget - 1)
         try:
             text = await run_faculty(
                 role,
@@ -213,8 +214,6 @@ async def run_faculty_json(
                 logger.info("faculty_bridge_json_parse_failed_fallback", role=role)
                 parsed = None
             if parsed is not None:
-                if budget is not None:
-                    _faculty_budget.set(budget - 1)
                 return parsed, True
             logger.info("faculty_bridge_empty_or_unparsed_fallback", role=role)
         else:

--- a/apps/negentropy/src/negentropy/engine/routine/faculty_bridge.py
+++ b/apps/negentropy/src/negentropy/engine/routine/faculty_bridge.py
@@ -17,8 +17,10 @@ Routine 的「人机交互」中「人」侧动作（审 Plan / 答问 / 门控 
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
-from typing import TYPE_CHECKING
+import contextlib
+import contextvars
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import TYPE_CHECKING, Any, TypeVar
 from uuid import uuid4
 
 from negentropy.logging import get_logger
@@ -38,9 +40,53 @@ _ROLE_TO_FACULTY_FACTORY: dict[str, str] = {
     "influence": "create_influence_agent",  # 喉舌
 }
 
+# read_only 模式下 Faculty 可保留的工具名白名单。经 ``_apply_readonly`` 过滤后，Faculty 仅能调
+# 这些工具，**任何副作用工具（save_to_memory / update_knowledge_graph / ingest_paper /
+# ingest_to_corpus / write_file / invoke_claude_code / publish_content / send_notification /
+# execute_code）一律剥离**。这是收编后台 LLM 到六翼的关键安全增量：桥接层注入
+# ``approval_policy=never``（见 ``_drive``），若不剥离副作用工具，Internalization 等翼会在
+# 无人在环下静默真写记忆 / KG → 记忆重复 / KG 污染（ADR 040「副作用工具陷阱」）。
+# 注：read_only 同时整体剔除 ``BaseToolset``（六翼的可摘工具集经 WS1 以 toolset 承载，副作用工具
+# 藏于其内逐请求解析），故 read_only 调用不会触发任何可摘工具——契合「要确定性 JSON、不要工具漫游」。
+_READONLY_TOOL_ALLOWLIST: set[str] = {
+    "log_activity",
+    "load_memory",
+    "search_knowledge_base",
+    "search_knowledge_graph_global",
+    "search_knowledge_graph_with_papers",
+    "search_web",
+    "search_papers",
+    "analyze_context",
+    "create_plan",
+}
 
-def _build_faculty_agent(role: str) -> BaseAgent | None:
-    """按 agent_role 工厂新建 Faculty 实例（不传 mode——Runner root 仅允许 chat）。"""
+# 单任务 Faculty 调用预算（contextvar）：consolidation 等多条目循环收编时，防止「条目越多、ADK
+# Runner 同步驱动次数线性膨胀」的成本 / 延迟失控。``None`` = 不限。调用方用
+# ``faculty_bridge_budget(budget)`` 在任务作用域内设置；``run_faculty_json`` 每次调用前自减。
+_faculty_budget: contextvars.ContextVar[int | None] = contextvars.ContextVar("negentropy_faculty_budget", default=None)
+
+T = TypeVar("T")
+
+
+@contextlib.asynccontextmanager
+async def faculty_bridge_budget(budget: int) -> AsyncIterator[None]:
+    """为一个高层任务（一次 consolidate / extract_on_termination 等）设定 Faculty 调用预算。
+
+    在此作用域内，``run_faculty_json`` 每次 Faculty 调用消耗 1；耗尽后剩余调用直接降级 litellm
+    （``used_faculty=False``），防多条目循环下 Runner 开销线性膨胀。未进入本上下文 → 不限。
+    """
+    token = _faculty_budget.set(budget)
+    try:
+        yield
+    finally:
+        _faculty_budget.reset(token)
+
+
+def _build_faculty_agent(role: str, *, read_only: bool = False) -> BaseAgent | None:
+    """按 agent_role 工厂新建 Faculty 实例（不传 mode——Runner root 仅允许 chat）。
+
+    ``read_only=True`` 时剥离副作用工具（仅留白名单），用于后台 LLM 收编（WS2）。
+    """
     factory_name = _ROLE_TO_FACULTY_FACTORY.get(role)
     if factory_name is None:
         logger.warning("faculty_bridge_unknown_role", role=role)
@@ -49,10 +95,35 @@ def _build_faculty_agent(role: str) -> BaseAgent | None:
         from negentropy.agents import faculties
 
         factory: Callable[..., BaseAgent] = getattr(faculties, factory_name)
-        return factory()
+        agent = factory()
+        if read_only:
+            _apply_readonly(agent)
+        return agent
     except Exception:  # pragma: no cover - 防御：faculties 导入/构造异常
         logger.warning("faculty_bridge_build_failed", role=role, exc_info=True)
         return None
+
+
+def _apply_readonly(agent: BaseAgent) -> None:
+    """read_only 过滤：整体剔除 ``BaseToolset``（副作用工具藏于其内）+ 只保留白名单工具名。
+
+    在原地改 ``agent.tools``。保留 ``log_activity``（审计）与 ``load_memory``（只读记忆回溯）。
+    """
+    from google.adk.tools.base_toolset import BaseToolset
+
+    from negentropy.agents.tools.registry import tool_name
+
+    kept: list[Any] = []
+    for tool in getattr(agent, "tools", None) or []:
+        # BaseToolset 整体剔除：read_only 调用要确定性 JSON，不该触发任何可摘工具（含副作用工具）。
+        if isinstance(tool, BaseToolset):
+            continue
+        if tool_name(tool) in _READONLY_TOOL_ALLOWLIST:
+            kept.append(tool)
+    try:
+        agent.tools = kept  # type: ignore[misc]
+    except (AttributeError, TypeError):  # pragma: no cover - frozen / 无 setter
+        logger.warning("faculty_bridge_readonly_apply_failed", role=getattr(agent, "name", "?"))
 
 
 async def run_faculty(
@@ -61,6 +132,7 @@ async def run_faculty(
     *,
     timeout_seconds: float = 90.0,
     user_id: str = "system:routine-faculty",
+    read_only: bool = False,
 ) -> str | None:
     """同步驱动一个 Faculty Agent 处理 ``task_prompt``，返回其最终响应文本。
 
@@ -69,11 +141,12 @@ async def run_faculty(
         task_prompt: 投喂给 Faculty 的任务消息（含目标 / 验收 / 待审方案等上下文）。
         timeout_seconds: 单次调用超时；超时即返回 None（调用方降级）。
         user_id: 审计用 user 标识。
+        read_only: 剥离副作用工具（用于后台 LLM 收编，WS2）。
 
     Returns:
         Faculty 的最终响应文本；失败 / 超时 / 空响应 → ``None``（调用方应降级）。
     """
-    agent = _build_faculty_agent(role)
+    agent = _build_faculty_agent(role, read_only=read_only)
     if agent is None:
         return None
 
@@ -88,6 +161,67 @@ async def run_faculty(
     except Exception:
         logger.warning("faculty_bridge_run_failed", role=role, exc_info=True)
         return None
+
+
+async def run_faculty_json(
+    role: str,
+    task_prompt: str,
+    *,
+    parse: Callable[[str], T | None],
+    fallback: Callable[[], Awaitable[T]],
+    enabled: bool,
+    timeout_seconds: float = 90.0,
+    read_only: bool = True,
+    user_id: str = "system:routine-faculty",
+) -> tuple[T, bool]:
+    """Faculty 优先 + litellm 兜底，产出结构化结果（WS2 统一收编 helper）。
+
+    Args:
+        role: Faculty agent_role。
+        task_prompt: 投喂给 Faculty 的任务消息（含 JSON 契约）。
+        parse: 把 Faculty 文本解析为目标结构；``None`` 表示解析失败 / 非预期 → 触发降级。
+            复用调用点既有解析（多已含 ``loads_lenient`` 剥围栏 + 截平衡子串）。
+        fallback: 降级路径（现有 litellm 直调整体包成 async thunk）；返回与 Faculty 命中
+            同型结果。``run_faculty_json`` 保证：Faculty 文本为空 / 超时 / 解析返回 None →
+            走 ``fallback``，**批任务绝不因 Faculty JSON 破损而失败**（硬闸）。
+        enabled: ``settings.routine.faculty_bridge_enabled and settings.routine.<group>_enabled``
+            由调用方算好（总开关 AND 组开关）。``False`` → 直接走 ``fallback``。
+        timeout_seconds: 单次超时；批处理类建议传 ``faculty_bridge_batch_timeout_seconds``。
+        read_only: 默认 True——剥离副作用工具（见 ``_READONLY_TOOL_ALLOWLIST``）。评审 / 判定
+            类若确需 Faculty 调用只读工具，可显式传 False（须论证副作用已隔离）。
+        user_id: 审计用 user 标识。
+
+    Returns:
+        ``(result, used_faculty)``——``used_faculty`` 标识结果是否来自真实 Faculty（供归因 / 可观测）。
+    """
+    budget = _faculty_budget.get()
+    if enabled and (budget is None or budget > 0):
+        try:
+            text = await run_faculty(
+                role,
+                task_prompt,
+                timeout_seconds=timeout_seconds,
+                user_id=user_id,
+                read_only=read_only,
+            )
+        except Exception:  # pragma: no cover - run_faculty 内部已吞，双保险
+            text = None
+        if text:
+            try:
+                parsed = parse(text)
+            except Exception:
+                logger.info("faculty_bridge_json_parse_failed_fallback", role=role)
+                parsed = None
+            if parsed is not None:
+                if budget is not None:
+                    _faculty_budget.set(budget - 1)
+                return parsed, True
+            logger.info("faculty_bridge_empty_or_unparsed_fallback", role=role)
+        else:
+            logger.info("faculty_bridge_no_text_fallback", role=role)
+
+    result = await fallback()
+    return result, False
 
 
 async def _drive(agent: BaseAgent, task_prompt: str, *, user_id: str) -> str | None:
@@ -143,4 +277,9 @@ async def run_with_fallback(
     return await fallback(), False
 
 
-__all__ = ["run_faculty", "run_with_fallback"]
+__all__ = [
+    "run_faculty",
+    "run_faculty_json",
+    "run_with_fallback",
+    "faculty_bridge_budget",
+]

--- a/apps/negentropy/src/negentropy/engine/routine/memory_extractor.py
+++ b/apps/negentropy/src/negentropy/engine/routine/memory_extractor.py
@@ -426,8 +426,11 @@ class IterationMemoryExtractor:
         enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_memory_extract_enabled
 
         def parse(text: str) -> tuple[list[ExtractedMemory], float, str] | None:
-            # 解析失败（非 dict）→ None 触发降级；有效 dict（含空 memories）→ 接受。
-            if not isinstance(loads_lenient(text), dict):
+            # 缺 memories 键 / 非 dict → None 触发降级；含空 memories 的合法 dict → 接受。
+            # 注：loads_lenient 解析失败恒返回 {}（见 json_extract），故须靠键存在性而非
+            # isinstance(dict) 辨别脏输出，否则散文脏文本会被误判为「命中」而不降级 litellm。
+            data = loads_lenient(text)
+            if not isinstance(data, dict) or "memories" not in data:
                 return None
             return self._parse_response(text), 0.0, "InternalizationFaculty"
 
@@ -437,7 +440,9 @@ class IterationMemoryExtractor:
                 return [], cost, self._model
             return self._parse_response(content), cost, self._model
 
-        return await run_faculty_json(
+        # run_faculty_json 返回 (result, used_faculty)；解包丢弃 flag，仅回 3 元组结果，
+        # 与调用方（extract_on_iteration / extract_on_termination）的三目标解包契合。
+        result, _used = await run_faculty_json(
             "internalization",
             prompt,
             parse=parse,
@@ -446,6 +451,7 @@ class IterationMemoryExtractor:
             timeout_seconds=float(settings.routine.faculty_bridge_batch_timeout_seconds),
             read_only=True,
         )
+        return result
 
     @staticmethod
     def _parse_response(content: str) -> list[ExtractedMemory]:

--- a/apps/negentropy/src/negentropy/engine/routine/memory_extractor.py
+++ b/apps/negentropy/src/negentropy/engine/routine/memory_extractor.py
@@ -26,6 +26,7 @@ from typing import Any
 
 import litellm
 
+from negentropy.engine.routine.faculty_bridge import run_faculty_json
 from negentropy.engine.utils.json_extract import loads_lenient
 from negentropy.engine.utils.model_config import resolve_model_config_async
 from negentropy.logging import get_logger
@@ -261,16 +262,8 @@ class IterationMemoryExtractor:
         if not prompt:
             return MemoryExtractionResult(memories=[])
 
-        content, cost = await self._call_llm(prompt)
-        if not content:
-            return MemoryExtractionResult(memories=[], cost_usd=cost, model_used=self._model)
-
-        memories = self._parse_response(content)
-        return MemoryExtractionResult(
-            memories=memories,
-            cost_usd=cost,
-            model_used=self._model,
-        )
+        memories, cost, model = await self._extract_memories(prompt)
+        return MemoryExtractionResult(memories=memories, cost_usd=cost, model_used=model)
 
     # ------------------------------------------------------------------
     # 终止时批量提取
@@ -297,16 +290,8 @@ class IterationMemoryExtractor:
         if not prompt:
             return MemoryExtractionResult(memories=[])
 
-        content, cost = await self._call_llm(prompt)
-        if not content:
-            return MemoryExtractionResult(memories=[], cost_usd=cost, model_used=self._model)
-
-        memories = self._parse_response(content)
-        return MemoryExtractionResult(
-            memories=memories,
-            cost_usd=cost,
-            model_used=self._model,
-        )
+        memories, cost, model = await self._extract_memories(prompt)
+        return MemoryExtractionResult(memories=memories, cost_usd=cost, model_used=model)
 
     # ------------------------------------------------------------------
     # Prompt 构建
@@ -427,6 +412,40 @@ class IterationMemoryExtractor:
     # ------------------------------------------------------------------
     # 响应解析
     # ------------------------------------------------------------------
+
+    async def _extract_memories(self, prompt: str) -> tuple[list[ExtractedMemory], float, str]:
+        """LLM 提取记忆：FacultyBridge(internalization, read_only) 优先 + litellm 兜底（WS2 收编）。
+
+        命中 Faculty → cost=0.0（无 response 对象）、model=``InternalizationFaculty``（模型由
+        ``agents.model`` 决定）；降级 → 沿用 task_registry 模型 + litellm。开关关（默认）→ 直接
+        litellm，行为与改造前逐字节等价。``read_only=True`` 剥离副作用工具（save_to_memory 等），
+        防自治 Faculty 在 approval=never 下静默写记忆。
+        """
+        from negentropy.config import settings
+
+        enabled = settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_memory_extract_enabled
+
+        def parse(text: str) -> tuple[list[ExtractedMemory], float, str] | None:
+            # 解析失败（非 dict）→ None 触发降级；有效 dict（含空 memories）→ 接受。
+            if not isinstance(loads_lenient(text), dict):
+                return None
+            return self._parse_response(text), 0.0, "InternalizationFaculty"
+
+        async def fallback() -> tuple[list[ExtractedMemory], float, str]:
+            content, cost = await self._call_llm(prompt)
+            if not content:
+                return [], cost, self._model
+            return self._parse_response(content), cost, self._model
+
+        return await run_faculty_json(
+            "internalization",
+            prompt,
+            parse=parse,
+            fallback=fallback,
+            enabled=enabled,
+            timeout_seconds=float(settings.routine.faculty_bridge_batch_timeout_seconds),
+            read_only=True,
+        )
 
     @staticmethod
     def _parse_response(content: str) -> list[ExtractedMemory]:

--- a/apps/negentropy/src/negentropy/engine/routine/plan_reviewer.py
+++ b/apps/negentropy/src/negentropy/engine/routine/plan_reviewer.py
@@ -192,7 +192,7 @@ class PlanReviewer:
         """
         from negentropy.config import settings
 
-        if settings.routine.faculty_bridge_enabled:
+        if settings.routine.faculty_bridge_enabled and settings.routine.faculty_bridge_review_enabled:
             with suppress(Exception):
                 from negentropy.engine.routine.faculty_bridge import run_faculty
 

--- a/apps/negentropy/src/negentropy/interface/agent_presets.py
+++ b/apps/negentropy/src/negentropy/interface/agent_presets.py
@@ -13,6 +13,7 @@ from typing import Any
 
 from google.adk.agents import BaseAgent, LlmAgent, LoopAgent, ParallelAgent, SequentialAgent
 
+from negentropy.agents._dynamic_tools import NegentropyToolset
 from negentropy.agents.agent import root_agent
 from negentropy.agents.faculties import (
     action_agent,
@@ -21,6 +22,10 @@ from negentropy.agents.faculties import (
     internalization_agent,
     perception_agent,
 )
+
+# 命名单源：``_tool_name`` 委派到 registry.tool_name，保证 sync 落库的 ``agents.tools`` 与
+# ``NegentropyToolset`` 的注册表键逐字一致（消除正 / 反向命名漂移）。
+from negentropy.agents.tools.registry import tool_name as _tool_name
 from negentropy.model_names import canonicalize_model_name
 from negentropy.serialization import to_json_compatible
 
@@ -68,14 +73,27 @@ def _callable_name(callback: Any) -> str | None:
     return callback.__class__.__name__
 
 
-def _tool_name(tool: Any) -> str:
-    name = getattr(tool, "name", None)
-    if isinstance(name, str) and name:
-        return name
-    func_name = getattr(tool, "__name__", None)
-    if isinstance(func_name, str) and func_name:
-        return func_name
-    return tool.__class__.__name__
+def _expand_tool_names(agent: BaseAgent) -> list[str]:
+    """展开 ``agent.tools`` 为稳定的工具名数组（保序去重）。
+
+    WS1：faculty 的可摘工具集以 ``NegentropyToolset`` 承载，直接 ``_tool_name`` 会得到类名
+    ``NegentropyToolset``，污染 sync 落库的 ``agents.tools``。此处对 toolset 展开为其
+    ``configured_tool_names()``（恒常 + 默认），使 sync 出的 tools 仍是稳定工具名数组、
+    与改造前逐字节一致（mandatory 既在常量位又在 configured 里，去重消除重复）。
+    """
+    names: list[str] = []
+    for tool in getattr(agent, "tools", None) or []:
+        if isinstance(tool, NegentropyToolset):
+            names.extend(tool.configured_tool_names())
+        else:
+            names.append(_tool_name(tool))
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for name in names:
+        if name not in seen:
+            seen.add(name)
+            ordered.append(name)
+    return ordered
 
 
 def _model_name(model: Any) -> str | None:
@@ -117,7 +135,7 @@ def serialize_adk_config(agent: BaseAgent) -> dict[str, Any]:
             {
                 "instruction": agent.instruction,
                 "model": _model_name(agent.model),
-                "tools": [_tool_name(tool) for tool in (agent.tools or [])],
+                "tools": _expand_tool_names(agent),
                 "output_key": agent.output_key,
                 "include_contents": to_json_compatible(agent.include_contents),
                 "disallow_transfer_to_parent": agent.disallow_transfer_to_parent,

--- a/apps/negentropy/tests/unit_tests/agents/test_dynamic_tools.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_dynamic_tools.py
@@ -1,0 +1,139 @@
+"""NegentropyToolset 单测 — WS1 tools 运行时回源（纯逻辑，无真实 DB）。
+
+覆盖：
+- **flag-off 零回归**（默认）：``get_tools`` 恒返回 ``default_names``，与硬编码逐字节等价；
+- flag-on 回源：DB 子集 → 仅返回子集；白名单挡跨翼高危工具；别名归一；
+- fail-soft：``_resolve_names`` 异常 → 回退 default；
+- 序列化 ``configured_tool_names`` 稳定（供 sync 落库）。
+
+flag-on 路径用 monkeypatch ``_resolve_names`` 模拟 DB 返回（绕过 frozen settings 的 flag 检查），
+聚焦白名单 / mandatory / 别名过滤逻辑（安全关键）。
+"""
+
+from __future__ import annotations
+
+from google.adk.tools.base_toolset import BaseToolset
+
+from negentropy.agents._dynamic_tools import NegentropyToolset
+from negentropy.agents.faculties import action_agent, perception_agent
+
+
+def _toolset_of(agent) -> NegentropyToolset:
+    return [t for t in agent.tools if isinstance(t, BaseToolset)][0]
+
+
+def _names(tools) -> list[str]:
+    return sorted(t.name for t in tools)
+
+
+async def test_flag_off_returns_default_zero_regression():
+    """开关默认关 → faculty 自身 toolset 返回 default_names（mandatory 在常量位不在此处）。"""
+    ts = _toolset_of(perception_agent)
+    tools = await ts.get_tools(None)
+    assert _names(tools) == sorted(
+        [
+            "search_knowledge_base",
+            "search_knowledge_graph_global",
+            "search_knowledge_graph_with_papers",
+            "search_web",
+            "search_papers",
+        ]
+    )
+    # mandatory（log_activity / load_memory）在常量位挂载，toolset 不重复产出
+    assert "log_activity" not in _names(tools)
+    assert "load_memory" not in _names(tools)
+
+
+async def test_flag_on_db_subset(monkeypatch):
+    """flag-on + DB 返回子集 → 仅返回子集（经白名单）。"""
+    ts = NegentropyToolset(
+        agent_name="PerceptionFaculty",
+        default_names=["search_knowledge_base", "search_web", "search_papers"],
+        mandatory_names=["log_activity", "load_memory"],
+    )
+
+    async def fake_resolve():
+        return ["search_web"]  # DB 仅配 search_web
+
+    monkeypatch.setattr(ts, "_resolve_names", fake_resolve)
+    assert _names(await ts.get_tools(None)) == ["search_web"]
+
+
+async def test_flag_on_disallowed_high_risk_dropped(monkeypatch):
+    """DB 给 Perception 配 invoke_claude_code（跨翼高危）→ 白名单丢弃 + warn。"""
+    ts = NegentropyToolset(
+        agent_name="PerceptionFaculty",
+        default_names=["search_web"],
+        mandatory_names=["log_activity"],
+    )
+
+    async def fake_resolve():
+        return ["search_web", "invoke_claude_code"]
+
+    monkeypatch.setattr(ts, "_resolve_names", fake_resolve)
+    names = _names(await ts.get_tools(None))
+    assert "search_web" in names
+    assert "invoke_claude_code" not in names  # 被白名单挡
+
+
+async def test_flag_on_alias_resolved(monkeypatch):
+    """DB 存别名 ``claude_code`` → 归一为 ``invoke_claude_code``（Action 允许）。"""
+    ts = NegentropyToolset(
+        agent_name="ActionFaculty",
+        default_names=["execute_code", "invoke_claude_code"],
+        mandatory_names=["log_activity"],
+    )
+
+    async def fake_resolve():
+        return ["claude_code"]  # DB 用 BuiltinTool 命名
+
+    monkeypatch.setattr(ts, "_resolve_names", fake_resolve)
+    assert _names(await ts.get_tools(None)) == ["invoke_claude_code"]
+
+
+async def test_flag_on_mandatory_dropped_even_if_in_db(monkeypatch):
+    """DB 误列 mandatory（log_activity）→ toolset 不重复产出（已在常量位）。"""
+    ts = NegentropyToolset(
+        agent_name="PerceptionFaculty",
+        default_names=["search_web"],
+        mandatory_names=["log_activity", "load_memory"],
+    )
+
+    async def fake_resolve():
+        return ["search_web", "log_activity", "load_memory"]
+
+    monkeypatch.setattr(ts, "_resolve_names", fake_resolve)
+    assert _names(await ts.get_tools(None)) == ["search_web"]
+
+
+async def test_resolve_failure_falls_back_to_default(monkeypatch):
+    """_resolve_names 异常 → get_tools 回退 default（永不阻塞）。"""
+    ts = NegentropyToolset(
+        agent_name="PerceptionFaculty",
+        default_names=["search_web", "search_papers"],
+        mandatory_names=["log_activity"],
+    )
+
+    async def boom():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(ts, "_resolve_names", boom)
+    assert _names(await ts.get_tools(None)) == ["search_papers", "search_web"]
+
+
+def test_configured_tool_names_stable_for_sync():
+    """``configured_tool_names`` 返回「mandatory + default」保序去重，供 sync 落库。"""
+    ts = NegentropyToolset(
+        agent_name="PerceptionFaculty",
+        default_names=["search_web", "search_papers"],
+        mandatory_names=["log_activity", "load_memory"],
+    )
+    assert ts.configured_tool_names() == ["log_activity", "load_memory", "search_web", "search_papers"]
+
+
+async def test_action_faculty_flag_off_keeps_invoke_claude_code():
+    """flag-off 时 Action 保留 invoke_claude_code（别名 bug 回归锚：claude_code 不再被误删）。"""
+    ts = _toolset_of(action_agent)
+    names = _names(await ts.get_tools(None))
+    assert "invoke_claude_code" in names
+    assert "execute_code" in names

--- a/apps/negentropy/tests/unit_tests/agents/test_tool_registry.py
+++ b/apps/negentropy/tests/unit_tests/agents/test_tool_registry.py
@@ -1,0 +1,81 @@
+"""工具注册表单测 — 命名单源、别名归一、fail-soft（纯逻辑，无 DB）。
+
+覆盖 WS1 的名解析基座：
+- 正/反映射同口径（``tool_name(sym) == key``），消除 sync 落库与运行时解析的命名漂移；
+- ``claude_code`` 别名归一到 ``invoke_claude_code``（BuiltinTool 历史命名兼容）；
+- 未知名 fail-soft（log warning 后丢弃，绝不抛）。
+"""
+
+from __future__ import annotations
+
+from negentropy.agents.tools.registry import (
+    TOOL_REGISTRY,
+    canonicalize_tool_name,
+    resolve_tool_names,
+    tool_name,
+)
+
+
+def test_registry_self_consistent_naming():
+    """每个注册表键 = ``tool_name(符号)``：正/反映射同口径，消除漂移。"""
+    for key, sym in TOOL_REGISTRY.items():
+        assert tool_name(sym) == key, f"naming drift: key={key!r} tool_name={tool_name(sym)!r}"
+
+
+def test_registry_covers_six_faculty_tools():
+    """六翼所需工具全部登记（含 mandatory 与各翼可摘工具）。"""
+    expected = {
+        # 通用 / 记忆
+        "log_activity",
+        "load_memory",
+        "preload_memory",
+        # 感知
+        "search_knowledge_base",
+        "search_web",
+        "search_knowledge_graph_global",
+        "search_knowledge_graph_with_papers",
+        "search_papers",
+        # 内化
+        "save_to_memory",
+        "update_knowledge_graph",
+        "ingest_paper",
+        "ingest_to_corpus",
+        # 沉思
+        "analyze_context",
+        "create_plan",
+        # 行动
+        "execute_code",
+        "read_file",
+        "write_file",
+        "invoke_claude_code",
+        # 影响
+        "publish_content",
+        "send_notification",
+    }
+    assert expected <= set(TOOL_REGISTRY), f"missing: {expected - set(TOOL_REGISTRY)}"
+
+
+def test_alias_canonicalization():
+    assert canonicalize_tool_name("claude_code") == "invoke_claude_code"
+    # 已规范名原样返回
+    assert canonicalize_tool_name("invoke_claude_code") == "invoke_claude_code"
+    assert canonicalize_tool_name("search_web") == "search_web"
+
+
+def test_resolve_alias_returns_real_callable():
+    """别名 ``claude_code`` 解析为 ``invoke_claude_code`` 的真实 callable。"""
+    resolved = resolve_tool_names(["claude_code"])
+    assert len(resolved) == 1
+    assert tool_name(resolved[0]) == "invoke_claude_code"
+
+
+def test_resolve_unknown_skipped_fail_soft():
+    """未知名 log warning 后丢弃，绝不抛；合法名仍解析。"""
+    resolved = resolve_tool_names(["__nonexistent__", "search_web", "another_bogus"])
+    assert len(resolved) == 1
+    assert tool_name(resolved[0]) == "search_web"
+
+
+def test_resolve_none_and_empty():
+    assert resolve_tool_names(None) == []
+    assert resolve_tool_names([]) == []

--- a/apps/negentropy/tests/unit_tests/engine/eval/test_faculty_boundary.py
+++ b/apps/negentropy/tests/unit_tests/engine/eval/test_faculty_boundary.py
@@ -1,0 +1,31 @@
+"""eval 元层 Faculty 边界反向断言（WS2）。
+
+eval/runner（评测执行器）与 attack_generator（红队）是「元层」——用系统自身当 Judge/攻击者
+去评测/攻击被测 target。刻意**不接 FacultyBridge**：走六翼会造成循环偏置（元神评判修改元神
+自己的提案）、破坏 holdout 独立性、且多轮 tool-loop 结构与单发 Faculty 范式不兼容。
+
+本测试固化该边界：断言这两个模块的命名空间**未导入** FacultyBridge 相关符号，防止未来
+「顺手补齐」引入循环偏置。
+"""
+
+from __future__ import annotations
+
+import negentropy.engine.eval.attack_generator as attack_mod
+import negentropy.engine.eval.runner as runner_mod
+
+# 禁止 eval 元层导入的 FacultyBridge 符号（任一出现即破坏评测独立性）。
+_FORBIDDEN_ATTRS = ("run_faculty_json", "run_faculty", "run_with_fallback", "faculty_bridge")
+
+
+def test_eval_runner_namespace_excludes_faculty_bridge():
+    for attr in _FORBIDDEN_ATTRS:
+        assert not hasattr(runner_mod, attr), (
+            f"eval/runner 不得导入 FacultyBridge 符号 {attr!r}（评测元层须保持独立，防循环偏置）"
+        )
+
+
+def test_attack_generator_namespace_excludes_faculty_bridge():
+    for attr in _FORBIDDEN_ATTRS:
+        assert not hasattr(attack_mod, attr), (
+            f"attack_generator 不得导入 FacultyBridge 符号 {attr!r}（红队元层须保持独立）"
+        )

--- a/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_claude_code_service.py
@@ -825,7 +825,7 @@ async def test_auto_answer_question_uses_faculty_bridge_when_enabled(monkeypatch
     try:
         captured: dict = {}
 
-        async def _fake_run_faculty(role, prompt, *, timeout_seconds=90.0):
+        async def _fake_run_faculty(role, prompt, *, timeout_seconds=90.0, read_only=False, **_):
             captured["role"] = role
             return '{"answers": ["120ms 去抖方案"]}'
 
@@ -854,7 +854,7 @@ async def test_auto_answer_question_falls_back_when_faculty_returns_none(monkeyp
     try:
         import negentropy.engine.routine.faculty_bridge as fb
 
-        async def _none_faculty(role, prompt, *, timeout_seconds=90.0):
+        async def _none_faculty(role, prompt, *, timeout_seconds=90.0, read_only=False, **_):
             return None
 
         monkeypatch.setattr(fb, "run_faculty", _none_faculty)

--- a/apps/negentropy/tests/unit_tests/engine/test_routine_faculty_bridge.py
+++ b/apps/negentropy/tests/unit_tests/engine/test_routine_faculty_bridge.py
@@ -31,14 +31,14 @@ async def test_run_faculty_unknown_role_returns_none():
 @pytest.mark.asyncio
 async def test_run_faculty_build_failure_returns_none(monkeypatch):
     """Faculty 构造异常（如 ADK 不可用）→ None（调用方降级）。"""
-    monkeypatch.setattr(faculty_bridge, "_build_faculty_agent", lambda role: None)
+    monkeypatch.setattr(faculty_bridge, "_build_faculty_agent", lambda role, *, read_only=False: None)
     assert await faculty_bridge.run_faculty("contemplation", "task") is None
 
 
 @pytest.mark.asyncio
 async def test_run_faculty_timeout_returns_none(monkeypatch):
     """_drive 超时 → None。"""
-    monkeypatch.setattr(faculty_bridge, "_build_faculty_agent", lambda role: object())
+    monkeypatch.setattr(faculty_bridge, "_build_faculty_agent", lambda role, *, read_only=False: object())
 
     async def _slow(*args, **kwargs):
         await asyncio.sleep(10)
@@ -50,7 +50,7 @@ async def test_run_faculty_timeout_returns_none(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_run_faculty_drive_exception_returns_none(monkeypatch):
-    monkeypatch.setattr(faculty_bridge, "_build_faculty_agent", lambda role: object())
+    monkeypatch.setattr(faculty_bridge, "_build_faculty_agent", lambda role, *, read_only=False: object())
 
     async def _boom(*args, **kwargs):
         raise RuntimeError("adk down")
@@ -61,7 +61,7 @@ async def test_run_faculty_drive_exception_returns_none(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_run_faculty_success_returns_text(monkeypatch):
-    monkeypatch.setattr(faculty_bridge, "_build_faculty_agent", lambda role: object())
+    monkeypatch.setattr(faculty_bridge, "_build_faculty_agent", lambda role, *, read_only=False: object())
 
     async def _ok(*args, **kwargs):
         return '{"verdict": "approve"}'
@@ -168,3 +168,168 @@ async def test_drive_precreate_failure_does_not_block(monkeypatch):
     result = await faculty_bridge._drive(object(), "task", user_id="u")
     assert result is None
     assert runner_called, "预创建失败后 runner 仍应被调用"
+
+
+# ---------------------------------------------------------------------------
+# WS2: run_faculty_json（Faculty 优先 + litellm 兜底）+ read_only 护栏 + budget
+# ---------------------------------------------------------------------------
+
+
+async def test_run_faculty_json_disabled_goes_fallback(monkeypatch):
+    """enabled=False → 直接 fallback，run_faculty 不被调用。"""
+    called: list = []
+
+    async def _fac(*a, **kw):
+        called.append(1)
+        return "should-not-reach"
+
+    monkeypatch.setattr(faculty_bridge, "run_faculty", _fac)
+
+    async def _fallback():
+        return {"v": "litellm"}
+
+    res, used = await faculty_bridge.run_faculty_json(
+        "contemplation", "p", parse=lambda s: {"v": s}, fallback=_fallback, enabled=False
+    )
+    assert res == {"v": "litellm"}
+    assert used is False
+    assert not called  # faculty 未触发
+
+
+async def test_run_faculty_json_hit_returns_parsed(monkeypatch):
+    """faculty 返回有效文本 + parse 非 None → 用之，fallback 不调用。"""
+    fb_called: list = []
+
+    async def _fac(*a, **kw):
+        return '{"score": 88}'
+
+    monkeypatch.setattr(faculty_bridge, "run_faculty", _fac)
+
+    async def _fallback():
+        fb_called.append(1)
+        return {"score": 0}
+
+    def _parse(text):
+        import json
+
+        d = json.loads(text)
+        return {"score": d["score"]} if isinstance(d, dict) and "score" in d else None
+
+    res, used = await faculty_bridge.run_faculty_json(
+        "contemplation", "p", parse=_parse, fallback=_fallback, enabled=True
+    )
+    assert res == {"score": 88}
+    assert used is True
+    assert not fb_called
+
+
+async def test_run_faculty_json_none_text_falls_back(monkeypatch):
+    """faculty 返回 None → 降级 fallback。"""
+
+    async def _fac(*a, **kw):
+        return None
+
+    monkeypatch.setattr(faculty_bridge, "run_faculty", _fac)
+
+    async def _fallback():
+        return "litellm"
+
+    res, used = await faculty_bridge.run_faculty_json(
+        "contemplation", "p", parse=lambda s: s, fallback=_fallback, enabled=True
+    )
+    assert res == "litellm"
+    assert used is False
+
+
+async def test_run_faculty_json_parse_none_falls_back(monkeypatch):
+    """parse 返回 None（脏文本 / 非预期）→ 降级 fallback（硬闸）。"""
+
+    async def _fac(*a, **kw):
+        return "garbage not json"
+
+    monkeypatch.setattr(faculty_bridge, "run_faculty", _fac)
+
+    async def _fallback():
+        return "litellm-clean"
+
+    res, used = await faculty_bridge.run_faculty_json(
+        "contemplation", "p", parse=lambda s: None, fallback=_fallback, enabled=True
+    )
+    assert res == "litellm-clean"
+    assert used is False
+
+
+async def test_run_faculty_json_budget_exhausted_skips_faculty(monkeypatch):
+    """budget=0 + enabled=True → 跳过 faculty 直接 fallback（成本护栏）。"""
+    fac_called: list = []
+
+    async def _fac(*a, **kw):
+        fac_called.append(1)
+        return '{"score": 1}'
+
+    monkeypatch.setattr(faculty_bridge, "run_faculty", _fac)
+
+    async def _fallback():
+        return "litellm"
+
+    async with faculty_bridge.faculty_bridge_budget(0):
+        res, used = await faculty_bridge.run_faculty_json(
+            "contemplation", "p", parse=lambda s: "x", fallback=_fallback, enabled=True
+        )
+    assert res == "litellm"
+    assert used is False
+    assert not fac_called
+
+
+async def test_read_only_strips_side_effect_tools():
+    """read_only=True：Internalization 剥离副作用工具 + 整体剔除 BaseToolset。
+
+    核心安全测试（破解「副作用工具陷阱」）：桥接层注入 approval=never，若不剥离，
+    save_to_memory / update_knowledge_graph / ingest_* 会在无人在环下静默真写。
+    """
+    from google.adk.tools.base_toolset import BaseToolset
+
+    from negentropy.agents.tools.registry import tool_name
+
+    agent = faculty_bridge._build_faculty_agent("internalization", read_only=True)
+    tool_names = {tool_name(t) for t in agent.tools}
+    # 恒常只读工具保留
+    assert "log_activity" in tool_names
+    assert "load_memory" in tool_names
+    # 副作用工具全部剥离
+    for side_effect in ("save_to_memory", "update_knowledge_graph", "ingest_paper", "ingest_to_corpus"):
+        assert side_effect not in tool_names, f"read_only 未剥离副作用工具 {side_effect!r}"
+    # BaseToolset 整体剔除（副作用工具藏于其内）
+    assert not any(isinstance(t, BaseToolset) for t in agent.tools)
+
+
+async def test_read_only_false_keeps_toolset():
+    """read_only=False（默认）：保留 BaseToolset（完整可摘工具集）。"""
+    from google.adk.tools.base_toolset import BaseToolset
+
+    agent = faculty_bridge._build_faculty_agent("internalization", read_only=False)
+    assert any(isinstance(t, BaseToolset) for t in agent.tools)
+
+
+async def test_faculty_bridge_budget_decrements_on_hit(monkeypatch):
+    """budget 命中后自减；第二次调用仍可命中（budget>0），第三次耗尽则降级。"""
+
+    async def _fac(*a, **kw):
+        return "ok"
+
+    monkeypatch.setattr(faculty_bridge, "run_faculty", _fac)
+
+    async def _fallback():
+        return "litellm"
+
+    async with faculty_bridge.faculty_bridge_budget(2):
+        _, u1 = await faculty_bridge.run_faculty_json(
+            "contemplation", "p", parse=lambda s: s, fallback=_fallback, enabled=True
+        )
+        _, u2 = await faculty_bridge.run_faculty_json(
+            "contemplation", "p", parse=lambda s: s, fallback=_fallback, enabled=True
+        )
+        _, u3 = await faculty_bridge.run_faculty_json(
+            "contemplation", "p", parse=lambda s: s, fallback=_fallback, enabled=True
+        )
+    assert (u1, u2, u3) == (True, True, False)  # 第三次耗尽 → 降级

--- a/apps/negentropy/tests/unit_tests/interface/test_agent_presets.py
+++ b/apps/negentropy/tests/unit_tests/interface/test_agent_presets.py
@@ -12,17 +12,17 @@ from negentropy.interface.agent_presets import (
     KIND_AGENT,
     KIND_ROOT,
     NEGENTROPY_AGENT_NAMES,
+    _expand_tool_names,
     build_negentropy_agent_payloads,
 )
 from negentropy.model_names import canonicalize_model_name
 
 
 def _tool_names(agent) -> list[str]:
-    names: list[str] = []
-    for tool in agent.tools or []:
-        name = getattr(tool, "name", None) or getattr(tool, "__name__", None) or tool.__class__.__name__
-        names.append(name)
-    return names
+    # 复用生产序列化的展开逻辑：WS1 后可摘工具以 NegentropyToolset 承载，直接取类名会得到
+    # 'NegentropyToolset'，与 build_negentropy_agent_payloads 落库的稳定工具名数组不符。委派到
+    # 生产的 _expand_tool_names（toolset → configured_tool_names，保序去重），保证测试口径单源一致。
+    return _expand_tool_names(agent)
 
 
 def test_builtin_payload_count_and_order():


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：系统中对「一核五翼」6 个 Agent 的调用未完全落到 Interface/Agents 页配置的单一实例——六翼 `tools` 运行时未回读 DB（UI 编辑不生效，`_load_subagent_row` SELECT 了 `Agent.tools` 却丢弃）；memory_extractor / consolidation / evolution proposer 等后台 LLM 直调 litellm 绕过六翼。
- 关联上下文/Issue/文档：ADR `docs/concepts/040-routine-multi-agent-faculty.md`；AGENTS.md「单一事实源」「最小干预」「Verification Before Done」。循证核查：六翼「身份/指令/模型/技能」此前已是单例+单源（每轮按 name 读 DB、全库无分叉克隆），真正缺口仅上述两处。

# 核心变更
- **WS1 tools 运行时回源**：新增 `agents/tools/registry.py`（工具名→callable 单源，`tool_name` 命名口径供 sync 序列化与运行时解析共用、消除漂移；`claude_code→invoke_claude_code` 别名兼容 BuiltinTool 命名）+ `agents/_dynamic_tools.py::NegentropyToolset`（亲验 ADK 2.2.0 `BaseToolset.get_tools(readonly_context)` 为 per-invocation 解析，复用 `subagent:<name>` 60s TTL 缓存行，**单例 faculty 无需重建**；每翼 `allowed` 白名单防跨翼挂高危工具，fail-soft 回退 default）。`_load_subagent_row` 不再丢弃 tools，新增 `resolve_subagent_tool_names`；5 faculty 工厂可摘工具集改由 toolset 承载（恒常工具留常量位）；`serialize_adk_config` 展开 toolset 为稳定名数组。新增 `AgentsSettings.tools_from_db_enabled` 总开关**默认关**。
- **WS2 后台 LLM 收编**：`FacultyBridge` 新增 `run_faculty_json`（Faculty 优先+litellm 兜底，`parse→None` 即降级的**硬闸**保证批任务不因 JSON 破损失败）+ `read_only` 护栏（整体剔除 `BaseToolset`+只留白名单，**破解副作用工具陷阱**：桥接层 `approval=never` 下剥离 Internalization 的 `save_to_memory`/`update_knowledge_graph`/`ingest_*`，防静默写记忆/KG）+ `faculty_bridge_budget` 单任务调用上限成本护栏。`config/routine` 加 review/memory_extract/consolidation/evolution 四组子开关挂总 kill-switch 下（**默认全关**）+ `batch_timeout`/`max_calls_per_task`。`memory_summarizer`/`entity_normalization`/`claude_code` 严格 `json.loads`→`loads_lenient`。6 站点接入 `run_faculty_json`（memory_extractor/fact_extractor/summarizer/entity→internalization；reflection/proposer 3 子类→contemplation，均 read_only）。`eval/runner`+`attack_generator` 刻意排除（评测元层，循环偏置）+反向断言固化边界；`task_registry` 槽位补模型单源迁移注释。

# 风险与回滚
- 主要风险：`tools_from_db_enabled` 开启前若 DB tools 陈旧会丢失代码新增工具（故默认关，须先重新 Sync 对齐）；faculty_bridge 组开关开启后单 worker 阻塞放大（已加 `batch_timeout`+`max_calls` 护栏 + `read_only` 抑制工具漫游）。
- 回滚方式：所有新增能力均由开关门控，默认关 = 逐字节等价改造前；任一组异常翻对应开关 False 即秒级回基线，**无需 revert 代码**。

# 验证证据
- 单元测试：新增 34 + 既有 50（subagent/approval）无回归，共 **84 通过**；覆盖 registry 命名/别名/fail-soft、toolset flag-off 零回归/flag-on 回源/白名单安全/别名修正、`run_faculty_json` 命中/降级/开关关/budget、`read_only` 剥离副作用工具、eval 边界反向断言。
- 集成测试：DB 依赖套件受共享测试库 alembic 漂移阻断（记忆已知，非本次引入）；纯逻辑测试以「复制到临时目录脱离 DB autouse」跑通。
- E2E/Workflow：未跑（开关默认关、零行为变更；激活路径见 Next Best Action）。
- 覆盖率/关键截图：ruff lint+format 全过；6 payloads 序列化校验通过；flag 默认值实证（`tools_from_db_enabled=False`、`faculty_bridge_enabled=False`）。

# 影响范围
- 前端：无（Interface/Agents 页 tools 字段语义不变；开启 `tools_from_db_enabled` 后 UI 编辑 tools 真正生效）。
- 后端：`agents/`、`config/`、`engine/{routine,consolidation,claude_code,eval,evolution}`、`interface/agent_presets`；新增 2 模块（registry、_dynamic_tools）+ 1 配置段（AgentsSettings）。
- GitHub Actions / 文档：`task_registry` 槽位注释更新；建议后续同步 ADR 040 补 WS1/WS2 开关说明（本次未改文档）。

# Next Best Action
- 激活（分期灰度）：① `POST /interface/agents/sync/negentropy` 使 DB tools 对齐代码 → 翻 `NE_AGENTS_TOOLS_FROM_DB_ENABLED=true`；② 翻 `faculty_bridge_enabled=true`（review 组默认 true）点亮评审三点；③ 逐个点亮 memory_extract/consolidation/evolution 组，观测 `used_faculty` 命中率与单 worker 延迟。
- 单独跟进：`engine/consolidation/memory_service.py:~397` `extract()` 疑似 async 未 await（协程被丢弃、`for fact in extracted` 恐抛 TypeError），建议先核实再单独 PR。

🤖 Generated with [Claude Code](https://github.com/claude), [CodeX](https://openai.com), [Gemini](https://github.com/apps/gemini-code-assist)
Co-Authored-By: Aurelius Huang<threefish.ai@gmail.com>