### PR TITLE
fix(wiki-export): 启动期以进度与统计取代逐条 blob 日志刷屏;

### DIFF
--- a/apps/negentropy/scripts/_logging.py
+++ b/apps/negentropy/scripts/_logging.py
@@ -1,0 +1,37 @@
+"""scripts/ 目录共享日志配置工具。
+
+独立脚本不经 ``negentropy.engine.bootstrap``（后者在 import 期配置日志，但会拉起
+ADK / LiteLLM 等重型依赖），若不显式配置，structlog 将停留在**出厂默认**：
+不过滤 DEBUG + stock ``ConsoleRenderer``（``_name`` 键泄漏、格式与后端不一致），
+且 ``NE_LOG_LEVEL`` 完全失效。
+
+本模块把 ``settings.log_*`` 映射到项目唯一的日志入口 ``configure_logging``，
+让脚本与后端共享同一套级别控制与输出格式。脚本通过 ``sys.path[0]`` 解析同目录
+模块，可直接 ``from _logging import configure_script_logging``。
+"""
+
+from __future__ import annotations
+
+from negentropy.config import settings
+from negentropy.logging import configure_logging
+
+
+def configure_script_logging(*, level: str | None = None) -> None:
+    """按项目配置初始化脚本日志（级别默认取 ``settings.log_level``，尊重 ``NE_LOG_LEVEL``）。
+
+    注意：``configure_logging`` 会以 ``StreamToLogger`` 接管 ``sys.stdout`` /
+    ``sys.stderr``，故调用方的 ``print`` 会被转为日志行——脚本应改用 logger 输出汇总。
+    """
+    configure_logging(
+        level=level or settings.log_level,
+        sinks=settings.log_sinks,
+        fmt=settings.log_format,
+        file_path=settings.log_file_path,
+        gcloud_project=settings.vertex_project_id,
+        gcloud_log_name=settings.gcloud_log_name,
+        console_timestamp_format=settings.log_console_timestamp_format,
+        console_level_width=settings.log_console_level_width,
+        console_logger_width=settings.log_console_logger_width,
+        console_separator=settings.log_console_separator,
+        service_name=settings.log_service_name,
+    )

--- a/apps/negentropy/scripts/_logging.py
+++ b/apps/negentropy/scripts/_logging.py
@@ -21,6 +21,8 @@ def configure_script_logging(*, level: str | None = None) -> None:
 
     注意：``configure_logging`` 会以 ``StreamToLogger`` 接管 ``sys.stdout`` /
     ``sys.stderr``，故调用方的 ``print`` 会被转为日志行——脚本应改用 logger 输出汇总。
