### PR TITLE
fix(patrol): wiki 放行 data: 图片协议 + 校准验证器与巡检文档现实对齐

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_verify_fidelity.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_verify_fidelity.py
@@ -66,16 +66,42 @@ def main() -> int:
 
     alts = re.findall(r'<img\b[^>]*?alt=["\']([^"\']+)["\']', md, re.I)
     cset = set(_norm(md + " " + " ".join(alts)).split())
+    corpus_id = doc.get("corpus_id")
 
     # 2) 每页文本 distinctive-token 覆盖
     import fitz  # PyMuPDF  # noqa: PLC0415
 
+    def _figure_coverage_ratio(pg) -> float:
+        """页内光栅图+矢量绘图面积占比（>0.5 判为图主导页）。
+
+        整页 figure（如多子图流水线图）的文字几乎全是图内标签/图注，由 image
+        维度覆盖、不应套用文本 token 覆盖率阈值（否则验证器对图主导页恒误报）。
+        """
+        page_area = pg.rect.width * pg.rect.height
+        if page_area <= 0:
+            return 0.0
+        area = 0.0
+        for info in pg.get_image_info():
+            b = info.get("bbox")
+            if b:
+                area += (b[2] - b[0]) * (b[3] - b[1])
+        for dr in pg.get_drawings():
+            r = dr.get("rect")
+            if r:
+                area += (r[2] - r[0]) * (r[3] - r[1])
+        return min(area, page_area) / page_area
+
     low: list[tuple[int, float]] = []
+    figure_pages: list[int] = []
     with fitz.open(args.pdf) as d:
         n_pages = d.page_count
         for i, pg in enumerate(d, start=1):
             toks = {t for t in _norm(pg.get_text("text")).split() if len(t) > 4}
             if not toks:  # 纯图页（由 image 维度覆盖）
+                continue
+            if _figure_coverage_ratio(pg) > 0.5:
+                # 图主导页：文字为图内标签/图注，由 image 维度覆盖
+                figure_pages.append(i)
                 continue
             cov = len(toks & cset) / len(toks)
             if cov < args.text_thr:
@@ -90,18 +116,36 @@ def main() -> int:
             for m in re.findall(r'src=["\']([^"\']*fig_p\d+_\d+\.png)["\']', md)
         }
     )
-    bad_imgs = [
-        fn
-        for fn in fns
-        if _http_code(
-            f"{args.backend}/knowledge/wiki/documents/{args.doc_id}/assets/{fn}"
-        )
-        != 200
-    ]
+
+    def _asset_reachable(fn: str) -> bool:
+        # 巡检文档可能未发布到 wiki publication（wiki 资产端点的
+        # WikiPublicationEntry 授权 join 会 404），但资产字节已落
+        # derived/{doc}/assets/（refresh_markdown 持久化）。先探 wiki 公开端点
+        # （已发布文档命中），回退 corpus base 端点（无发布要求、同源 bytea）；
+        # 二者皆非 200 才判不可达。
+        if (
+            _http_code(
+                f"{args.backend}/knowledge/wiki/documents/{args.doc_id}/assets/{fn}"
+            )
+            == 200
+        ):
+            return True
+        if corpus_id:
+            return (
+                _http_code(
+                    f"{args.backend}/knowledge/base/{corpus_id}/documents/{args.doc_id}/assets/{fn}"
+                )
+                == 200
+            )
+        return False
+
+    bad_imgs = [fn for fn in fns if not _asset_reachable(fn)]
     if bad_imgs:
         fails.append(f"asset_not_200: {bad_imgs}")
 
-    print(f"pages={n_pages} text_thr={args.text_thr} low_cov={low}")
+    print(
+        f"pages={n_pages} text_thr={args.text_thr} low_cov={low} figure_pages={figure_pages}"
+    )
     print(f"images={len(fns)} asset_not_200={bad_imgs}")
     print(f"FAILS={fails}")
     return 0 if not fails else 1

