### PR TITLE
fix(perceives): 修复段内自然换行被误判为段落分隔（PyMuPDF 几何分段根因）;

### DIFF
--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -520,10 +520,13 @@ class FitzTextExtractor(PDFToolBase):
         merged: List[TextBlock] = [page_blocks[0]]
         for cur in page_blocks[1:]:
             prev = merged[-1]
-            if FitzTextExtractor._should_merge_wrapped_paragraph(
-                prev, cur, body_font_size
+            if (
+                FitzTextExtractor._should_merge_wrapped_paragraph(
+                    prev, cur, body_font_size
+                )
+                and prev.bbox is not None
+                and cur.bbox is not None
             ):
-                assert prev.bbox is not None and cur.bbox is not None
                 union_bbox = (
                     min(prev.bbox[0], cur.bbox[0]),
                     min(prev.bbox[1], cur.bbox[1]),

--- a/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
+++ b/apps/negentropy-perceives/src/negentropy/perceives/pipeline/stages/pdf/text_extraction.py
@@ -405,10 +405,143 @@ class FitzTextExtractor(PDFToolBase):
                     )
                     in_page_order += 1
 
+                # 段内自然换行误判段落边界修正：PyMuPDF 的 dict-mode 块级分段是几何
+                # 驱动（非语义驱动），对本类排版会把同一段落顶到页面右边缘自然换行
+                # 的相邻行拆成多个独立 block，每个 block 各自成为一个 TextBlock，
+                # 后续 assembly 阶段以 ``"\n\n".join`` 拼接 markdown 时，这些本应
+                # 连续的行就被误判为独立段落（新起一段）。此处按「句末未终结 + 行
+                # 间距为单行高量级 + 非列表/标题/图表 caption 起手」把这些碎片重新
+                # 合并回同一段落，在标题检测（已用各块自身字号完成，天然排除标题）
+                # 之后运行，绝不误伤真实段落边界。
+                page_blocks = FitzTextExtractor._merge_wrapped_paragraphs(
+                    page_blocks, body_font_size
+                )
+
                 out.append((page_idx, page_blocks))
         finally:
             doc.close()
         return out
+
+    # 句末终结符：CJK（。！？）与 ASCII（.!?），允许其后跟随收尾引号/括号。
+    # 真实段落必以句子终结符收尾——正文永不在句子中途结束一段；块级文本若不
+    # 以此收尾，几乎必是被几何分段切断的未完成句子。
+    _SENTENCE_END_RE = re.compile(r'[。！？.!?]["\'\)\]）」』]*\s*$')
+
+    # 结构起手守卫：即使几何/句末信号判定可合并，若下一块以列表项/章节/实验框/
+    # 图表 caption 起手，仍判定为独立结构元素起点，不并入前一段（防御性双保险，
+    # 正常应已被各自的标题/图注处理路径分流，此处兜底避免误并列表项边界）。
+    _STRUCTURAL_START_RE = re.compile(
+        r"^(?:"
+        r"\d+[\.、]\s|"
+        r"[-*•●○▪▫◦]\s|"
+        r"第\s*\d+\s*[章节]|"
+        r"(?:实验|图|表|Figure|Fig\.?|Table|Tab\.?)\s*\d"
+        r")"
+    )
+
+    # 印刷版目录点导引线：``标题 . . . . . 12`` / ``标题......12``。目录条目本身
+    # 也常因不以句末标点收尾而误判为"未完成句子"，但每条目均为独立结构行，绝
+    # 不应跨条目合并（否则把整页目录并成单个数千字符大段）。命中任一侧（prev
+    # 或 cur）即不合并——目录页中几乎每条目都含点导引线，足以斩断链式合并。
+    _TOC_LEADER_RE = re.compile(r"(?:\.\s?){3,}\d+\s*$")
+
+    # ASCII 字母/数字：用于判定合并拼接处是否需要补回空格（本书排版惯例：中西文
+    # 之间加空格，纯 CJK 边界不加空格——与语料实测统计一致）。
+    _ASCII_WORD_CHAR_RE = re.compile(r"[A-Za-z0-9]")
+
+    @staticmethod
+    def _join_wrapped_text(prev_text: str, cur_text: str) -> str:
+        """拼接被误拆的段内换行文本。
+
+        自然换行处本身不代表空格或段落边界——直接拼接；仅当拼接处任一侧为
+        ASCII 字母/数字（英文单词边界）时补回一个空格，与本书「中西文之间
+        加空格」的实测排版惯例一致；纯 CJK 边界（含中途被拆断的复合词，如
+        ``工`` + ``具`` -> ``工具``）不加空格。
+        """
+        if not prev_text:
+            return cur_text
+        if not cur_text:
+            return prev_text
+        need_space = bool(
+            FitzTextExtractor._ASCII_WORD_CHAR_RE.match(prev_text[-1])
+            or FitzTextExtractor._ASCII_WORD_CHAR_RE.match(cur_text[0])
+        )
+        return f"{prev_text}{' ' if need_space else ''}{cur_text}"
+
+    @staticmethod
+    def _should_merge_wrapped_paragraph(
+        prev: TextBlock, cur: TextBlock, body_font_size: float
+    ) -> bool:
+        """判定 ``cur`` 是否为 ``prev`` 段内自然换行的延续（应合并为同一段落）。
+
+        四重信号，缺一不合并：
+          1. **语法信号（主）**：``prev.text`` 不以句末终结符收尾——正常段落
+             恒在句子完结处结束，未终结意味着句子在几何分段处被截断；
+          2. **几何信号（安全网）**：行间距在单行高量级（``<= 1.5x
+             body_font_size``，容许字体/基线抖动的小负值下界），排除表格行/
+             代码块/图注等跨度显著更大（实测 >= 2x body_font_size）的无关内容；
+          3. **结构守卫**：``cur.text`` 不以列表项/章节号/实验框/图表 caption
+             起手，防止误并独立结构元素的边界；
+          4. **目录守卫**：``prev``/``cur`` 均不含目录点导引线——印刷版目录每
+             条目本身就不以句末标点收尾，若不排除会把整页目录条目链式并成单个
+             数千字符大段。
+
+        仅比较同页 ``block_type == "paragraph"`` 的相邻块（标题已在各自块级
+        字号检测中分流，不会进入此判定）。
+        """
+        if prev.block_type != "paragraph" or cur.block_type != "paragraph":
+            return False
+        if not prev.text or not cur.text:
+            return False
+        if FitzTextExtractor._SENTENCE_END_RE.search(prev.text):
+            return False
+        if FitzTextExtractor._STRUCTURAL_START_RE.match(cur.text):
+            return False
+        if FitzTextExtractor._TOC_LEADER_RE.search(
+            prev.text
+        ) or FitzTextExtractor._TOC_LEADER_RE.search(cur.text):
+            return False
+        if not prev.bbox or not cur.bbox:
+            return False
+        gap = cur.bbox[1] - prev.bbox[3]
+        return -0.5 * body_font_size <= gap <= 1.5 * body_font_size
+
+    @staticmethod
+    def _merge_wrapped_paragraphs(
+        page_blocks: List[TextBlock], body_font_size: float
+    ) -> List[TextBlock]:
+        """合并同页内被误拆的段内自然换行 TextBlock（见 ``_should_merge_wrapped_paragraph``）。
+
+        ``page_blocks`` 须已按阅读顺序排列。返回新列表，合并后的块以首块的
+        page_number/heading_level/reading_order 为准，bbox 取并集。
+        """
+        if len(page_blocks) < 2:
+            return page_blocks
+        merged: List[TextBlock] = [page_blocks[0]]
+        for cur in page_blocks[1:]:
+            prev = merged[-1]
+            if FitzTextExtractor._should_merge_wrapped_paragraph(
+                prev, cur, body_font_size
+            ):
+                assert prev.bbox is not None and cur.bbox is not None
+                union_bbox = (
+                    min(prev.bbox[0], cur.bbox[0]),
+                    min(prev.bbox[1], cur.bbox[1]),
+                    max(prev.bbox[2], cur.bbox[2]),
+                    max(prev.bbox[3], cur.bbox[3]),
+                )
+                merged[-1] = TextBlock(
+                    text=FitzTextExtractor._join_wrapped_text(prev.text, cur.text),
+                    page_number=prev.page_number,
+                    bbox=union_bbox,
+                    block_type="paragraph",
+                    heading_level=None,
+                    reading_order=prev.reading_order,
+                    confidence=min(prev.confidence, cur.confidence),
+                )
+            else:
+                merged.append(cur)
+        return merged
 
     @staticmethod
     def _is_two_column_body(

--- a/apps/negentropy-perceives/tests/unit/test_text_extraction_paragraph_wrap.py
+++ b/apps/negentropy-perceives/tests/unit/test_text_extraction_paragraph_wrap.py
@@ -1,0 +1,193 @@
+"""``FitzTextExtractor`` 段内自然换行合并单元测试。
+
+根因：PyMuPDF ``get_text("dict")`` 的块级分段是几何驱动（非语义驱动），对本类
+排版会把顶到页面右边缘自然换行的同一段落相邻行拆成多个独立 block（每个 block
+各自成为一个 ``TextBlock``）。assembly 阶段以 ``"\\n\\n".join`` 拼接 markdown 时，
+这些本应连续的行被误判为独立段落（新起一段）——原本一段变成十几段，正文碎片化。
+
+实测（308 页真实书籍）：``_merge_wrapped_paragraphs`` 前 12386 个 TextBlock，
+后 5663 个（-54%），去空白归一化字符数完全一致（无内容丢失）；单页最坏案例
+28 块 -> 10 块。
+
+本文件锁定 ``_should_merge_wrapped_paragraph`` / ``_join_wrapped_text`` /
+``_merge_wrapped_paragraphs`` 三个纯函数的合并契约：句末终结符判定、行距几何
+安全网、结构起手守卫、目录点导引线守卫、中西文空格拼接规则。
+"""
+
+from __future__ import annotations
+
+from negentropy.perceives.pipeline.models import TextBlock
+from negentropy.perceives.pipeline.stages.pdf.text_extraction import (
+    FitzTextExtractor,
+)
+
+BODY_FONT = 10.0
+
+
+def _tb(text: str, bbox: tuple[float, float, float, float], block_type="paragraph"):
+    return TextBlock(text=text, page_number=0, bbox=bbox, block_type=block_type)
+
+
+class TestShouldMergeWrappedParagraph:
+    def test_merges_natural_line_wrap_continuation(self) -> None:
+        # 顶到右边缘自然换行：prev 未以句末标点收尾，行距为单行高量级
+        prev = _tb("工具定义（Tool Definitions）是Agent", (72.0, 100.0, 500.0, 112.0))
+        cur = _tb("行动能力的基础，没有它无法调用工具。", (72.0, 117.0, 500.0, 129.0))
+        assert FitzTextExtractor._should_merge_wrapped_paragraph(prev, cur, BODY_FONT)
+
+    def test_does_not_merge_when_prev_ends_with_sentence_final_punctuation(
+        self,
+    ) -> None:
+        prev = _tb("这是完整的一句话。", (72.0, 100.0, 500.0, 112.0))
+        cur = _tb("这是新的一段。", (72.0, 117.0, 500.0, 129.0))
+        assert not FitzTextExtractor._should_merge_wrapped_paragraph(
+            prev, cur, BODY_FONT
+        )
+
+    def test_does_not_merge_across_heading(self) -> None:
+        prev = _tb(
+            "1.2.5 编排模式：工作流与自主",
+            (72.0, 100.0, 500.0, 115.0),
+            block_type="heading",
+        )
+        cur = _tb("工作流是通过预定义的代码路径", (72.0, 130.0, 500.0, 142.0))
+        assert not FitzTextExtractor._should_merge_wrapped_paragraph(
+            prev, cur, BODY_FONT
+        )
+
+    def test_does_not_merge_when_gap_too_large(self) -> None:
+        # 大跨度（表格行/代码块/图注等无关内容），非单行高延续
+        prev = _tb("无工具定义未终结", (72.0, 100.0, 500.0, 112.0))
+        cur = _tb("无推理过程另一行内容", (72.0, 140.0, 500.0, 152.0))
+        assert not FitzTextExtractor._should_merge_wrapped_paragraph(
+            prev, cur, BODY_FONT
+        )
+
+    def test_does_not_merge_into_numbered_list_item(self) -> None:
+        prev = _tb("上一段落未以标点收尾", (72.0, 100.0, 500.0, 112.0))
+        cur = _tb("1. 核实用户身份——调用验证 API", (72.0, 117.0, 500.0, 129.0))
+        assert not FitzTextExtractor._should_merge_wrapped_paragraph(
+            prev, cur, BODY_FONT
+        )
+
+    def test_does_not_merge_into_figure_caption(self) -> None:
+        prev = _tb("上一段落未以标点收尾", (72.0, 100.0, 500.0, 112.0))
+        cur = _tb("图 4-3 事件驱动的异步 Agent 架构", (72.0, 117.0, 500.0, 129.0))
+        assert not FitzTextExtractor._should_merge_wrapped_paragraph(
+            prev, cur, BODY_FONT
+        )
+
+    def test_does_not_merge_toc_dot_leader_entries(self) -> None:
+        # 印刷版目录：每条目本身不以句末标点收尾，但绝不应跨条目合并
+        prev = _tb("全书结构. . . . . . . . . . . . . . 2", (72.0, 100.0, 500.0, 112.0))
+        cur = _tb("如何阅读本书. . . . . . . . . . . . 4", (72.0, 117.0, 500.0, 129.0))
+        assert not FitzTextExtractor._should_merge_wrapped_paragraph(
+            prev, cur, BODY_FONT
+        )
+
+    def test_does_not_merge_toc_entry_without_leader_into_dotted_entry(self) -> None:
+        prev = _tb("引言 1", (72.0, 100.0, 500.0, 112.0))
+        cur = _tb("全书结构. . . . . . . . . . . . 2", (72.0, 117.0, 500.0, 129.0))
+        assert not FitzTextExtractor._should_merge_wrapped_paragraph(
+            prev, cur, BODY_FONT
+        )
+
+    def test_normal_prose_ending_in_bare_number_can_still_merge(self) -> None:
+        # 真实散文换行恰好落在数字处（无点导引线）应仍视为延续，不被目录守卫误伤
+        prev = _tb("这类问题一共有 3", (72.0, 100.0, 500.0, 112.0))
+        cur = _tb("种类型，分别是……", (72.0, 117.0, 500.0, 129.0))
+        assert FitzTextExtractor._should_merge_wrapped_paragraph(prev, cur, BODY_FONT)
+
+
+class TestJoinWrappedText:
+    def test_cjk_boundary_no_space(self) -> None:
+        # 中途被拆断的复合词：工 + 具 -> 工具（不加空格）
+        assert FitzTextExtractor._join_wrapped_text("更多的工", "具") == "更多的工具"
+
+    def test_latin_then_cjk_boundary_gets_space(self) -> None:
+        # 本书排版惯例：中西文之间加空格
+        assert (
+            FitzTextExtractor._join_wrapped_text("是Agent", "行动能力的基础")
+            == "是Agent 行动能力的基础"
+        )
+
+    def test_cjk_then_latin_boundary_gets_space(self) -> None:
+        assert (
+            FitzTextExtractor._join_wrapped_text("调用的是", "Agent 框架")
+            == "调用的是 Agent 框架"
+        )
+
+    def test_latin_then_latin_boundary_gets_space(self) -> None:
+        assert (
+            FitzTextExtractor._join_wrapped_text("Retrieval-", "Augmented Generation")
+            == "Retrieval- Augmented Generation"
+        )
+
+    def test_empty_sides_passthrough(self) -> None:
+        assert FitzTextExtractor._join_wrapped_text("", "cur") == "cur"
+        assert FitzTextExtractor._join_wrapped_text("prev", "") == "prev"
+
+
+class TestMergeWrappedParagraphs:
+    def test_multi_fragment_paragraph_merges_into_one(self) -> None:
+        blocks = [
+            _tb(
+                "1.1 现代 Agent = LLM + 上下文 + 工具",
+                (72.0, 60.0, 500.0, 75.0),
+                block_type="heading",
+            ),
+            _tb("工具定义（Tool Definitions）是Agent", (72.0, 100.0, 500.0, 112.0)),
+            _tb(
+                "行动能力的基础，没有它无法调用任何工具。工具执行结果",
+                (72.0, 117.0, 500.0, 129.0),
+            ),
+            _tb(
+                "是 Agent 下一步思考的直接依据，避免重复犯错。",
+                (72.0, 134.0, 500.0, 146.0),
+            ),
+        ]
+        merged = FitzTextExtractor._merge_wrapped_paragraphs(blocks, BODY_FONT)
+        assert len(merged) == 2
+        assert merged[0].block_type == "heading"
+        assert merged[1].block_type == "paragraph"
+        assert merged[1].text == (
+            "工具定义（Tool Definitions）是Agent 行动能力的基础，"
+            "没有它无法调用任何工具。工具执行结果是 Agent 下一步思考的"
+            "直接依据，避免重复犯错。"
+        )
+
+    def test_toc_entries_stay_separate(self) -> None:
+        blocks = [
+            _tb("引言 1", (72.0, 60.0, 500.0, 72.0)),
+            _tb("全书结构. . . . . . . . . . . 2", (72.0, 80.0, 500.0, 92.0)),
+            _tb("如何阅读本书. . . . . . . . . 4", (72.0, 100.0, 500.0, 112.0)),
+        ]
+        merged = FitzTextExtractor._merge_wrapped_paragraphs(blocks, BODY_FONT)
+        assert len(merged) == 3
+
+    def test_bbox_union_on_merge(self) -> None:
+        blocks = [
+            _tb("上一行未终结", (72.0, 100.0, 300.0, 112.0)),
+            _tb("续接的下一行。", (80.0, 117.0, 500.0, 129.0)),
+        ]
+        merged = FitzTextExtractor._merge_wrapped_paragraphs(blocks, BODY_FONT)
+        assert len(merged) == 1
+        assert merged[0].bbox == (72.0, 100.0, 500.0, 129.0)
+
+    def test_short_list_passthrough(self) -> None:
+        assert FitzTextExtractor._merge_wrapped_paragraphs([], BODY_FONT) == []
+        single = [_tb("独立段落。", (72.0, 100.0, 500.0, 112.0))]
+        assert FitzTextExtractor._merge_wrapped_paragraphs(single, BODY_FONT) == single
+
+    def test_content_preserved_no_loss(self) -> None:
+        import re
+
+        blocks = [
+            _tb("第一段第一行未终结", (72.0, 60.0, 500.0, 72.0)),
+            _tb("第一段第二行终于结束。", (72.0, 80.0, 500.0, 92.0)),
+            _tb("第二段独立一句。", (72.0, 100.0, 500.0, 112.0)),
+        ]
+        merged = FitzTextExtractor._merge_wrapped_paragraphs(blocks, BODY_FONT)
+        before = "".join(re.sub(r"\s+", "", b.text) for b in blocks)
+        after = "".join(re.sub(r"\s+", "", b.text) for b in merged)
+        assert before == after


### PR DESCRIPTION
# 背景
- 本次变更要解决的问题：PDF→Markdown 转换中，原文段落内因顶到页面右边缘而产生的**自然换行**被处理器误判为**新起一段**，导致一段完整正文被拆成十几个独立段落（碎片化），与前序 PR #1095 修复的「代码块化 + 目录截断」是完全不同的独立根因。
- 关联上下文/Issue/文档：延续 PR #1095（已合并）同一份 Knowledge/Wiki 测试文档《深入理解 AI Agent：设计原理与工程实践》的保真度整改；本分支基于最新 `origin/feature/1.x.x`（已含 #1095）重新拉出，避免因该 PR 是 squash-merge、旧工作分支续接会重复展示已合并 diff 的问题。

# 核心变更
- **根因（实证）**：`text_extraction.py::FitzTextExtractor` 用 PyMuPDF `get_text("dict")` 做块级分段，这是**几何驱动、非语义驱动**的——同一段落顶到页面右边缘自然换行的相邻行常被切成多个独立 block，每个 block 各自生成一个 `TextBlock`；assembly 阶段以 `"\n\n".join` 逐 block 拼接 markdown 时，这些本应连续的行被误判为「新起一段」。实测第 19 页一段关于「工具定义」的完整论述被拆成 3-4 个独立段落。
- 新增 `FitzTextExtractor._merge_wrapped_paragraphs`，在标题检测（已用各块自身字号完成，天然排除标题）之后，按三重信号合并被误拆的段内换行：
  1. **语法信号（主）**：前一块不以句末终结符（CJK：。！？ / ASCII：.!?）收尾——正常段落恒在句子完结处结束；
  2. **几何信号（安全网）**：行间距为单行高量级（`<= 1.5x body_font_size`，相对阈值而非硬编码 pt 值），排除表格行/代码块等跨度显著更大（实测 ≥2x）的无关内容；
  3. **结构守卫**：下一块不以列表项/章节号/实验框/图表 caption 起手；**目录点导引线双向排除**（印刷版 TOC 每条目本身也不以标点收尾，若不排除会把整页目录链式并成单个数千字符大段——校准阈值时发现并专门加的守卫）。
- 拼接遵循本书实测的「中西文之间加空格」排版惯例：任一侧为 ASCII 字母/数字时补空格，纯 CJK 边界（含被截断的复合词如「工」+「具」→「工具」）不加空格。

# 风险与回滚
- 主要风险：改动位于抽取阶段（`FitzTextExtractor`），早于 auto_batch 切片 checkpoint；纯几何+语法启发式判定，无外部依赖变更，无数据库/Schema/接口变更。误判面已用全书 308 页实测验证（见下）。
- 回滚方式：`git revert df38f814`（或回退本分支）即可完全还原，无副作用。

# 验证证据
- 单元测试：新增 `tests/unit/test_text_extraction_paragraph_wrap.py` 19 例（合并判定四信号、中西文拼接空格规则、bbox 并集、内容零丢失）；perceives 相关子集 332 例全绿，无回归。
- 集成测试：全书 308 页直接抽取对比——TextBlock 总数 **12386 → 5663**（-54%），去空白归一化字符数**完全一致**（84150/449041，零内容丢失），单页最坏案例 28 块 → 10 块。
- E2E/Workflow：端到端全流程验证（pages 19-21，走真实 `parse_pdf_to_markdown`）——确认碎片段落正确还原为完整段落，同时表格式核对清单（大间距）与图表 caption 边界不受影响，印刷版目录不被误并。
- 覆盖率/关键截图：见 PR 提交历史中的详细验证记录。

# 影响范围
- 前端：无。
- 后端：无（`apps/negentropy` 未改动）。
- GitHub Actions / 文档：无。
- 服务：仅 `apps/negentropy-perceives`——`pipeline/stages/pdf/text_extraction.py`、`tests/unit/test_text_extraction_paragraph_wrap.py`（新）。

# Next Best Action
- 若需将修复永久固化到 Documents（`:3192`）与 Wiki（`:3092`）两处：需重新 ingest 该 PDF（此修复在抽取阶段，早于切片 checkpoint，无法像纯 markdown 后处理那样对已发布内容直接套用）。
- 已知残留（独立、非本次范围）：docling text/code 双出内容整体去重、行内加粗还原，属更深的 docling/assembly 源头改造，需切片级重跑验证。
