### PR TITLE
fix(site-header): 修复 Document View 页顶部导航栏左移,恢复全局右靠一致

### DIFF
--- a/apps/negentropy-ui/components/layout/SiteHeader.tsx
+++ b/apps/negentropy-ui/components/layout/SiteHeader.tsx
@@ -13,10 +13,10 @@ export function SiteHeader({ children }: { children?: React.ReactNode }) {
 
   return (
     <div className="sticky top-0 z-30 border-b border-border bg-card/85 px-6 py-2 backdrop-blur-md">
-      <div className="flex flex-wrap items-center justify-between gap-2">
+      <div className="flex items-center justify-between gap-4">
         {/* Brand + Location */}
-        <div className="flex items-center gap-6">
-          <Link href="/" className="flex items-center gap-0">
+        <div className="flex min-w-0 items-center gap-6">
+          <Link href="/" className="flex shrink-0 items-center gap-0">
             <Image
               src="/logo.svg"
               alt="Negentropy"
@@ -31,10 +31,15 @@ export function SiteHeader({ children }: { children?: React.ReactNode }) {
 
           {/* Location breadcrumb from secondary nav */}
           {navigationInfo && (
-            <div className="flex items-center gap-2 text-sm text-text-secondary">
-              <span className="text-text-muted">{navigationInfo.moduleLabel}</span>
-              <span className="text-text-muted/50">/</span>
-              <span className="font-semibold text-foreground">
+            <div className="flex min-w-0 items-center gap-2 text-sm text-text-secondary">
+              <span className="shrink-0 text-text-muted">
+                {navigationInfo.moduleLabel}
+              </span>
+              <span className="shrink-0 text-text-muted/50">/</span>
+              <span
+                className="truncate font-semibold text-foreground"
+                title={navigationInfo.pageTitle}
+              >
                 {navigationInfo.pageTitle}
               </span>
             </div>
@@ -42,7 +47,7 @@ export function SiteHeader({ children }: { children?: React.ReactNode }) {
         </div>
 
         {/* User Area and Actions */}
-        <div className="flex items-center gap-3 text-sm">
+        <div className="flex shrink-0 items-center gap-3 text-sm">
           <MainNav items={mainNavConfig} />
           {children}
           <div className="mx-2 hidden h-4 w-px bg-border sm:block"></div>


### PR DESCRIPTION
## 背景

Knowledge → Documents → 某文档的 **View** 页,顶部全局导航组(`Home / Knowledge / Memory / Interface / Admin` + 主题切换 + 用户头像)跑到了**左侧**,与全局其他页面统一**右靠**的规范不一致(见用户反馈截图:导航组被挤到品牌/面包屑下方的第二行并左对齐)。

## 根因

- 全局头 `SiteHeader.tsx` 外层行使用 `flex flex-wrap ... justify-between`,而面包屑标题 `navigationInfo.pageTitle` **无 `min-w-0` / `truncate` / `max-w` 约束**,会随内容无限撑宽。
- 各模块二级导航通过 `NavigationProvider` 写入面包屑标题。**其他页面传入的都是短固定标题**(如 `Documents`、`Tools`、`Overview`);**唯独 Document View 页**把 `KnowledgeNav` 的 `title` 设为**完整文档文件名**(`effectiveDocumentName(detail)`,如 `SkillOpt-Lite: Better and Faster Agent Self-evolution via One Line of Vibe.pdf`)。
- 超长标题把左组撑至超出可用宽度 → 因外层 `flex-wrap`,右组换行到第二行 → 单个 flex 项对齐到行首(左)。
- `flex-wrap` 的换行判定基于 flex 项**基于内容的 hypothetical main size**而非收缩后尺寸,故仅加 `min-w-0`/`truncate` 而保留 `flex-wrap` 仍会换行——必须**去除 `flex-wrap`** 才能确定性修复。

## 改动

单文件 `apps/negentropy-ui/components/layout/SiteHeader.tsx`(纯 Tailwind 布局约束,结构不变):

1. 外层行去除 `flex-wrap`(`gap-2`→`gap-4`),头部恒单行;
2. 左组加 `min-w-0`,品牌 Link 加 `shrink-0`;
3. 面包屑容器加 `min-w-0`,模块名与 `/` 加 `shrink-0`,标题 span 加 `truncate` 并补 `title` 悬浮显示全名(符合"省略号 + Tooltip"规范);
4. 右组(导航+主题+用户)加 `shrink-0`,恒停靠右侧,仅左侧标题让位收缩。

属 `SiteHeader`(全局头 SSOT)层的系统性修复,惠及所有模块,而非只补 Document View 一处。

## 为何安全

其他页面标题短、本就单行放得下,收缩/截断不触发,去 `flex-wrap` 对其零视觉变化;`shrink-0`/`min-w-0` 对短内容无副作用。`SiteHeader` 为根布局唯一全局实例且不传 `children`,无额外调用点受影响。

## 验证

- `tsc --noEmit` 与 `eslint --max-warnings=0` 均通过(exit 0);pre-commit 钩子 ESLint(negentropy-ui)通过。
- 隔离 harness 1:1 复刻该 flex 结构做前后对照(对照图存于工作区 `.context/siteheader-before-after.png`):
  - **BEFORE**:长标题下导航组换行至第二行、左对齐(复现 bug);
  - **AFTER**:导航组恒单行、右靠,标题以 `…` 截断,`Knowledge /` 恒可见;
  - **AFTER @ 更窄宽度**:导航仍右靠单行,标题继续渐进截断,布局稳健。

🤖 Generated with [Claude Code](https://github.com/claude)