### PR TITLE
fix(perceives): 修复 PDF→Markdown 正文代码块化与目录截断（切片围栏失衡根因）;

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/fence_normalizer.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/fence_normalizer.py
@@ -1,0 +1,98 @@
+"""代码围栏平衡归一。
+
+保证 Markdown ``` / ~~~ 代码围栏在**单个文本块内严格配对且以闭合收尾**，
+从根本上杜绝「悬空开围栏泄漏到相邻文本」这一 auto_batch 合并失真源。
+
+背景（实证）：docling 代码增强对「API 请求/响应」等示例偶产出畸形围栏序列——
+一串带 info-string 的开围栏（``` ```javascript ```）缺配对裸 ``` 闭合，使单个
+切片净奇数个围栏标记、结尾遗留悬空开围栏。auto_batch 逐切片原样拼接后，该悬空
+开围栏会**相位错位（phase-shift）其后所有内容的围栏配对**，把大段正文与标题误
+困入代码块（渲染为等宽字面文本），并使依「真实标题」生成的 Wiki 目录在首个围栏
+处截断。
+
+本模块为**纯函数**（无 IO / 无状态），供 ``pipeline.batch_merge`` 在切片拼接前
+逐切片平衡，及 ``markdown.formatter.format_fidelity_safe`` 作为全局安全网调用。
+"""
+
+from __future__ import annotations
+
+import re
+
+# 围栏行：行首可选缩进 + ≥3 个反引号或波浪号 + 可选 info-string。
+# 注意 info-string 捕获要求以非空白字符起手，避免把「``` ``」这类误判。
+_FENCE_LINE_RE = re.compile(
+    r"^(?P<indent>[ \t]*)(?P<ticks>`{3,}|~{3,})[ \t]*(?P<info>\S.*)?$"
+)
+
+
+def balance_code_fences(markdown: str) -> str:
+    """平衡 Markdown 代码围栏，保证严格配对且结尾闭合。
+
+    状态机逐行扫描围栏标记，处理三类情形：
+
+    1. **未开 → 开围栏行**：进入 fence（记录围栏字符与缩进）。
+    2. **已开 → 同字符裸围栏行**（无 info-string）：闭合当前块。
+    3. **已开 → 同字符带 info-string 围栏行**（``` ```lang```）：判定为
+       docling 畸形「未闭合即开新块」，**先补裸 ``` 闭合当前块，再以该行开新块**，
+       从而把被错误粘连的两个代码块拆开，且总数保持偶。
+
+    扫描结束若仍处于开状态（奇数个围栏），在文本末尾补一行裸围栏闭合，确保该
+    文本块绝不把围栏泄漏给后续拼接内容。
+
+    幂等：对已平衡的文本再次调用不产生变化（无 info-fence-while-open、无悬空开）。
+
+    Args:
+        markdown: 单个文本块（切片或整篇）的 markdown。
+
+    Returns:
+        围栏严格配对、以闭合收尾的 markdown。无围栏时原样返回。
+    """
+    if not markdown or ("```" not in markdown and "~~~" not in markdown):
+        return markdown
+
+    lines = markdown.split("\n")
+    out: list[str] = []
+    open_char: str | None = None  # '`' 或 '~'，None 表示当前不在围栏内
+    open_indent = ""
+
+    for line in lines:
+        m = _FENCE_LINE_RE.match(line)
+        if not m:
+            out.append(line)
+            continue
+
+        ticks = m.group("ticks")
+        info = (m.group("info") or "").strip()
+        char = ticks[0]
+
+        if open_char is None:
+            # 情形 1：开围栏
+            open_char = char
+            open_indent = m.group("indent")
+            out.append(line)
+        elif char != open_char:
+            # 异种围栏字符（如 ```-块内出现 ~~~）视为块内正文，原样保留
+            out.append(line)
+        elif not info:
+            # 情形 2：同字符裸围栏 → 闭合当前块
+            out.append(line)
+            open_char = None
+        else:
+            # 情形 3：同字符带 info-string 且当前已开 → 畸形，先闭合再开新块
+            out.append(f"{open_indent}{open_char * 3}")
+            out.append(line)
+            open_indent = m.group("indent")
+            # open_char 不变（新块继续开着）
+
+    if open_char is not None:
+        # 悬空开围栏 → 末尾补闭合
+        out.append(f"{open_indent}{open_char * 3}")
+
+    return "\n".join(out)
+
+
+def count_fence_markers(markdown: str) -> int:
+    """统计文本中的围栏标记行数（用于测试/诊断断言奇偶平衡）。"""
+    if not markdown:
+        return 0
+    return sum(1 for line in markdown.split("\n") if _FENCE_LINE_RE.match(line))

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -11,6 +11,8 @@ import uuid
 from enum import Enum, auto
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
+from .fence_normalizer import balance_code_fences
+
 if TYPE_CHECKING:
     from .html_preprocessor import ImgDimensionRegistry, VideoRegistry
 
@@ -81,6 +83,110 @@ _NON_CODE_FENCE_CODE_SIGNALS = (
     re.compile(r"""["'][^"'\n]{1,80}["']"""),  # 引号字符串
     re.compile(r"(?<!:)//|/\*|\*/"),  # C 系注释（排除 URL ``https://`` 的 ``//``）
 )
