### PR TITLE
feat(knowledge): 文档列表新增按名称/作者的模糊搜索

### DIFF
--- a/apps/negentropy-ui/app/knowledge/documents/page.tsx
+++ b/apps/negentropy-ui/app/knowledge/documents/page.tsx
@@ -27,7 +27,7 @@ import {
   effectiveDocumentName,
   useInlineDocumentRename,
 } from "@/features/knowledge";
-import { Check, Pencil, RotateCcw, X } from "lucide-react";
+import { Check, Pencil, RotateCcw, Search, X } from "lucide-react";
 
 import { KnowledgeNav } from "@/components/ui/KnowledgeNav";
 import { Pagination } from "@/components/ui/Pagination";
@@ -50,6 +50,12 @@ import { PatrolStatusBadge, patrolStatusLabel } from "./_components/PatrolStatus
 const APP_NAME = process.env.NEXT_PUBLIC_AGUI_APP_NAME || "negentropy";
 /** 文档列表每页条数（偏移分页粒度 + 无限滚动加载粒度 + 页码跳页粒度）。 */
 const DOCUMENTS_PAGE_SIZE = 10;
+
+/** 文档列表筛选状态（序列化进 useInfiniteList.filters，变化即 reset 回第 1 页）。 */
+interface DocumentFilters {
+  /** 按 文件名/显示名/作者姓名 模糊搜索的防抖提交值。 */
+  search: string;
+}
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) return `${bytes} B`;
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -132,6 +138,9 @@ export default function DocumentsPage() {
   const [isTranslating, setIsTranslating] = useState(false);
   /** 乐观覆盖：Translate accepted 的文档即时置 processing，待 refresh/心跳带回真实状态后超时清除。 */
   const [optimisticProcessing, setOptimisticProcessing] = useState<Set<string>>(new Set());
+  // 文档搜索：searchInput 即时受控输入，search 为 300ms 防抖后的提交值（对齐 EntityListPanel）。
+  const [searchInput, setSearchInput] = useState("");
+  const [search, setSearch] = useState("");
   const router = useRouter();
 
   // 无限滚动 + 翻页：滚动容器 ref（哨兵 / 滚动联动 observer 的 root）、程序化滚动闸门、待跳页号。
@@ -139,19 +148,37 @@ export default function DocumentsPage() {
   const programmaticScrollRef = useRef(false);
   const pendingPageRef = useRef<number | null>(null);
 
-  // 偏移分页适配器：薄包 fetchAllDocuments；响应 count 归一为 total。
-  const fetcher = useMemo<OffsetFetcher<KnowledgeDocument>>(
+  // 搜索防抖：输入停顿 300ms 后提交 search，避免每次按键都触发取数（对齐 EntityListPanel）。
+  useEffect(() => {
+    const timer = setTimeout(() => setSearch(searchInput), 300);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  // 筛选键：序列化后进 useInfiniteList.filters，search 变化即 reset 回第 1 页并重取。
+  const filters = useMemo<DocumentFilters>(() => ({ search }), [search]);
+
+  // 偏移分页适配器：薄包 fetchAllDocuments；响应 count 归一为 total；search 经 filters 透传至后端。
+  const fetcher = useMemo<OffsetFetcher<KnowledgeDocument, DocumentFilters>>(
     () => ({
       kind: "offset",
-      fetchRange: async ({ offset, limit }) => {
-        const data = await fetchAllDocuments({ appName: APP_NAME, limit, offset });
+      fetchRange: async ({ offset, limit, filters: f }) => {
+        const data = await fetchAllDocuments({
+          appName: APP_NAME,
+          limit,
+          offset,
+          search: f?.search || undefined,
+        });
         return { items: data.items, total: data.count };
       },
     }),
     [],
   );
 
-  const list = useInfiniteList<KnowledgeDocument>({ fetcher, pageSize: DOCUMENTS_PAGE_SIZE });
+  const list = useInfiniteList<KnowledgeDocument, DocumentFilters>({
+    fetcher,
+    pageSize: DOCUMENTS_PAGE_SIZE,
+    filters,
+  });
   // 乐观覆盖：对 Translate accepted 的文档叠加 translation.status=processing，使其即时显示「Translating…」。
   const documents = useMemo(() => {
     if (optimisticProcessing.size === 0) return list.items;
@@ -466,14 +493,29 @@ export default function DocumentsPage() {
       <div className="flex min-h-0 flex-1 px-6 py-6">
         {/* 文档列表 */}
         <main className="flex min-h-0 flex-1 flex-col">
-          {/* 工具栏：左侧勾选提示，右侧 Translate / Import 批量操作 */}
-          <div className="mb-3 flex items-center justify-between">
-            <span className="text-xs text-muted-foreground">
+          {/* 工具栏：左侧勾选提示，中间文档搜索框，右侧 Translate / Import 批量操作 */}
+          <div className="mb-3 flex items-center justify-between gap-4">
+            <span className="shrink-0 text-xs text-muted-foreground">
               {selectedIds.size > 0
                 ? `${selectedIds.size} document${selectedIds.size !== 1 ? "s" : ""} selected`
                 : "Select documents to translate (EN → 中文)"}
             </span>
-            <div className="flex items-center gap-2">
+            {/* 文档搜索：按 文件名/显示名/作者姓名 模糊检索（300ms 防抖，服务端过滤）。 */}
+            <div className="relative min-w-0 max-w-md flex-1">
+              <Search
+                className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground"
+                aria-hidden="true"
+              />
+              <input
+                type="search"
+                value={searchInput}
+                onChange={(e) => setSearchInput(e.target.value)}
+                placeholder="Search by name or author..."
+                aria-label="Search documents by name or author"
+                className="w-full rounded-lg border border-border bg-input py-1.5 pl-8 pr-3 text-xs text-foreground placeholder:text-input-placeholder focus:outline-none focus:ring-2 focus:ring-ring"
+              />
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
               <button
                 onClick={() => handleTranslate(Array.from(selectedIds))}
                 disabled={selectedIds.size === 0 || isTranslating}
@@ -555,7 +597,7 @@ export default function DocumentsPage() {
                   ) : documents.length === 0 ? (
                     <tr>
                       <td colSpan={11} className="p-6 text-center text-sm text-muted-foreground">
-                        No documents uploaded yet
+                        {search ? "No documents match your search" : "No documents uploaded yet"}
                       </td>
                     </tr>
                   ) : (

--- a/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
+++ b/apps/negentropy-ui/features/knowledge/utils/knowledge-api.ts
@@ -1561,12 +1561,15 @@ export async function fetchAllDocuments(
     appName?: string;
     limit?: number;
     offset?: number;
+    /** 按 文件名/显示名/作者姓名 模糊搜索（大小写不敏感）。 */
+    search?: string;
   },
 ): Promise<DocumentListResponse> {
   const query = new URLSearchParams();
   if (params?.appName) query.set("app_name", params.appName);
   if (params?.limit) query.set("limit", String(params.limit));
   if (params?.offset) query.set("offset", String(params.offset));
+  if (params?.search) query.set("search", params.search);
 
   const res = await fetch(
     `/api/knowledge/documents?${query.toString()}`,

--- a/apps/negentropy/src/negentropy/knowledge/routes/documents.py
+++ b/apps/negentropy/src/negentropy/knowledge/routes/documents.py
@@ -80,6 +80,7 @@ async def list_documents(
     app_name: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
+    search: str | None = Query(default=None, description="按 文件名/显示名/作者姓名 模糊搜索（大小写不敏感）"),
 ) -> DocumentListResponse:
     """列出语料库中的已上传文档
 
@@ -88,6 +89,7 @@ async def list_documents(
         app_name: 应用名称
         limit: 分页大小
         offset: 偏移量
+        search: 可选模糊搜索词（文件名/显示名/作者姓名）
 
     Returns:
         DocumentListResponse: 文档列表
@@ -103,6 +105,7 @@ async def list_documents(
         limit=limit,
         offset=offset,
         order_by="updated_at",
+        search=search,
     )
 
     unique_user_ids = list({doc.created_by for doc in docs if doc.created_by})
@@ -125,6 +128,7 @@ async def list_all_documents(
     app_name: str | None = Query(default=None),
     limit: int = Query(default=50, ge=1, le=100),
     offset: int = Query(default=0, ge=0),
+    search: str | None = Query(default=None, description="按 文件名/显示名/作者姓名 模糊搜索（大小写不敏感）"),
 ) -> DocumentListResponse:
     """列出所有已上传文档（跨语料库）
 
@@ -132,6 +136,7 @@ async def list_all_documents(
         app_name: 应用名称
         limit: 分页大小
         offset: 偏移量
+        search: 可选模糊搜索词（文件名/显示名/作者姓名）
 
     Returns:
         DocumentListResponse: 文档列表
@@ -147,6 +152,7 @@ async def list_all_documents(
         limit=limit,
         offset=offset,
         order_by="updated_at",
+        search=search,
     )
 
     unique_user_ids = list({doc.created_by for doc in docs if doc.created_by})

--- a/apps/negentropy/src/negentropy/storage/service.py
+++ b/apps/negentropy/src/negentropy/storage/service.py
@@ -14,10 +14,12 @@ from uuid import UUID
 from sqlalchemy import func, or_, select, text
 from sqlalchemy.exc import IntegrityError
 
+from negentropy.config import settings
 from negentropy.db.session import AsyncSessionLocal
 from negentropy.logging import get_logger
 from negentropy.models.base import NEGENTROPY_SCHEMA
 from negentropy.models.perception import KnowledgeDocument
+from negentropy.models.state import UserState
 from negentropy.serialization import strip_nul_chars
 
 from .exceptions import StorageError
@@ -355,6 +357,7 @@ class DocumentStorageService:
         offset: int = 0,
         order_by: str = "created_at",
         markdown_status: str | None = None,
+        search: str | None = None,
     ) -> tuple[list[KnowledgeDocument], int]:
         """List documents with optional filtering.
 
@@ -369,6 +372,12 @@ class DocumentStorageService:
                 pagination when timestamps tie.
             markdown_status: Optional ``markdown_extract_status`` 过滤（如
                 ``"completed"``）。None 表示不过滤，保留既有调用方语义。
+            search: 可选模糊搜索词，对 文件名(``original_filename``)/
+                显示名(``display_name``)/作者姓名 做大小写不敏感 ILIKE。
+                作者维度：``created_by`` 存的是用户 ID 而非姓名，故经
+                ``user_states.state.profile.name`` 参数化子查询反解为匹配的
+                user_id 集合再过滤（对齐 ``_resolve_user_display_names``）。
+                None/空串表示不过滤。
 
         Returns:
             Tuple of (list of documents, total count)
@@ -382,6 +391,20 @@ class DocumentStorageService:
                 conditions.append(KnowledgeDocument.app_name == app_name)
             if markdown_status:
                 conditions.append(KnowledgeDocument.markdown_extract_status == markdown_status)
+            if search and search.strip():
+                like = f"%{search.strip()}%"
+                # 名称：文件名 / 用户显示名直接 ILIKE。
+                name_cond = KnowledgeDocument.original_filename.ilike(like) | (
+                    KnowledgeDocument.display_name.ilike(like)
+                )
+                # 作者：created_by 存的是 user_id，须经 user_states.state.profile.name
+                # 反解为匹配的 user_id 集合（子查询参数化，注入安全；app_name 作用域
+                # 对齐 _resolve_user_display_names → settings.app_name 兜底）。
+                author_subq = select(UserState.user_id).where(
+                    UserState.app_name == (app_name or settings.app_name),
+                    UserState.state["profile"]["name"].astext.ilike(like),
+                )
+                conditions.append(name_cond | KnowledgeDocument.created_by.in_(author_subq))
 
             # Count query
             count_stmt = select(func.count()).select_from(KnowledgeDocument).where(*conditions)

--- a/apps/negentropy/tests/integration_tests/storage/test_document_list_search.py
+++ b/apps/negentropy/tests/integration_tests/storage/test_document_list_search.py
@@ -1,0 +1,141 @@
+"""DocumentStorageService.list_documents 的 search 过滤 DB 集成测试。
+
+覆盖新增的「名称 + 作者」模糊搜索（service.py）：
+- 名称命中 ``original_filename`` / ``display_name``（直接 ILIKE，大小写不敏感）；
+- 作者命中：``created_by`` 存的是 user_id，须经 ``user_states.state.profile.name``
+  参数化 JSONB 子查询反解为 user_id 集合再过滤（本次改动的核心新逻辑）；
+- 空 search 保留无过滤的既有语义（向后兼容）；
+- count 与 items 在过滤下保持一致（共享 conditions 列表）。
+
+隔离策略：使用唯一 ``app_name`` 避免测试库跨 session 累积干扰（见 test-db-accumulates）；
+显式 patch ``negentropy.storage.service.AsyncSessionLocal``——service 模块 import 期即绑定该名，
+conftest 仅 patch ``db_session.AsyncSessionLocal`` 无法覆盖（见 service-asyncsessionlocal-ci-cross-loop）。
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from negentropy.models.perception import KnowledgeDocument
+from negentropy.models.state import UserState
+from negentropy.storage.service import DocumentStorageService
+
+
+def _make_doc(
+    app_name: str, *, original_filename: str, created_by: str | None = None, display_name: str | None = None
+) -> KnowledgeDocument:
+    """构建满足 NOT NULL 约束的库文档（corpus_id=None）ORM 行。"""
+    return KnowledgeDocument(
+        corpus_id=None,
+        app_name=app_name,
+        file_hash=uuid4().hex,
+        original_filename=original_filename,
+        display_name=display_name,
+        content_uri=f"pgblob://test/{uuid4().hex}",
+        content_type="application/pdf",
+        file_size=1024,
+        status="active",
+        created_by=created_by,
+        markdown_extract_status="completed",
+    )
+
+
+@pytest.fixture
+async def seeded_docs(db_engine, monkeypatch):
+    """播种唯一 app_name 下的文档 + 用户状态，并将 service 的 AsyncSessionLocal 指向测试引擎。
+
+    产出 (app_name, session_factory)；teardown 清理本 app_name 的全部文档与用户状态。
+    """
+    app_name = f"search-it-{uuid4().hex[:8]}"
+    session_factory = async_sessionmaker(bind=db_engine, class_=AsyncSession, expire_on_commit=False)
+
+    # service.py 于 import 期 `from ...session import AsyncSessionLocal` 绑定本地名，
+    # 须直接 patch service 模块属性（conftest 的 db_session patch 不覆盖此本地引用）。
+    monkeypatch.setattr("negentropy.storage.service.AsyncSessionLocal", session_factory)
+
+    author_user_id = f"user-{uuid4().hex[:8]}"
+    docs = [
+        _make_doc(app_name, original_filename="Attention Is All You Need.pdf"),
+        _make_doc(app_name, original_filename="loop-engineering.pdf", display_name="Loop Engineering IEEE"),
+        _make_doc(app_name, original_filename="misc-notes.pdf", created_by=author_user_id),
+    ]
+    async with session_factory() as s:
+        # 作者显示名：user_states.state.profile.name（供作者维度反解命中）。
+        s.add(UserState(user_id=author_user_id, app_name=app_name, state={"profile": {"name": "Chao Ming Huang"}}))
+        for d in docs:
+            s.add(d)
+        await s.commit()
+
+    yield app_name, author_user_id
+
+    async with session_factory() as s:
+        from sqlalchemy import delete
+
+        await s.execute(delete(KnowledgeDocument).where(KnowledgeDocument.app_name == app_name))
+        await s.execute(delete(UserState).where(UserState.app_name == app_name))
+        await s.commit()
+
+
+@pytest.mark.asyncio
+async def test_search_matches_original_filename(seeded_docs):
+    """名称维度：按 original_filename 子串大小写不敏感命中。"""
+    app_name, _ = seeded_docs
+    svc = DocumentStorageService()
+
+    docs, total = await svc.list_documents(app_name=app_name, search="attention")
+
+    assert total == 1
+    assert len(docs) == 1
+    assert docs[0].original_filename == "Attention Is All You Need.pdf"
+
+
+@pytest.mark.asyncio
+async def test_search_matches_display_name(seeded_docs):
+    """名称维度：按用户改名后的 display_name 命中。"""
+    app_name, _ = seeded_docs
+    svc = DocumentStorageService()
+
+    docs, total = await svc.list_documents(app_name=app_name, search="loop engineering")
+
+    assert total == 1
+    assert docs[0].display_name == "Loop Engineering IEEE"
+
+
+@pytest.mark.asyncio
+async def test_search_matches_author_name_via_user_states(seeded_docs):
+    """作者维度（核心新逻辑）：按 user_states 显示名反解命中 created_by 文档。"""
+    app_name, author_user_id = seeded_docs
+    svc = DocumentStorageService()
+
+    docs, total = await svc.list_documents(app_name=app_name, search="chao ming")
+
+    assert total == 1
+    assert docs[0].created_by == author_user_id
+    assert docs[0].original_filename == "misc-notes.pdf"
+
+
+@pytest.mark.asyncio
+async def test_empty_search_returns_all(seeded_docs):
+    """空 search 等价无过滤：返回该 app 下全部三条（向后兼容）。"""
+    app_name, _ = seeded_docs
+    svc = DocumentStorageService()
+
+    docs, total = await svc.list_documents(app_name=app_name, search="")
+
+    assert total == 3
+    assert len(docs) == 3
+
+
+@pytest.mark.asyncio
+async def test_search_no_match_returns_empty(seeded_docs):
+    """无命中：count 与 items 一致地归零（共享 conditions）。"""
+    app_name, _ = seeded_docs
+    svc = DocumentStorageService()
+
+    docs, total = await svc.list_documents(app_name=app_name, search="zzz-nonexistent-zzz")
+
+    assert total == 0
+    assert docs == []

--- a/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_api_documents.py
@@ -651,3 +651,26 @@ async def test_list_corpus_documents_orders_by_updated_at(monkeypatch):
     assert fake_storage.list_calls[0]["order_by"] == "updated_at"
     assert fake_storage.list_calls[0]["corpus_id"] == corpus_id
     assert result.items[0].updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_list_all_documents_threads_search_to_storage(monkeypatch):
+    """全局文档端点：search 查询参数透传至 storage.list_documents(search=...)。"""
+    fake_storage = _FakeListStorage([_make_list_doc()])
+    _patch_list_helpers(monkeypatch, fake_storage)
+
+    await documents.list_all_documents(app_name="negentropy", limit=10, offset=0, search="attention")
+
+    assert fake_storage.list_calls[0]["search"] == "attention"
+
+
+@pytest.mark.asyncio
+async def test_list_corpus_documents_threads_search_to_storage(monkeypatch):
+    """语料文档端点同样透传 search 至 storage.list_documents(search=...)。"""
+    corpus_id = uuid4()
+    fake_storage = _FakeListStorage([_make_list_doc(corpus_id=corpus_id)])
+    _patch_list_helpers(monkeypatch, fake_storage)
+
+    await documents.list_documents(corpus_id=corpus_id, app_name="negentropy", limit=10, offset=0, search="paper")
+
+    assert fake_storage.list_calls[0]["search"] == "paper"


### PR DESCRIPTION
# 背景
- **本次变更要解决的问题**：`/knowledge/documents` 文档管理页此前工具栏仅有勾选提示与 Translate / Import 按钮，缺乏检索能力。随着文档数量增长（当前已 22 条、3 页并持续增加），用户只能逐页翻找目标文档，认知摩擦高。
- **关联上下文**：需求源于用户附图标注——在工具栏中央新增文档搜索框，支持按**名称、作者**等维度快速定位文档。遵循 AGENTS.md 熵减与复用驱动原则实现。

# 核心变更
- **存储层** `storage/service.py`：`list_documents` 新增可选 `search` 参数。名称维度对 `original_filename` / `display_name` 做大小写不敏感 ILIKE；作者维度因 `created_by` 存的是不可见 user_id 而非姓名，经 `user_states.state.profile.name` 参数化 JSONB 子查询反解为 user_id 集合再过滤。过滤条件并入共享 `conditions`，使 count 与分页自动一致。
- **路由层** `knowledge/routes/documents.py`：`list_all_documents`（跨语料库，本页调用）与 `list_documents`（按语料库）两端点对称新增 `search` 查询参数并透传。
- **客户端 API** `knowledge-api.ts`：`fetchAllDocuments` 新增 `search` 参数并写入 query string。
- **页面** `documents/page.tsx`：镜像姊妹组件 `EntityListPanel` 范式——300ms 防抖输入即搜、`filters` memo 驱动 `useInfiniteList` 自动 reset 回第 1 页、lucide `Search` 图标搜索框置于工具栏中央、区分「无数据 / 搜索无结果」空状态文案。
- **BFF** `_proxy.ts` 无需改动：`proxyGet` 已透传全部 query string。

# 风险与回滚
- **主要风险**：低。`search` 全链路可选、默认不过滤，不传时行为与改动前完全一致；全程 SQLAlchemy 列表达式 + `.astext.ilike()` 参数化，无 SQL 注入面；作者子查询命中小表 `user_states`，无 N+1。**注意**：live 后端从主仓运行，需部署本分支后线上过滤才实际生效（未部署时前端优雅降级返回全量，不报错）。
- **回滚方式**：`git revert` 本 PR 合并提交即可，无数据迁移、无 schema 变更，可安全回滚。

# 验证证据
- **单元测试**：新增 3 个路由透传单测（验证两端点将 `search` 正确传入存储层）。
- **集成测试**：新增 5 个真库集成测试（`test_document_list_search.py`），覆盖名称命中 / 作者姓名经 `user_states` 反解命中 / 空搜索等价全量 / 无命中 / count 与 items 一致性。`test_api_documents.py` 全量 **24 passed**。
- **E2E/Workflow**：工作区 dev（:3193）+ 已认证 Chrome 实机回归——搜索框在目标位置精确渲染，网络请求 `?...&search=Attention+Is+All` → 200 确认参数透传，深/浅色模式对比度达标，清空恢复全量正常。
- **静态检查**：Ruff lint/format、前端 `tsc --noEmit`、ESLint（`--max-warnings=0`）全部通过。

# 影响范围
- **前端**：`negentropy-ui` 文档页 + 客户端 API（新增能力，不改既有 Translate/Import/删除/心跳链路）。
- **后端**：`negentropy` 文档列表存储层 + 路由层（新增可选参数，向后兼容）。
- **GitHub Actions / 文档**：无。

# Next Best Action
- 合并后部署本分支使线上搜索过滤生效；后续可视需要将搜索维度扩展至语料库名 / 文件哈希，或为高频作者搜索评估 `created_by` 索引。