+    失败路径必须显式走 ``logger.error`` / ``logger.exception``：print 只落 INFO 级，
+    会被 ``NE_LOG_LEVEL>=WARNING`` 过滤为静默失败。
     """
     configure_logging(
         level=level or settings.log_level,

--- a/apps/negentropy/scripts/export_wiki_content.py
+++ b/apps/negentropy/scripts/export_wiki_content.py
@@ -36,12 +36,18 @@ from negentropy.logging import get_logger  # noqa: E402
 logger = get_logger("negentropy.scripts.export_wiki_content")
 
 
-async def _run(out_dir: Path) -> None:
-    async with script_engine() as engine:
-        session_factory = async_sessionmaker(engine, expire_on_commit=False)
-        async with session_factory() as db:
-            service = WikiExportService()
-            result = await service.export_all_published(db, out_dir=out_dir)
+async def _run(out_dir: Path) -> int:
+    try:
+        async with script_engine() as engine:
+            session_factory = async_sessionmaker(engine, expire_on_commit=False)
+            async with session_factory() as db:
+                service = WikiExportService()
+                result = await service.export_all_published(db, out_dir=out_dir)
+    except Exception:
+        # error 级保证失败原因不被 NE_LOG_LEVEL≥WARNING 门控（stderr 已被接管，
+        # run_script 的 print 只会落成 INFO 级日志行）。退出码交由 run_script。
+        logger.exception("wiki_export_cli_failed", out_dir=str(out_dir))
+        return 1
 
     # 用结构化事件而非 print 输出汇总：configure_script_logging 已接管 sys.stdout。
     summary = result.to_dict()
@@ -53,6 +59,7 @@ async def _run(out_dir: Path) -> None:
         files=summary["files_count"],
         out_dir=str(out_dir),
     )
+    return 0
 
 
 def main() -> None:

--- a/apps/negentropy/scripts/export_wiki_content.py
+++ b/apps/negentropy/scripts/export_wiki_content.py
@@ -21,10 +21,19 @@ from pathlib import Path
 # 让 `from _db import ...` 可用（scripts/ 同目录共享工具）。
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
+from _logging import configure_script_logging  # noqa: E402
+
+# 顺序即正确性：先配置日志，再 import 下方重型模块——后者在 import 期即注册 disposer
+# 等并打日志，若晚于本行，这些早期事件会落到 structlog 出厂默认（不过滤 DEBUG、非项目格式）。
+configure_script_logging()
+
 from _db import run_script, script_engine  # noqa: E402
 from sqlalchemy.ext.asyncio import async_sessionmaker  # noqa: E402
 
 from negentropy.knowledge.lifecycle.wiki_export_service import WikiExportService  # noqa: E402
+from negentropy.logging import get_logger  # noqa: E402
+
+logger = get_logger("negentropy.scripts.export_wiki_content")
 
 
 async def _run(out_dir: Path) -> None:
@@ -34,13 +43,15 @@ async def _run(out_dir: Path) -> None:
             service = WikiExportService()
             result = await service.export_all_published(db, out_dir=out_dir)
 
+    # 用结构化事件而非 print 输出汇总：configure_script_logging 已接管 sys.stdout。
     summary = result.to_dict()
-    print(
-        "[wiki-export] 已导出静态内容包："
-        f"{summary['publications_count']} publications / "
-        f"{summary['entries']} entries / "
-        f"{summary['graphs']} graphs / "
-        f"{summary['files_count']} files → {out_dir}"
+    logger.info(
+        "wiki_export_cli_done",
+        publications=summary["publications_count"],
+        entries=summary["entries"],
+        graphs=summary["graphs"],
+        files=summary["files_count"],
+        out_dir=str(out_dir),
     )
 
 

--- a/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_export_service.py
+++ b/apps/negentropy/src/negentropy/knowledge/lifecycle/wiki_export_service.py
@@ -95,6 +95,7 @@ class WikiExportService:
         result.generated_at = datetime.utcnow().isoformat() + "Z"
 
         pubs, _total = await WikiDao.list_publications(db, status="published", offset=0, limit=200)
+        logger.info("wiki_export_started", publications=len(pubs), out_dir=str(out_dir))
 
         self._reset(out_dir)
         entries_dir = out_dir / "entries"
@@ -118,6 +119,7 @@ class WikiExportService:
             entries = await WikiDao.get_entries(db, pub.id)
             doc_entries = [e for e in entries if e.document_id is not None]
             entries_count = sum(1 for e in entries if getattr(e, "entry_kind", None) == "DOCUMENT") or len(doc_entries)
+            logger.info("wiki_export_publication", slug=slug, entries=len(entries))
 
             # publication.json
             pub_payload = self._serialize_publication(pub, entries_count)
@@ -134,7 +136,10 @@ class WikiExportService:
             # entries-index.json + entries/{id}.json
             entry_items: list[dict[str, Any]] = []
             slug_to_id: dict[str, str] = {}
-            for e in entries:
+            entries_total = len(entries)
+            # 进度节流：每 publication 恒定约 10 行，输出量与语料规模解耦（逐条明细见 debug）。
+            progress_step = max(1, entries_total // 10)
+            for idx, e in enumerate(entries, start=1):
                 entry_items.append(
                     {
                         "id": str(e.id),
@@ -150,14 +155,23 @@ class WikiExportService:
                     content_data = await WikiDao.get_entry_content(db, e.id)
                     if content_data is None:
                         logger.warning("wiki_export_entry_no_content", entry_id=str(e.id))
-                        continue
-                    resp = build_entry_content_response(e.id, content_data, entry_slug=e.entry_slug)
-                    payload = resp.model_dump(mode="json")
-                    payload["markdown_content"] = await self._rewrite_asset_links(
-                        payload.get("markdown_content") or "", assets_dir=assets_dir
+                    else:
+                        resp = build_entry_content_response(e.id, content_data, entry_slug=e.entry_slug)
+                        payload = resp.model_dump(mode="json")
+                        payload["markdown_content"] = await self._rewrite_asset_links(
+                            payload.get("markdown_content") or "", assets_dir=assets_dir
+                        )
+                        self._write_json(entries_dir / f"{e.id}.json", payload, result)
+                        result.entries += 1
+
+                if idx % progress_step == 0 or idx == entries_total:
+                    logger.info(
+                        "wiki_export_progress",
+                        slug=slug,
+                        entries_done=idx,
+                        entries_total=entries_total,
+                        assets=len(self._asset_files),
                     )
-                    self._write_json(entries_dir / f"{e.id}.json", payload, result)
-                    result.entries += 1
 
             self._write_json(
                 pub_dir / "entries-index.json",
@@ -230,7 +244,8 @@ class WikiExportService:
 
         logger.info(
             "wiki_export_done",
-            publications=len(pubs),
+            # 用 result.publications：含注入的 docs pack，与 to_dict()/CLI 汇总口径一致。
+            publications=len(result.publications),
             entries=result.entries,
             graphs=result.graphs,
             assets=len(self._asset_files),

--- a/apps/negentropy/src/negentropy/storage/postgres_client.py
+++ b/apps/negentropy/src/negentropy/storage/postgres_client.py
@@ -105,7 +105,9 @@ class PostgresBlobStorage:
             raise StorageError(f"Blob not found: {uri}")
 
         content = row[0]
-        logger.info("blob_download_completed", uri=uri, size=len(content))
+        # 逐次读取属 per-IO trace（批量导出/Range 预览下可达数百行），降为 debug；
+        # 写入与删除仍保留 info 审计线索。
+        logger.debug("blob_download_completed", uri=uri, size=len(content))
         return content
 
     async def get_size(self, uri: str) -> int | None:
@@ -142,7 +144,8 @@ class PostgresBlobStorage:
 
         # asyncpg 对 bytea 可能回 memoryview，统一归一为 bytes。
         chunk = bytes(row[0])
-        logger.info("blob_download_range_completed", uri=uri, start=start, length=len(chunk))
+        # 同 download：PDF 阅读器单次预览即触发大量 Range 请求，降为 debug。
+        logger.debug("blob_download_range_completed", uri=uri, start=start, length=len(chunk))
         return chunk
 
     async def delete(self, uri: str) -> None:

--- a/apps/negentropy/tests/unit_tests/knowledge/test_wiki_export_docs_pub.py
+++ b/apps/negentropy/tests/unit_tests/knowledge/test_wiki_export_docs_pub.py
@@ -126,6 +126,68 @@ async def test_db_slug_conflict_skips_docs(tmp_path: Path, docs_tree: Path):
 
 
 @pytest.mark.asyncio
+async def test_progress_bounded_and_summary_counts_docs_pack(tmp_path: Path, docs_tree: Path):
+    """进度日志按 publication 有界（与 entry 数解耦），且汇总计数含注入的 docs pack。
+
+    回归背景：``wiki_export_done`` 曾用 ``len(pubs)`` 计数，漏掉 L204 追加的合成
+    docs publication，导致同一次运行日志报 1 而 CLI 汇总报 2。
+    """
+    out = tmp_path / "content"
+    from types import SimpleNamespace
+    from uuid import UUID
+
+    from structlog.testing import capture_logs
+
+    db_pub = SimpleNamespace(
+        id=UUID("22222222-2222-4222-8222-222222222222"),
+        catalog_id=UUID("44444444-4444-4444-8444-444444444442"),
+        app_name="negentropy",
+        publish_mode="LIVE",
+        name="Wiki",
+        slug="wiki",
+        description=None,
+        status="published",
+        theme=None,
+        version=1,
+        published_at=None,
+        created_at=None,
+        updated_at=None,
+    )
+    # 全部 CONTAINER（document_id=None）：只驱动进度循环，不触发内容读取与资产下载。
+    entries = [
+        SimpleNamespace(
+            id=UUID(f"33333333-3333-4333-8333-{i:012d}"),
+            document_id=None,
+            entry_slug=f"e{i}",
+            entry_title=f"E{i}",
+            is_index_page=False,
+            entry_kind="CONTAINER",
+        )
+        for i in range(50)
+    ]
+
+    svc = WikiExportService()
+    with _patch_docs_cfg(docs_tree):
+        with (
+            patch(f"{_MOD}.WikiDao.list_publications", new=AsyncMock(return_value=([db_pub], 1))),
+            patch(f"{_MOD}.WikiDao.get_entries", new=AsyncMock(return_value=entries)),
+            patch(f"{_MOD}.WikiDao.get_nav_tree", new=AsyncMock(return_value=[])),
+            patch(f"{_MOD}.get_publication_graph", new=AsyncMock(return_value=None)),
+            capture_logs() as logs,
+        ):
+            await svc.export_all_published(db=None, out_dir=out)
+
+    # 50 个 entry → step=5 → 10 条；无论语料多大都不逐条刷屏。
+    progress = [r for r in logs if r["event"] == "wiki_export_progress"]
+    assert 1 <= len(progress) <= 11, f"进度日志应有界，实际 {len(progress)} 条"
+    assert progress[-1]["entries_done"] == len(entries), "末条进度须覆盖最后一个 entry"
+
+    done = next(r for r in logs if r["event"] == "wiki_export_done")
+    # DB pub（wiki）+ 合成 docs pack（negentropy）= 2；修复前此处为 len(pubs)=1。
+    assert done["publications"] == 2
+
+
+@pytest.mark.asyncio
 async def test_idempotent_across_exports(tmp_path: Path, docs_tree: Path):
     out1, out2 = tmp_path / "c1", tmp_path / "c2"
     with _patch_docs_cfg(docs_tree):


### PR DESCRIPTION
# 背景

- **本次变更要解决的问题**：启动期 Wiki 内容同步（`cli.sh` → `sync-wiki-content.sh` → `export_wiki_content.py`）实测输出 **412 行，其中 403 行是 `blob_download_completed`**，把仅有的汇总行彻底淹没，用户只想看到「执行进度 + 统计结果」。
- **根因为两层，只修一层无效**：
  1. `postgres_client` 对每次 blob 读取打 INFO —— 这是 per-IO trace 而非业务事件；
  2. `export_wiki_content.py` **从未调用 `configure_logging`**，也不经 `engine.bootstrap`（全仓唯一在 import 期配置日志之处），structlog 停留在**出厂默认**：`make_filtering_bound_logger(NOTSET)` 不过滤 DEBUG + stock `ConsoleRenderer`。故 **`NE_LOG_LEVEL` 对该脚本此前完全失效**，仅降级日志一行都不会少。
- **诊断证据**（可在原始日志中直接读出）：`_name=negentropy.storage.postgres` 键泄漏（项目的 `add_logger_name` 处理器本会 pop 掉它），以及 `logging.level: INFO` 配置下仍打印的 `[debug] disposer_registered`。
- 关联上下文：[`logging/core.py`](https://github.com/ThreeFish-AI/negentropy/blob/master/apps/negentropy/src/negentropy/logging/core.py)（`configure_logging` 唯一入口）、[`engine/bootstrap.py`](https://github.com/ThreeFish-AI/negentropy/blob/master/apps/negentropy/src/negentropy/engine/bootstrap.py)（唯一既有调用点）。

# 核心变更

- **读路径 per-IO trace 降级**：`postgres_client.py` 的 `blob_download_completed` 与 `blob_download_range_completed` 由 info 改 debug（后者是 PDF 阅读器每次 Range 请求刷一行，为后端运行期最高频同类噪音）。语义分界：**读是 trace，写是审计事件** —— `blob_upload_completed` / `blob_delete_completed` 与全部 error 分支**保持不变**。
- **导出 CLI 接入项目统一日志**：新增 `scripts/_logging.py::configure_script_logging()`，把 `settings.log_*` 映射到项目唯一日志入口，**不 import 重型 engine 包**（避免拉起 ADK/LiteLLM 副作用）。`export_wiki_content.py` 在**重型 import 之前**调用（顺序即正确性：`db_session` 等在 import 期即打 `disposer_registered`），并将末尾 `print` 汇总改为结构化事件（`configure_logging` 会以 `StreamToLogger` 接管 `sys.stdout`，顺应该设计而非与之对抗）。
- **补有界进度日志**：`wiki_export_service` 增加 `wiki_export_started` / `wiki_export_publication` / `wiki_export_progress`，进度按 `step = max(1, total // 10)` 节流并强制在末条发一次 —— **每 publication 恒定约 10 行，输出量与语料规模解耦**。原 `continue` 改写为 `else` 分支以保证进度不被跳过（语义等价）。
- **修正汇总统计口径**：`wiki_export_done` 原用 `len(pubs)`，漏计注入的合成 docs publication，导致**同一次运行日志报 `publications=1` 而 CLI 汇总报 `2`**；改用 `len(result.publications)`，与 `to_dict()` 对齐。
- **刻意不做**：不加资产去重缓存 —— 已核对日志，403 条 URI 全部互异，无重复下载可消除（YAGNI）。

# 风险与回滚

- **主要风险**：
  1. blob 读日志降级后，线上排查失去逐条 INFO 线索 —— 已缓解：**明细未删除，`NE_LOG_LEVEL=DEBUG` 可完整取回**；且全仓核实这两个事件**零测试、零文档、零看板引用**（各仅 1 处定义）。
  2. `configure_logging` 会重置 root logger、拦截三方 logger 并接管 stdout/stderr —— 短命 CLI 中均为预期行为；`run_script` 的 `print("Error: ...", file=sys.stderr)` 会变成日志行，仍可见，且 `cli.sh` 依赖的是**退出码**而非该文本，行为不变。
  3. 爆炸半径已收敛：其余 7 个 `scripts/*.py` **未改动**，`_logging.py` 仅为其留好接入口。
- **回滚方式**：单个 commit，`git revert` 即可完整回退；无 DB 迁移、无配置变更、无接口契约变更。

# 验证证据

- **单元测试**：新增回归用例 `test_progress_bounded_and_summary_counts_docs_pack`，复用既有免 DB 夹具 + `structlog.testing.capture_logs`，断言 ①进度日志有界（50 entry → 10 条）②末条覆盖最后一个 entry ③`publications == 2`。已实测**改前失败（`assert 1 == 2`）、改后通过**。
- **集成测试**：`tests/unit_tests/knowledge` + `tests/integration_tests/storage` 全量 **1086 passed**；pre-commit（ruff lint + format 等）全绿。
- **E2E/Workflow**：实跑真实启动链路 `bash scripts/sync-wiki-content.sh` —— 日志 **412 → 18 行**、`blob_download_completed` **403 → 0**、`_name=` 泄漏 **0**，格式已与后端一致：

```text
wiki_export_started publications=1 out_dir=...
wiki_export_publication slug=wiki entries=25
wiki_export_progress slug=wiki entries_done=2  entries_total=25 assets=6
...（共 13 条，assets 累加至 403）
wiki_export_docs_pack slug=negentropy entries=115
wiki_export_done publications=2 entries=135 graphs=1 assets=403 files=547
wiki_export_cli_done publications=2 entries=135 graphs=1 files=547 out_dir=...
```

- **门控有效性**：`NE_LOG_LEVEL=DEBUG` 下 **403 行明细完整取回** —— 同时证明该环境变量对此脚本终于生效。
- **产物零回归**：改前/改后各跑一次全量导出并 `diff -r` —— **547 文件 / 403 assets 逐字节一致**，唯一差异是 `index.json` 的 `generated_at` 时间戳。

# 影响范围

- **前端**：无。
- **后端**：`storage/postgres_client.py`（2 行日志级别）、`knowledge/lifecycle/wiki_export_service.py`（进度日志 + 统计口径）。PDF 预览 Range 端点的逐请求 INFO 一并降噪。
- **GitHub Actions / 文档**：CI `wiki-content-export.yml` 走 `bake_assets=false` 的 URL 重写分支，本就无 blob 日志，仅受益于格式统一；`publish-wiki-pages.sh` / `build-wiki-local.sh` 调用同一脚本，**一处改动覆盖三条噪音路径**，无需另改。

# Next Best Action

- 其余 7 个 `apps/negentropy/scripts/*.py` 仍是「出厂默认 structlog」状态（同样 `NE_LOG_LEVEL` 失效、`_name=` 泄漏），`_logging.py` 已留好接入口，可另开 PR 统一接入。
- 可考虑把「读=debug / 写=info」的 blob 日志分级口径沉淀进 `docs/.agents/`，避免后续新增存储后端时重蹈逐条 IO 打 INFO。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