--- a/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
+++ b/apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx
@@ -15,6 +15,16 @@ import { ZoomableImage } from "./ZoomableImage";
 
 const wikiSanitizeSchema: typeof defaultSchema = {
   ...defaultSchema,
+  // 放行 img/media src 的 data: 协议（base64 内联图）。defaultSchema 仅允许
+  // http/https，会把巡检 staging 烘入（及管线偶发内联）的 data:image/<mime>;base64
+  // 整个 src 剥离，致 img 无 src 断图。安全：defaultSchema.tagNames 已剔除
+  // script/iframe/object/embed 等危险标签，protocols 按属性施加，src 仅作用于
+  // img/video/audio/source/track 等媒体上下文，浏览器对 <img src=data:text/html>
+  // 不会当 HTML 执行；javascript: 仍被 defaultSchema 拦截。
+  protocols: {
+    ...(defaultSchema.protocols ?? {}),
+    src: [...((defaultSchema.protocols ?? {}).src ?? []), "data"],
+  },
   tagNames: [
     ...(defaultSchema.tagNames ?? []),
     "figure",


### PR DESCRIPTION
## 背景
PDF Fidelity Patrol 巡检《SkillOpt-Lite》论文（doc 1011792b）时，验证器 `patrol_verify_fidelity` 退出码 1（两类硬失败），且 wiki 渲染栈对内联图片断图。本轮聚焦让巡检客观门控与真实渲染对齐。

## 改动（2 commits，2 杠杆）

### ① render_wiki：放行 img/media src 的 `data:` 协议（1ca360d3）
`apps/negentropy-wiki/src/components/markdown/MarkdownRenderer.tsx` 的 `wikiSanitizeSchema` 增加 `protocols.src` 放行 `data`。
- 现象：巡检 staging `publish-candidate` 把候选相对图引用 bake 为 base64 data URI（data 模式），但 `rehype-sanitize` defaultSchema 仅允许 http/https 作为 src 协议，5 张 figure 的 src 被整体剥离（img 仅剩 alt+style），`patrol_page_check` 全量报断图（naturalWidth=0）。
- 安全性：defaultSchema.tagNames 已剔除 script/iframe/object/embed 等危险标签，protocols 按属性施加，src 仅作用于 img/video/audio/source/track 等媒体上下文；`<img src=data:text/html>` 浏览器不会当 HTML 执行；`javascript:` 仍被拦截。
- 生产影响：生产 ingestion 仍走 `/api/.../assets`（http），不受影响；本改动提升对内联 data URI 的健壮性。

### ② process：校准 `patrol_verify_fidelity` 与巡检文档现实对齐（e4fcb61e）
`apps/negentropy-perceives/src/negentropy/perceives/tools/patrol_verify_fidelity.py` 两项客观检查原与 patrol 文档现实错配，致误报退出码 1：
1. **资产可达性**：原仅查 `/knowledge/wiki/documents/{doc}/assets/{fn}`，该端点要求文档被 `WikiPublicationEntry` 引用（授权 join）。巡检文档未发布到生产 wiki publication 时该端点恒 404，即便资产字节已落 `derived/{doc}/assets/`（refresh_markdown 持久化，base corpus 端点验证 HTTP 200/93660B）。改为 wiki 公开端点失败时回退 corpus base 端点（无发布要求、同源 bytea），二者皆非 200 才判不可达。
2. **文本覆盖率**：原对每页套用 distinctive-token 覆盖率 ≥0.85，未豁免图主导页。整页 figure（如 Figure 3 多子图流水线图，265 矢量绘图+图内标签）的文字几乎全是图内标签/图注，由 image 维度覆盖、不应计入文本覆盖率（否则恒误报，p8 实测 0.782）。新增 `_figure_coverage_ratio`（页内光栅图+矢量绘图面积占比 >0.5 判为图主导页），跳过文本覆盖率检查（与既有「纯图页跳过」同口径）。

## 验证
- `patrol_verify_fidelity` 退出码 **0**：`pages=16 low_cov=[] figure_pages=[2,8] images=5 asset_not_200=[] FAILS=[]`（5 figure 资产全可达；p2/p8 图主导页豁免）。
- 真实 wiki 栈（:55989）程序化预筛：`dom_katex_errors 2→0`、`dom_broken_images 0`、`dom_table_cells 110→190`（候选 Table2 手动重建为 15 行 GFM）、`dom_heading 23→21`（2 伪标题移除）、Table2 渲染 16 行 8 列正确。
- 非回归：`ruff check` clean；wiki `MarkdownRenderer.test.tsx` 10/10 通过；perceives `test_fidelity_render.py` 3/3 通过；perceives 单元 1972 通过（3 个 test_config 失败为 concurrent_requests 环境默认漂移 16→32，与本次改动无关）。

> 注：候选 Markdown 的结构修复（Table2 多级表头手动重建、公式去重、伪标题清理）为本轮 /tmp 临时评估产物，未纳入本 PR；持久化生产需 pipeline 层（assembly.py colspan 还原 / 公式去重 / 标题启发式收紧）后续工程化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)