+
+
+# ---------------------------------------------------------------------------
+# 散文误围栏降级（Layer 2）
+# ---------------------------------------------------------------------------
+# docling 代码增强对「API 请求/响应」等区域偶把大段中文正文（含章节标题、图表
+# 题注、目录点导引线）误包进代码围栏，并猜测 go/elixir/visualbasic 等语言标签，
+# 渲染为整段等宽字面文本，且其中的 `#` 标题不再是真标题（Wiki 目录随之截断）。
+# ``_demote_prose_fences`` 按内容判定，把散文块拆栏还原、并抹掉误标语言。
+
+# 强「文档章节标题」信号：多级章节号（1.2.5）或「第 N 章/节」。代码注释
+# ``# 1. 用户提问`` 不含多级点分号，不误命中；真代码块绝不含此类标题行。
+_FENCE_SECTION_HEADING_RE = re.compile(
+    r"^#{1,6}[ \t]+(?:\d+(?:\.\d+)+|第\s*\d+\s*[章节])", re.MULTILINE
+)
+# 印刷版目录点导引线：``全书结构............ 2``（正文/代码均无此形态）。
+_FENCE_TOC_LEADER_RE = re.compile(r"\.{5,}\s*\d+\s*$", re.MULTILINE)
+# 图/表题注起手（中文）：``图 1-1 ...`` / ``表 2：...``。
+_FENCE_FIG_CAPTION_RE = re.compile(
+    r"^[ \t]*[图表]\s*\d+(?:[-.]\d+)*[\s：:、]", re.MULTILINE
+)
+# CJK 字形（含日韩），用于散文占比估计（真代码正文 CJK 占比极低）。
+_FENCE_CJK_CHAR_RE = re.compile(r"[一-鿿㐀-䶿぀-ヿ가-힯]")
+# 强代码信号（逐行判定）。
+_FENCE_STRONG_ASSIGN_RE = re.compile(r"(?:^|\s)[A-Za-z_]\w*\s*=\s*\S")
+_FENCE_JSON_PAIR_RE = re.compile(r'"[^"\n]+"\s*:')
+_FENCE_STRONG_KW_RE = re.compile(
+    r"\b(?:def|function|class|import|return|const|let|var|public|private|"
+    r"void|func|package|SELECT|INSERT|UPDATE|DELETE)\b"
+)
+# 明显不属本语料、docling 高频误标的语言标签：保留围栏但抹掉标签，避免错误
+# 语法高亮。刻意排除 go/python/js/yaml 等常见合法语言，避免误伤真代码标注。
+_IMPLAUSIBLE_CODE_LANGS = frozenset(
+    {"elixir", "visualbasic", "vb", "cobol", "pascal", "erlang", "unknown"}
+)
+
+
+# ---------------------------------------------------------------------------
+# 标题质量归一（Layer 4）
+# ---------------------------------------------------------------------------
+# docling 字号启发式偶把「有序列表项 / 图表题注 / 散文句/lead-in / 页眉 running
+# header」误升为 Markdown 标题，污染正文层级与 Wiki 目录。以下常量供
+# ``_normalize_heading_quality`` 做定点、保守的降级/去重。
+
+_HEADING_LINE_RE = re.compile(r"^(#{1,6}) (.+?)[ \t]*$")
+# 有序列表项签名：单个整数 + ``.``/``、`` + 空格（排除多级章节号 ``1.2``）。
+_LIST_ITEM_HEADING_RE = re.compile(r"^(\d+)[\.、](?!\d)[ \t]+(.+)$")
+# 真实章节号/编号型标题：多级号 / 第 N 章节 / 实验 N / 附录 / 参考文献。
+_SEC_STRONG_HEADING_RE = re.compile(
+    r"^(?:\d+\.\d+|第\s*\d+\s*[章节]|实验\s*[\d\-]|附录|参考文献)"
+)
+# 图/表题注起手（应为题注段落而非标题）。
+_FIG_HEADING_RE = re.compile(r"^[图表]\s*\d")
+
+
+def _heading_is_prose(text: str) -> bool:
+    """判定标题文本是否实为散文句 / lead-in（应降级为段落）。
+
+    高置信信号（避免误伤真标题）：
+      - 含句号「。」（真标题几乎不含完整句号）；
+      - 长度 ≥ 12 且以 lead-in 标点「，：、」收尾（如「初始状态（…）：」）。
+    编号型标题（``_SEC_STRONG_HEADING_RE``）一律不判为散文。
+    """
+    if _SEC_STRONG_HEADING_RE.match(text):
+        return False
+    body = text.rstrip()
+    if "。" in body:
+        return True
+    return len(body) >= 12 and body[-1] in "，：、"
+
+
+def _fence_han_ratio(text: str) -> float:
+    """去空白后 CJK 字形占比（0~1）。空文本返回 0。"""
+    compact = "".join(text.split())
+    if not compact:
+        return 0.0
+    return len(_FENCE_CJK_CHAR_RE.findall(compact)) / len(compact)
+
+
+def _fence_looks_like_prose(body: str) -> bool:
+    """判定围栏体是否实为自然语言正文（应拆栏还原为段落）。
+
+    判定分层（任一命中即判散文）：
+      - D1 结构信号：含真实章节标题 / 目录点导引线 —— 二者绝不出现在代码中；
+      - CJK 主导：去空白 CJK 占比 ≥ 0.55；
+      - 图表题注密集：≥ 2 处图/表题注且 CJK 占比 ≥ 0.30；
+      - D2 中等 CJK 且无强代码信号：0.30 ≤ CJK < 0.55 且无「≥2 赋值 / ≥2 JSON
+        键值 / ≥3 花括号分号 / ≥1 代码关键字」——含中文注释的真 Python
+        （多处赋值/关键字）不命中，零误伤。
+    """
+    if _FENCE_SECTION_HEADING_RE.search(body) or _FENCE_TOC_LEADER_RE.search(body):
+        return True
+    han = _fence_han_ratio(body)
+    if han >= 0.55:
+        return True
+    if len(_FENCE_FIG_CAPTION_RE.findall(body)) >= 2 and han >= 0.30:
+        return True
+    lines = body.split("\n")
+    assigns = sum(1 for ln in lines if _FENCE_STRONG_ASSIGN_RE.search(ln))
+    jsons = sum(1 for ln in lines if _FENCE_JSON_PAIR_RE.search(ln))
+    braces = sum(ln.count("{") + ln.count("}") + ln.count(";") for ln in lines)
+    kw = sum(1 for ln in lines if _FENCE_STRONG_KW_RE.search(ln))
+    strong = assigns >= 2 or jsons >= 2 or braces >= 3 or kw >= 1
+    return 0.30 <= han < 0.55 and not strong
 
 
 # 跨行断字复合词守护：``([a-z]+)- ([a-z]+)`` 合并规则（行 910 附近）默认把所有
@@ -851,6 +957,10 @@ class MarkdownFormatter:
         用于 :mod:`ops.pdf` 各返回路径对最终 markdown 的轻量后处理。
         """
         try:
+            # 全局围栏平衡安全网：合并路径已逐切片平衡，但单次（非 auto_batch）路径
+            # 及任何残余奇偶失衡在此兜底闭合，确保下游 _format_code_blocks 的语言
+            # 标注/降级建立在配对围栏之上，绝不把正文误困入代码块。
+            markdown_content = balance_code_fences(markdown_content)
             markdown_content = self._format_code_blocks(markdown_content)
             markdown_content = self._strip_running_headers(markdown_content)
             markdown_content = self._strip_orphan_lang_labels(markdown_content)
@@ -964,6 +1074,10 @@ class MarkdownFormatter:
             # 标题末尾不加标点；仅剥离末尾中文句号「。」，保留「？」「！」等可能
             # 表语气的标点，英文「.」不处理（章节编号/缩写可能合法结尾）。
             markdown_content = re.sub(r"(?m)^(#{1,6} .*?)。+$", r"\1", markdown_content)
+            # 标题质量归一：有序列表项/图表题注/散文句被误升为标题的降级，及页眉
+            # running-header 重复标题去重。置于末尾（尾随句号剥离之后），避免把仅
+            # 带尾随句号的合法标题误判为散文句。
+            markdown_content = self._normalize_heading_quality(markdown_content)
             return markdown_content
         except Exception as e:
             logger.warning(f"Error in fidelity-safe formatting: {str(e)}")
@@ -1499,6 +1613,95 @@ class MarkdownFormatter:
             flags=re.MULTILINE | re.DOTALL,
         )
 
+    def _normalize_heading_quality(self, markdown_content: str) -> str:
+        """把 docling 误升为标题的非标题内容降级/去重（fence 外逐行处理）。
+
+        四条定点规则（仅作用于代码围栏外的标题行）：
+          1. **有序列表项**：``## 1. 核实用户身份`` → ``1. 核实用户身份``（订机票
+             四步、思考题编号等），还原为 Markdown 有序列表；
+          2. **图/表题注**：``#### 图 2-4 …`` → 题注段落（移出目录）；
+          3. **散文句/lead-in**：见 :func:`_heading_is_prose`，降级为普通段落；
+          4. **页眉 running-header 去重**：同级、文本相同、其间无更浅层标题（同一
+             父节点作用域内）的重复标题判为页眉回声，删除后者。作用域随更浅层
+             标题重置，故各章共有的「思考题」等同名标题（分处不同章）不被误删。
+
+        保守优先：编号型标题（``\\d+.\\d+`` / 第 N 章节 / 实验 N）绝不降级；去重仅在
+        同一父作用域内、逐字相同才触发。
+        """
+        lines = markdown_content.split("\n")
+        out: List[str] = []
+        in_fence = False
+        prev_at_level: Dict[int, str] = {}
+        for ln in lines:
+            if re.match(r"^\s*(```|~~~)", ln):
+                in_fence = not in_fence
+                out.append(ln)
+                continue
+            if in_fence:
+                out.append(ln)
+                continue
+            hm = _HEADING_LINE_RE.match(ln)
+            if not hm:
+                out.append(ln)
+                continue
+            level = len(hm.group(1))
+            text = hm.group(2)
+            # 规则 1：有序列表项还原
+            lm = _LIST_ITEM_HEADING_RE.match(text)
+            if lm:
+                out.append(f"{lm.group(1)}. {lm.group(2)}")
+                continue
+            # 规则 2：图/表题注 → 段落
+            if _FIG_HEADING_RE.match(text):
+                out.append(text)
+                continue
+            # 规则 3：散文句/lead-in → 段落
+            if _heading_is_prose(text):
+                out.append(text)
+                continue
+            # 规则 4：同作用域同级同文标题去重（页眉回声）
+            norm = re.sub(r"\s+", "", text)
+            if prev_at_level.get(level) == norm:
+                continue
+            prev_at_level[level] = norm
+            for deeper in [lv for lv in prev_at_level if lv > level]:
+                del prev_at_level[deeper]
+            out.append(ln)
+        return "\n".join(out)
+
+    def _demote_prose_fences(self, markdown_content: str) -> str:
+        """把实为自然语言正文的代码围栏还原为普通段落，并抹掉误标语言。
+
+        docling 代码增强对「API 示例」等区域偶把大段中文正文（含章节标题、图表
+        题注、目录点导引线）误包进围栏并猜测 go/elixir/visualbasic 等语言，渲染为
+        整段等宽字面文本，且其中的 `#` 标题不再是真标题（Wiki 目录随之截断）。
+
+        逐围栏块判定（见 :func:`_fence_looks_like_prose`）：
+          - 判为散文 → 拆栏还原为普通段落；
+          - 判为代码但语言标签明显不属本语料（``_IMPLAUSIBLE_CODE_LANGS``）→ 保留
+            围栏、抹掉误标语言（降为裸围栏），避免错误语法高亮。
+
+        对含中文注释的真 Python（多处赋值/关键字）零误伤。假定围栏已由
+        :func:`fence_normalizer.balance_code_fences` 平衡（闭合皆为裸 ``` ）。
+        """
+
+        def _handle(m: re.Match) -> str:
+            info = (m.group(1) or "").strip()
+            body = m.group(2)
+            if _fence_looks_like_prose(body):
+                return body.strip("\n")
+            lang = info.split()[0].lower() if info else ""
+            if lang in _IMPLAUSIBLE_CODE_LANGS:
+                return "```\n" + body.rstrip("\n") + "\n```"
+            return m.group(0)
+
+        return re.sub(
+            r"^```([^\n]*)\n(.*?)^```[ \t]*$",
+            _handle,
+            markdown_content,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+
     def _format_code_blocks(self, markdown_content: str) -> str:
         """Enhance code block formatting with language detection.
 
@@ -1512,6 +1715,10 @@ class MarkdownFormatter:
         try:
             # 先把实为自然语言横幅（含 ©/®/™ 且无代码特征）的伪代码块降级为普通段落
             markdown_content = self._demote_non_code_fences(markdown_content)
+
+            # 再把 docling 误包进围栏的中文正文（含章节标题/图表题注/目录点导引线）
+            # 拆栏还原为段落，并抹掉 elixir/visualbasic 等误标语言。
+            markdown_content = self._demote_prose_fences(markdown_content)
 
             # 修复连续的代码围栏标记：```LANG\n``` filename → ```\n filename
             markdown_content = re.sub(

--- a/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/markdown/formatter.py
@@ -162,6 +162,28 @@ def _fence_han_ratio(text: str) -> float:
     return len(_FENCE_CJK_CHAR_RE.findall(compact)) / len(compact)
 
 
+def _is_code_leadin_line(line: str) -> bool:
+    """判定行是否为「代码前的中文导语」（应移出代码块）。
+
+    典型：``…四步流程在 API 层面的简化表示如下：`` / ``以下是…消息列表:``。docling
+    代码增强偶把这类紧邻代码的导语句纳入代码围栏，渲染为等宽字面。
+
+    严格判定（避免误伤代码注释/带参标签，如 ``# 例 2: …`` / ``1 次调用后(…):``）：
+      - 以 ``：`` / ``:`` / ``。`` 收尾；
+      - 不以注释/列表/引用符起手（``#`` ``*`` ``-`` ``>`` ``|`` ``//`` ``/*``）；
+      - 不含代码标点 ``{}=;<>"()``；
+      - CJK 字形 ≥ 3 且去空白 CJK 占比 ≥ 0.30。
+    """
+    s = line.strip()
+    if not s or not s.endswith(("：", ":", "。")):
+        return False
+    if s[0] in "#*->|" or s.startswith(("//", "/*")):
+        return False
+    if any(c in s for c in '{}=;<>"()'):
+        return False
+    return len(_FENCE_CJK_CHAR_RE.findall(s)) >= 3 and _fence_han_ratio(s) >= 0.30
+
+
 def _fence_looks_like_prose(body: str) -> bool:
     """判定围栏体是否实为自然语言正文（应拆栏还原为段落）。
 
@@ -1078,6 +1100,9 @@ class MarkdownFormatter:
             # running-header 重复标题去重。置于末尾（尾随句号剥离之后），避免把仅
             # 带尾随句号的合法标题误判为散文句。
             markdown_content = self._normalize_heading_quality(markdown_content)
+            # 末尾剥离代码块开头误纳入的中文导语行（echo-aware），再补围栏平衡兜底。
+            markdown_content = self._extract_code_block_leadins(markdown_content)
+            markdown_content = balance_code_fences(markdown_content)
             return markdown_content
         except Exception as e:
             logger.warning(f"Error in fidelity-safe formatting: {str(e)}")
@@ -1701,6 +1726,61 @@ class MarkdownFormatter:
             markdown_content,
             flags=re.MULTILINE | re.DOTALL,
         )
+
+    def _extract_code_block_leadins(self, markdown_content: str) -> str:
+        """把代码块开头被误纳入的中文导语行移出（echo-aware，不制造重复）。
+
+        docling 偶把紧邻代码的中文导语句（``…如下：``）连同代码一并纳入围栏。本 pass
+        对每个围栏块剥离**开头连续**的导语行（见 :func:`_is_code_leadin_line`）：
+          - 若该导语在块前邻近正文中已有**逐字相同的回声**（docling text/code 双出），
+            则**丢弃**块内副本（保留块前正文即可），避免重复行；
+          - 否则把导语**移出**到围栏前作为普通段落。
+        仅当剥离后仍有代码本体时才处理（纯导语块由 _demote_prose_fences 兜底）。
+        置于 ``format_fidelity_safe`` 末尾运行，避开代码围栏正则对新析出段落边界的
+        干扰；调用方随后补一次围栏平衡兜底。
+        """
+        result: List[str] = []
+        last = 0
+        for m in re.finditer(
+            r"^```([^\n]*)\n(.*?)^```[ \t]*$",
+            markdown_content,
+            flags=re.MULTILINE | re.DOTALL,
+        ):
+            result.append(markdown_content[last : m.start()])
+            last = m.end()
+            info = m.group(1) or ""
+            body = m.group(2)
+            lines = body.split("\n")
+            lead: List[str] = []
+            idx = 0
+            while idx < len(lines):
+                s = lines[idx].strip()
+                if not s:
+                    idx += 1
+                    if lead:
+                        break
+                    continue
+                if _is_code_leadin_line(s):
+                    lead.append(s)
+                    idx += 1
+                else:
+                    break
+            rest = "\n".join(lines[idx:]).strip("\n") if lead else body
+            if not lead or not rest:
+                result.append(m.group(0))
+                continue
+            # echo 检测：块前邻近正文（含被 docling 双出的乱码回声段）内是否已有逐字
+            # 相同导语行；导语句高度可辨识，宽窗口不致误判。
+            preceding = "".join(result)[-4000:]
+            pre_norm = {re.sub(r"\s+", "", x) for x in preceding.split("\n")}
+            kept = [ln for ln in lead if re.sub(r"\s+", "", ln) not in pre_norm]
+            block = f"```{info}\n{rest}\n```"
+            if kept:
+                result.append("\n\n".join(kept) + "\n\n" + block)
+            else:
+                result.append(block)
+        result.append(markdown_content[last:])
+        return "".join(result)
 
     def _format_code_blocks(self, markdown_content: str) -> str:
         """Enhance code block formatting with language detection.

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/batch_merge.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/batch_merge.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional, Sequence, Tuple
 
+from ..markdown.fence_normalizer import balance_code_fences
 from .models import ImageAsset, PipelineResult
 
 logger = logging.getLogger(__name__)
@@ -447,6 +448,11 @@ def merge_slice_markdowns(
     for i in range(len(rescued) - 1):
         a, b = boundary_figure_caption_rescue(rescued[i], rescued[i + 1])
         rescued[i], rescued[i + 1] = a, b
+
+    # 逐切片平衡代码围栏：任一切片结尾遗留的悬空开围栏（docling 畸形序列所致）
+    # 若不在此闭合，拼接后会相位错位其后所有切片的围栏配对，把正文/标题误困入
+    # 代码块。在此保证每个切片自身围栏配对、以闭合收尾，切片永不污染邻片。
+    rescued = [balance_code_fences(md) for md in rescued]
 
     parts: List[str] = []
     for i, md in enumerate(rescued):

--- a/apps/negentropy-perceives/tests/unit/test_fence_balance.py
+++ b/apps/negentropy-perceives/tests/unit/test_fence_balance.py
@@ -1,0 +1,229 @@
+"""代码围栏平衡与散文误围栏降级单元测试。
+
+锁定 auto_batch 路径「正文被整体代码块化 + 目录截断」根因修复的契约：
+
+- ``fence_normalizer.balance_code_fences``：悬空开围栏在文本块末尾闭合、畸形
+  连续开围栏拆分、幂等、无围栏透传、异种围栏字符不误判。
+- ``batch_merge.merge_slice_markdowns``：任一切片的悬空开围栏在拼接前被平衡，
+  绝不相位错位（phase-shift）邻片，邻片正文/标题不被困入代码块。
+- ``formatter._demote_prose_fences`` / ``format_fidelity_safe``：含章节标题 /
+  目录点导引线 / CJK 主导 / 图表题注的伪代码围栏被拆栏还原为段落；含中文注释
+  的真 Python（多处赋值）不被误降；elixir/visualbasic 等误标语言被抹掉。
+"""
+
+from __future__ import annotations
+
+import re
+
+from negentropy.perceives.markdown.fence_normalizer import (
+    balance_code_fences,
+    count_fence_markers,
+)
+from negentropy.perceives.markdown.formatter import MarkdownFormatter
+from negentropy.perceives.pipeline.batch_merge import (
+    merge_slice_markdowns,
+)
+
+
+def _fenced_line_indices(md: str) -> set[int]:
+    """返回处于代码围栏内部的行号集合（用于断言正文未被困）。"""
+    inside: set[int] = set()
+    in_fence = False
+    for i, ln in enumerate(md.split("\n")):
+        if re.match(r"^\s*(```|~~~)", ln):
+            in_fence = not in_fence
+            continue
+        if in_fence:
+            inside.add(i)
+    return inside
+
+
+# ---------------------------------------------------------------------------
+# balance_code_fences
+# ---------------------------------------------------------------------------
+
+
+class TestBalanceCodeFences:
+    def test_no_fence_passthrough(self) -> None:
+        md = "# 标题\n\n正文一段。\n\n另一段。"
+        assert balance_code_fences(md) == md
+
+    def test_balanced_unchanged(self) -> None:
+        md = "```python\nprint(1)\n```\n\n正文"
+        assert balance_code_fences(md) == md
+        assert count_fence_markers(md) % 2 == 0
+
+    def test_dangling_open_gets_closed(self) -> None:
+        md = "前文\n\n```python\nx = 1\n还有正文没有闭合围栏"
+        out = balance_code_fences(md)
+        assert count_fence_markers(out) % 2 == 0
+        assert out.endswith("```")
+
+    def test_malformed_consecutive_info_opens_split(self) -> None:
+        # docling 畸形：两个带 info 的开围栏之间缺裸 ``` 闭合
+        md = "```javascript\nfoo()\n```javascript\nbar()\n```"
+        out = balance_code_fences(md)
+        assert count_fence_markers(out) % 2 == 0
+        # 第一块在第二个 info 开围栏前被裸 ``` 闭合
+        assert "foo()\n```\n```javascript\nbar()" in out
+
+    def test_idempotent(self) -> None:
+        md = "```yaml\nk: v\n```javascript\nz=1\n悬空"
+        once = balance_code_fences(md)
+        assert balance_code_fences(once) == once
+
+    def test_tilde_fence_supported(self) -> None:
+        md = "~~~\ncode\n无闭合"
+        out = balance_code_fences(md)
+        assert out.endswith("~~~")
+        assert count_fence_markers(out) % 2 == 0
+
+
+# ---------------------------------------------------------------------------
+# merge_slice_markdowns —— 切片不泄漏围栏
+# ---------------------------------------------------------------------------
+
+
+class TestMergeDoesNotLeakFences:
+    def test_odd_fence_slice_does_not_trap_next_slice(self) -> None:
+        # slice0 结尾悬空开围栏；未平衡时会把 slice1 的标题/正文全部困入代码块
+        slice0 = "# 第 1 章\n\n```javascript\n{tool:1}\n```javascript\n{tool:2}"
+        slice1 = "## 第 2 章\n\n第二章正文。\n\n### 2.1 小节\n\n更多正文。"
+        merged = merge_slice_markdowns([slice0, slice1], [(0, 20), (20, 40)])
+        # 合并后围栏必平衡
+        assert count_fence_markers(merged) % 2 == 0
+        # slice1 的标题必须在围栏之外（真标题）
+        fenced = _fenced_line_indices(merged)
+        lines = merged.split("\n")
+        h2 = next(i for i, ln in enumerate(lines) if ln.startswith("## 第 2 章"))
+        h3 = next(i for i, ln in enumerate(lines) if ln.startswith("### 2.1"))
+        assert h2 not in fenced
+        assert h3 not in fenced
+
+
+# ---------------------------------------------------------------------------
+# _demote_prose_fences —— 散文降级 / 真代码保留 / 误标语言抹除
+# ---------------------------------------------------------------------------
+
+
+class TestDemoteProseFences:
+    def setup_method(self) -> None:
+        self.fmt = MarkdownFormatter()
+
+    def test_section_heading_inside_fence_demoted(self) -> None:
+        md = "```yaml\ntool_calls: [x]\n\n### 1.2.5 编排模式\n\n工作流是确定性编排。\n```"
+        out = self.fmt._demote_prose_fences(md)
+        assert "```" not in out
+        assert "### 1.2.5 编排模式" in out
+
+    def test_toc_leader_inside_fence_demoted(self) -> None:
+        md = "```text\n全书结构............ 2\n引言 ...... 1\n```"
+        out = self.fmt._demote_prose_fences(md)
+        assert "```" not in out
+
+    def test_cjk_dominant_prose_demoted(self) -> None:
+        md = "```visualbasic\n相比之下，流程驱动的提示词就像一份优秀的员工培训手册。\n它提供了清晰的标准操作流程。\n```"
+        out = self.fmt._demote_prose_fences(md)
+        assert "```" not in out
+        assert "visualbasic" not in out
+
+    def test_real_python_with_chinese_comments_kept(self) -> None:
+        md = (
+            "```python\n"
+            "# 1. 用户提问\n"
+            'query = "量子纠缠是什么？"\n'
+            "results = retriever.search(query, top_k=3)\n"
+            "answer = model.generate(results)\n"
+            "```"
+        )
+        out = self.fmt._demote_prose_fences(md)
+        assert out.strip().startswith("```python")
+        assert "retriever.search" in out
+
+    def test_implausible_lang_stripped_but_code_kept(self) -> None:
+        md = (
+            "```elixir\nmessages = [\n  {role: 'user'},\n  {role: 'assistant'},\n]\n```"
+        )
+        out = self.fmt._demote_prose_fences(md)
+        assert "elixir" not in out
+        assert out.strip().startswith("```")  # 仍是代码块（裸围栏）
+        assert "messages = [" in out
+
+    def test_plausible_json_code_untouched(self) -> None:
+        md = '```json\n{\n  "name": "get_weather",\n  "args": {"city": "SF"}\n}\n```'
+        out = self.fmt._demote_prose_fences(md)
+        assert out == md
+
+
+# ---------------------------------------------------------------------------
+# format_fidelity_safe —— 端到端：balance + demote 协同
+# ---------------------------------------------------------------------------
+
+
+class TestHeadingQuality:
+    def setup_method(self) -> None:
+        self.fmt = MarkdownFormatter()
+
+    def test_numbered_list_heading_becomes_ordered_list(self) -> None:
+        md = "## 1. 核实用户身份 ——调用身份验证 API\n\n## 2. 搜索可用航班"
+        out = self.fmt._normalize_heading_quality(md)
+        assert "1. 核实用户身份 ——调用身份验证 API" in out
+        assert "2. 搜索可用航班" in out
+        assert "## 1." not in out and "## 2." not in out
+
+    def test_multilevel_section_number_kept_as_heading(self) -> None:
+        md = "##### 1.2.5.1 工作流模式：确定性的编排"
+        assert self.fmt._normalize_heading_quality(md) == md
+
+    def test_figure_caption_heading_demoted(self) -> None:
+        md = "#### 图 2-4 Agent 每次调用模型时的上下文构成"
+        out = self.fmt._normalize_heading_quality(md)
+        assert out == "图 2-4 Agent 每次调用模型时的上下文构成"
+
+    def test_prose_sentence_heading_demoted(self) -> None:
+        md = "## 2025 年 8 月，我在图灵进行了讲座。讲座的初衷很简单。"
+        out = self.fmt._normalize_heading_quality(md)
+        assert not out.startswith("#")
+
+    def test_leadin_colon_heading_demoted(self) -> None:
+        md = "#### 让我们跟踪 messages 列表在每一轮的变化："
+        out = self.fmt._normalize_heading_quality(md)
+        assert not out.lstrip().startswith("#")
+
+    def test_running_header_echo_deduped_same_scope(self) -> None:
+        md = (
+            "### 1.1 现代 Agent = LLM + 上下文 + 工具\n\n"
+            "#### 1.1.1 工具\n\n正文\n\n"
+            "### 1.1 现代 Agent = LLM + 上下文 + 工具\n\n"  # 页眉回声
+            "#### 1.1.4 ReAct 循环\n"
+        )
+        out = self.fmt._normalize_heading_quality(md)
+        assert out.count("### 1.1 现代 Agent = LLM + 上下文 + 工具") == 1
+
+    def test_same_title_different_chapter_scope_kept(self) -> None:
+        # 各章共有的「思考题」分处不同章（其间有更浅层的章标题重置作用域），不去重
+        md = (
+            "## 第 1 章 入门\n\n### 思考题\n\n题目一\n\n"
+            "## 第 2 章 进阶\n\n### 思考题\n\n题目二\n"
+        )
+        out = self.fmt._normalize_heading_quality(md)
+        assert out.count("### 思考题") == 2
+
+
+class TestFidelitySafeFenceIntegrity:
+    def test_dangling_fence_and_prose_block_both_repaired(self) -> None:
+        fmt = MarkdownFormatter()
+        md = (
+            "# 深入理解 AI Agent\n\n"
+            "```yaml\n"
+            "tool_calls: [x]\n\n"
+            "#### 1.2.5 编排模式\n\n"
+            "工作流是通过预定义的代码路径来编排的系统。\n\n"
+            "##### 1.2.5.1 工作流模式\n"  # 无闭合围栏（悬空）
+        )
+        out = fmt.format_fidelity_safe(md)
+        assert count_fence_markers(out) % 2 == 0
+        fenced = _fenced_line_indices(out)
+        lines = out.split("\n")
+        h = next(i for i, ln in enumerate(lines) if "1.2.5.1 工作流模式" in ln)
+        assert h not in fenced  # 章节标题不再被困入代码块

--- a/apps/negentropy-perceives/tests/unit/test_fence_balance.py
+++ b/apps/negentropy-perceives/tests/unit/test_fence_balance.py
@@ -210,6 +210,38 @@ class TestHeadingQuality:
         assert out.count("### 思考题") == 2
 
 
+class TestCodeBlockLeadinExtraction:
+    def setup_method(self) -> None:
+        self.fmt = MarkdownFormatter()
+
+    def test_leadin_moved_out_when_no_echo(self) -> None:
+        md = "```yaml\n以一个查天气的场景为例，四步流程如下：\n\ntools: [1, 2]\n```"
+        out = self.fmt._extract_code_block_leadins(md)
+        assert out.startswith("以一个查天气的场景为例，四步流程如下：")
+        assert "```yaml\ntools: [1, 2]\n```" in out
+        assert count_fence_markers(out) % 2 == 0
+
+    def test_leadin_dropped_when_prose_echo_precedes(self) -> None:
+        md = (
+            "让我们通过伪代码来理解 Agent 轨迹的结构：\n\n"
+            "一些中间的乱码回声内容。\n\n"
+            "```python\n让我们通过伪代码来理解 Agent 轨迹的结构：\ntrace = build()\n```"
+        )
+        out = self.fmt._extract_code_block_leadins(md)
+        # 回声已在块前 → 块内导语被丢弃，不重复
+        assert out.count("让我们通过伪代码来理解 Agent 轨迹的结构：") == 1
+        assert "trace = build()" in out
+
+    def test_python_comment_not_extracted(self) -> None:
+        md = '```python\n# 例 2: 公司知识库，流程是什么：\nquery = "x"\nrun(query)\n```'
+        out = self.fmt._extract_code_block_leadins(md)
+        assert out == md  # 注释行保留在代码块内
+
+    def test_no_leadin_untouched(self) -> None:
+        md = '```json\n{"a": 1, "b": 2}\n```'
+        assert self.fmt._extract_code_block_leadins(md) == md
+
+
 class TestFidelitySafeFenceIntegrity:
     def test_dangling_fence_and_prose_block_both_repaired(self) -> None:
         fmt = MarkdownFormatter()


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：大型中文 PDF《深入理解 AI Agent：设计原理与工程实践》（308 页）经 `negentropy-perceives.parse_pdf_to_markdown` 转换后，**第 1 章起正文被整体渲染为代码块**（等宽字面 `####`/`##`），且 Wiki 右侧**目录只到第 1 章**、后 9 章缺失。
- 关联上下文/Issue/文档：Knowledge/Wiki 测试环境 `http://localhost:3092/wiki/harness-engineering/paper/ai-agent-v1-1-pdf/`；源文档 `assets/papers/source/深入理解-AI-Agent-李博杰-v1.1.pdf`。

# 核心变更
- **根因（实证）**：docling 代码增强对「API 请求/响应」示例产出畸形围栏序列（连续带 info-string 的开围栏缺配对裸 ``` 闭合），使 auto_batch **单切片净奇数个围栏、结尾遗留悬空开围栏**；`pipeline/batch_merge.py::merge_slice_markdowns` 逐片**原样拼接、无围栏平衡**，悬空开围栏**相位错位（phase-shift）其后所有切片的围栏配对** → 大段正文与标题被困代码块内，依真实标题生成的 Wiki 目录随之在首个围栏处截断（两症状同源）。
- **Layer 1 围栏完整性**：新增纯函数 `markdown/fence_normalizer.balance_code_fences` 状态机，保证每切片围栏严格配对且结尾必闭合（畸形连续开围栏拆分、悬空开补闭合）；`merge_slice_markdowns` 拼接前逐片平衡 + `formatter.format_fidelity_safe` 全局安全网。
- **Layer 2 散文误围栏降级**：`formatter._demote_prose_fences` 把含真实章节标题 / 目录点导引线 / CJK 主导 / 图表题注的伪代码围栏拆栏还原为段落，并抹掉 `elixir/visualbasic` 等误标语言（含中文注释的真 Python 零误伤）。
- **Layer 3 导语析出**：`formatter._extract_code_block_leadins` echo-aware 剥离代码块开头被误纳入的中文导语行（`…如下：`）——块前已有逐字回声则丢弃、否则移出为段落，末尾补围栏平衡兜底。
- **Layer 4 标题质量**：`formatter._normalize_heading_quality` 把误升为标题的有序列表项（`## 1.`→`1.`）、图表题注、散文句降级为正文，并作用域内去重页眉 running-header 重复标题（各章共有的「思考题」等不误删）。

# 风险与回滚
- 主要风险：全部为**切片后纯 markdown 后处理**，不改引擎与切片抽取逻辑；启发式降级/去重均以严格判定守卫（真代码、合法编号标题零误伤），误判面极小；无数据库/Schema/接口变更。
- 回滚方式：`git revert a2b3f034 d7e3eab2`（或回退工作分支）即可完全还原，无副作用。

# 验证证据
- 单元测试：新增 `tests/unit/test_fence_balance.py` 25 例（围栏平衡 / 散文降级 / 标题质量 / 导语 echo-aware 析出）；`uv run pytest tests/unit` 相关子集全绿、无回归。
- 集成测试：以 `resume=True` 复用 16 个缓存切片重跑真实 `parse_pdf_to_markdown`（3.6s，非 6.7h 全量）——围栏奇偶恢复平衡、真实标题 **47→381**、§1.2.5 订机票四步还原为有序列表、10 章目录齐全。
- E2E/Workflow：Wiki 测试环境 `:3092` 与源 PDF 逐页比对——§1.2.5 与 PDF 第 28 页逐项一致、第 1～10 章目录齐全、代码块内不再困标题（0）、高清图与图注正常。
- 覆盖率/关键截图：见会话内 `:3092` 渲染 vs PDF 对比。

# 影响范围
- 前端：无（wiki/ui 渲染代码未改动）。
- 后端：无（`apps/negentropy` 未改动）。
- GitHub Actions / 文档：无。
- 服务：仅 `apps/negentropy-perceives`——`markdown/formatter.py`、`markdown/fence_normalizer.py`（新）、`pipeline/batch_merge.py`、`tests/unit/test_fence_balance.py`（新）。

# Next Best Action
- 若需将修复永久固化到 Documents（`:3192`）与 Wiki 两处：经修复版 perceives 重灌该文档 + republish。
- 深层残留（docling `text/code` 双出内容整体去重、行内**加粗**还原）属 assembly/docling 源头改造，需针对含示例区切片做小范围重跑，另行推进。
